### PR TITLE
Simplify URL configuration and serve dev media

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -1,26 +1,19 @@
-"""
-URL configuration for config project.
+"""URL configuration for the project."""
 
-The `urlpatterns` list routes URLs to views. For more information please see:
-    https://docs.djangoproject.com/en/5.2/topics/http/urls/
-Examples:
-Function views
-    1. Add an import:  from my_app import views
-    2. Add a URL to urlpatterns:  path('', views.home, name='home')
-Class-based views
-    1. Add an import:  from other_app.views import Home
-    2. Add a URL to urlpatterns:  path('', Home.as_view(), name='home')
-Including another URLconf
-    1. Import the include() function: from django.urls import include, path
-    2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
-"""
+from django.conf import settings
+from django.conf.urls.static import static
 from django.contrib import admin
 from django.urls import path
 
 from core import views as core_views
 
+
 urlpatterns = [
-    path("", core_views.home, name="home"),
-    path("community/<slug:name>/", core_views.community, name="community"),
     path("admin/", admin.site.urls),
+    path("", core_views.home, name="home"),
+    path("r/<slug:name>/", core_views.community, name="community"),
 ]
+
+if settings.DEBUG:
+    urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+


### PR DESCRIPTION
## Summary
- Route `/` to home and `r/<slug:name>/` to community views
- Serve uploaded media in development with `static()`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689ea217fbb0832ca8e53a9b24dbad79