### PR TITLE
Add voting endpoints and HTMX buttons

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -13,6 +13,8 @@ urlpatterns = [
     path("", core_views.home, name="home"),
     path("post/<int:pk>/", core_views.post_detail, name="post_detail"),
     path("post/<int:pk>/comment/", core_views.add_comment, name="add_comment"),
+    path("vote/post/<int:pk>/", core_views.vote_post, name="vote_post"),
+    path("vote/comment/<int:pk>/", core_views.vote_comment, name="vote_comment"),
     path("r/<slug:name>/submit/", core_views.submit_post, name="submit_post"),
     path("r/<slug:name>/", core_views.community, name="community"),
 ]

--- a/core/tests.py
+++ b/core/tests.py
@@ -1,3 +1,59 @@
-from django.test import TestCase
+"""Tests for voting endpoints."""
 
-# Create your tests here.
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+
+from .models import Comment, Community, Post, Vote
+
+
+class VoteTests(TestCase):
+    """Ensure voting adjusts scores and upserts votes."""
+
+    def setUp(self):
+        user_model = get_user_model()
+        self.user = user_model.objects.create_user("alice", password="pwd")
+        self.community = Community.objects.create(name="t", title="Test")
+        self.post = Post.objects.create(
+            community=self.community,
+            author=self.user,
+            post_type="text",
+            title="Hello",
+        )
+        self.comment = Comment.objects.create(
+            post=self.post, author=self.user, body="hi"
+        )
+        self.client.login(username="alice", password="pwd")
+
+    def test_vote_post(self):
+        url = reverse("vote_post", args=[self.post.pk])
+        self.client.post(url, {"v": "1"})
+        self.post.refresh_from_db()
+        self.assertEqual(self.post.score, 1)
+        vote = Vote.objects.get(
+            user=self.user, target_type="post", target_id=self.post.pk
+        )
+        self.assertEqual(vote.value, 1)
+
+        self.client.post(url, {"v": "-1"})
+        self.post.refresh_from_db()
+        vote.refresh_from_db()
+        self.assertEqual(self.post.score, -1)
+        self.assertEqual(vote.value, -1)
+
+    def test_vote_comment(self):
+        url = reverse("vote_comment", args=[self.comment.pk])
+        self.client.post(url, {"v": "1"})
+        self.comment.refresh_from_db()
+        self.assertEqual(self.comment.score, 1)
+        vote = Vote.objects.get(
+            user=self.user, target_type="comment", target_id=self.comment.pk
+        )
+        self.assertEqual(vote.value, 1)
+
+        self.client.post(url, {"v": "-1"})
+        self.comment.refresh_from_db()
+        vote.refresh_from_db()
+        self.assertEqual(self.comment.score, -1)
+        self.assertEqual(vote.value, -1)
+

--- a/templates/core/community.html
+++ b/templates/core/community.html
@@ -15,7 +15,20 @@
             <span>
                 in <a href="{% url 'community' post.community.name %}" style="color: blue;">{{ post.community.title }}</a>
                 by {{ post.author.username }}
-                · {{ post.score }}
+                ·
+                <button hx-post="{% url 'vote_post' post.pk %}"
+                        hx-target="#post-score-{{ post.pk }}"
+                        hx-swap="outerHTML"
+                        hx-include="[name='v']">
+                    ▲<input type="hidden" name="v" value="1">
+                </button>
+                <span id="post-score-{{ post.pk }}">{{ post.score }}</span>
+                <button hx-post="{% url 'vote_post' post.pk %}"
+                        hx-target="#post-score-{{ post.pk }}"
+                        hx-swap="outerHTML"
+                        hx-include="[name='v']">
+                    ▼<input type="hidden" name="v" value="-1">
+                </button>
                 · {{ post.created_at|timesince }} ago
             </span>
         </li>

--- a/templates/core/home.html
+++ b/templates/core/home.html
@@ -14,7 +14,20 @@
             <span>
                 in <a href="{% url 'community' post.community.name %}" style="color: blue;">{{ post.community.title }}</a>
                 by {{ post.author.username }}
-                · {{ post.score }}
+                ·
+                <button hx-post="{% url 'vote_post' post.pk %}"
+                        hx-target="#post-score-{{ post.pk }}"
+                        hx-swap="outerHTML"
+                        hx-include="[name='v']">
+                    ▲<input type="hidden" name="v" value="1">
+                </button>
+                <span id="post-score-{{ post.pk }}">{{ post.score }}</span>
+                <button hx-post="{% url 'vote_post' post.pk %}"
+                        hx-target="#post-score-{{ post.pk }}"
+                        hx-swap="outerHTML"
+                        hx-include="[name='v']">
+                    ▼<input type="hidden" name="v" value="-1">
+                </button>
                 · {{ post.created_at|timesince }} ago
             </span>
         </li>

--- a/templates/core/post_detail.html
+++ b/templates/core/post_detail.html
@@ -13,7 +13,20 @@
     <p>
         in <a href="{% url 'community' post.community.name %}" style="color: blue;">{{ post.community.title }}</a>
         by {{ post.author.username }}
-        · {{ post.score }}
+        ·
+        <button hx-post="{% url 'vote_post' post.pk %}"
+                hx-target="#post-score-{{ post.pk }}"
+                hx-swap="outerHTML"
+                hx-include="[name='v']">
+            ▲<input type="hidden" name="v" value="1">
+        </button>
+        <span id="post-score-{{ post.pk }}">{{ post.score }}</span>
+        <button hx-post="{% url 'vote_post' post.pk %}"
+                hx-target="#post-score-{{ post.pk }}"
+                hx-swap="outerHTML"
+                hx-include="[name='v']">
+            ▼<input type="hidden" name="v" value="-1">
+        </button>
         · {{ post.created_at|timesince }} ago
     </p>
     <h2>Comments</h2>
@@ -21,7 +34,24 @@
         {% for comment in comments %}
         <li>
             <p>{{ comment.body }}</p>
-            <small>by {{ comment.author.username }} · {{ comment.created_at|timesince }} ago</small>
+            <small>
+                by {{ comment.author.username }}
+                ·
+                <button hx-post="{% url 'vote_comment' comment.pk %}"
+                        hx-target="#comment-score-{{ comment.pk }}"
+                        hx-swap="outerHTML"
+                        hx-include="[name='v']">
+                    ▲<input type="hidden" name="v" value="1">
+                </button>
+                <span id="comment-score-{{ comment.pk }}">{{ comment.score }}</span>
+                <button hx-post="{% url 'vote_comment' comment.pk %}"
+                        hx-target="#comment-score-{{ comment.pk }}"
+                        hx-swap="outerHTML"
+                        hx-include="[name='v']">
+                    ▼<input type="hidden" name="v" value="-1">
+                </button>
+                · {{ comment.created_at|timesince }} ago
+            </small>
         </li>
         {% empty %}
         <li>No comments yet.</li>


### PR DESCRIPTION
## Summary
- implement post and comment voting endpoints that upsert Vote records and adjust scores
- add HTMX vote buttons and score spans across post and comment templates
- test voting flows for posts and comments

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689ea8f721e4832cadeb697ff8744cb7