### PR TITLE
Add post detail and comment functionality

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -11,6 +11,8 @@ from core import views as core_views
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("", core_views.home, name="home"),
+    path("post/<int:pk>/", core_views.post_detail, name="post_detail"),
+    path("post/<int:pk>/comment/", core_views.add_comment, name="add_comment"),
     path("r/<slug:name>/submit/", core_views.submit_post, name="submit_post"),
     path("r/<slug:name>/", core_views.community, name="community"),
 ]

--- a/templates/core/community.html
+++ b/templates/core/community.html
@@ -11,7 +11,7 @@
     <ul>
         {% for post in posts %}
         <li>
-            <a href="#" style="color: blue;">{{ post.title }}</a>
+            <a href="{% url 'post_detail' post.pk %}" style="color: blue;">{{ post.title }}</a>
             <span>
                 in <a href="{% url 'community' post.community.name %}" style="color: blue;">{{ post.community.title }}</a>
                 by {{ post.author.username }}

--- a/templates/core/home.html
+++ b/templates/core/home.html
@@ -10,7 +10,7 @@
     <ul>
         {% for post in posts %}
         <li>
-            <a href="#" style="color: blue;">{{ post.title }}</a>
+            <a href="{% url 'post_detail' post.pk %}" style="color: blue;">{{ post.title }}</a>
             <span>
                 in <a href="{% url 'community' post.community.name %}" style="color: blue;">{{ post.community.title }}</a>
                 by {{ post.author.username }}

--- a/templates/core/post_detail.html
+++ b/templates/core/post_detail.html
@@ -1,0 +1,37 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>{{ post.title }}</title>
+    <link rel="stylesheet" href="/static/css/old.css">
+</head>
+<body>
+    <h1>{{ post.title }}</h1>
+    {% if post.body %}
+    <p>{{ post.body }}</p>
+    {% endif %}
+    <p>
+        in <a href="{% url 'community' post.community.name %}" style="color: blue;">{{ post.community.title }}</a>
+        by {{ post.author.username }}
+        · {{ post.score }}
+        · {{ post.created_at|timesince }} ago
+    </p>
+    <h2>Comments</h2>
+    <ul>
+        {% for comment in comments %}
+        <li>
+            <p>{{ comment.body }}</p>
+            <small>by {{ comment.author.username }} · {{ comment.created_at|timesince }} ago</small>
+        </li>
+        {% empty %}
+        <li>No comments yet.</li>
+        {% endfor %}
+    </ul>
+    <h3>Add comment</h3>
+    <form method="post" action="{% url 'add_comment' post.pk %}">
+        {% csrf_token %}
+        {{ form.as_p }}
+        <button type="submit">Comment</button>
+    </form>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Implement post detail view listing comments and providing a comment form
- Add comment submission view and URL routes
- Link posts to detail pages and create post detail template

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689ea6998890832cbd9b1bee601f8b33