### PR TITLE
Simplify post list and submission templates

### DIFF
--- a/templates/core/community.html
+++ b/templates/core/community.html
@@ -3,38 +3,39 @@
 <head>
     <meta charset="utf-8">
     <title>{{ community.title }}</title>
-    <link rel="stylesheet" href="/static/css/old.css">
 </head>
 <body>
+<header><a href="/">SureJan</a></header>
+<div class="page">
     <h1>{{ community.title }}</h1>
-    <p>{{ community.description }}</p>
-    <ul>
-        {% for post in posts %}
-        <li>
-            <a href="{% url 'post_detail' post.pk %}" style="color: blue;">{{ post.title }}</a>
-            <span>
-                in <a href="{% url 'community' post.community.name %}" style="color: blue;">{{ post.community.title }}</a>
-                by {{ post.author.username }}
-                ·
-                <button hx-post="{% url 'vote_post' post.pk %}"
-                        hx-target="#post-score-{{ post.pk }}"
-                        hx-swap="outerHTML"
-                        hx-include="[name='v']">
-                    ▲<input type="hidden" name="v" value="1">
-                </button>
-                <span id="post-score-{{ post.pk }}">{{ post.score }}</span>
-                <button hx-post="{% url 'vote_post' post.pk %}"
-                        hx-target="#post-score-{{ post.pk }}"
-                        hx-swap="outerHTML"
-                        hx-include="[name='v']">
-                    ▼<input type="hidden" name="v" value="-1">
-                </button>
+    {% for post in posts %}
+    <div class="postrow">
+        <div class="votes">
+            <button hx-post="{% url 'vote_post' post.id %}"
+                    hx-vals='{"v": 1}'
+                    hx-target="#post-score-{{ post.id }}"
+                    hx-swap="outerHTML">▲</button>
+            <button hx-post="{% url 'vote_post' post.id %}"
+                    hx-vals='{"v": -1}'
+                    hx-target="#post-score-{{ post.id }}"
+                    hx-swap="outerHTML">▼</button>
+        </div>
+        {% if post.media and post.media.thumb %}
+        <a href="{% url 'post_detail' post.id %}"><img src="{{ post.media.thumb.url }}" alt=""></a>
+        {% endif %}
+        <div>
+            <a href="{% url 'post_detail' post.id %}">{{ post.title }}</a>
+            <div class="meta">
+                <a href="{% url 'community' post.community.name %}">{{ post.community.title }}</a>
+                · {{ post.author.username }}
                 · {{ post.created_at|timesince }} ago
-            </span>
-        </li>
-        {% empty %}
-        <li>No posts yet.</li>
-        {% endfor %}
-    </ul>
+                · <span id="post-score-{{ post.id }}">{{ post.score }}</span>
+            </div>
+        </div>
+    </div>
+    {% empty %}
+    <p>No posts yet.</p>
+    {% endfor %}
+</div>
 </body>
 </html>

--- a/templates/core/home.html
+++ b/templates/core/home.html
@@ -3,37 +3,38 @@
 <head>
     <meta charset="utf-8">
     <title>Home</title>
-    <link rel="stylesheet" href="/static/css/old.css">
 </head>
 <body>
-    <h1>Home</h1>
-    <ul>
-        {% for post in posts %}
-        <li>
-            <a href="{% url 'post_detail' post.pk %}" style="color: blue;">{{ post.title }}</a>
-            <span>
-                in <a href="{% url 'community' post.community.name %}" style="color: blue;">{{ post.community.title }}</a>
-                by {{ post.author.username }}
-                ·
-                <button hx-post="{% url 'vote_post' post.pk %}"
-                        hx-target="#post-score-{{ post.pk }}"
-                        hx-swap="outerHTML"
-                        hx-include="[name='v']">
-                    ▲<input type="hidden" name="v" value="1">
-                </button>
-                <span id="post-score-{{ post.pk }}">{{ post.score }}</span>
-                <button hx-post="{% url 'vote_post' post.pk %}"
-                        hx-target="#post-score-{{ post.pk }}"
-                        hx-swap="outerHTML"
-                        hx-include="[name='v']">
-                    ▼<input type="hidden" name="v" value="-1">
-                </button>
+<header><a href="/">SureJan</a></header>
+<div class="page">
+    {% for post in posts %}
+    <div class="postrow">
+        <div class="votes">
+            <button hx-post="{% url 'vote_post' post.id %}"
+                    hx-vals='{"v": 1}'
+                    hx-target="#post-score-{{ post.id }}"
+                    hx-swap="outerHTML">▲</button>
+            <button hx-post="{% url 'vote_post' post.id %}"
+                    hx-vals='{"v": -1}'
+                    hx-target="#post-score-{{ post.id }}"
+                    hx-swap="outerHTML">▼</button>
+        </div>
+        {% if post.media and post.media.thumb %}
+        <a href="{% url 'post_detail' post.id %}"><img src="{{ post.media.thumb.url }}" alt=""></a>
+        {% endif %}
+        <div>
+            <a href="{% url 'post_detail' post.id %}">{{ post.title }}</a>
+            <div class="meta">
+                <a href="{% url 'community' post.community.name %}">{{ post.community.title }}</a>
+                · {{ post.author.username }}
                 · {{ post.created_at|timesince }} ago
-            </span>
-        </li>
-        {% empty %}
-        <li>No posts yet.</li>
-        {% endfor %}
-    </ul>
+                · <span id="post-score-{{ post.id }}">{{ post.score }}</span>
+            </div>
+        </div>
+    </div>
+    {% empty %}
+    <p>No posts yet.</p>
+    {% endfor %}
+</div>
 </body>
 </html>

--- a/templates/core/submit_post.html
+++ b/templates/core/submit_post.html
@@ -2,39 +2,40 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>Submit Post</title>
-    <link rel="stylesheet" href="/static/css/old.css">
+    <title>Submit to {{ community.title }}</title>
 </head>
 <body>
+<header><a href="/">SureJan</a></header>
+<div class="page">
     <h1>Submit to {{ community.title }}</h1>
     <form method="post" enctype="multipart/form-data">
         {% csrf_token %}
-        <div>
-            {{ form.title.label_tag }} {{ form.title }}
-            {% if form.title.errors %}<div>{{ form.title.errors }}</div>{% endif %}
-        </div>
-        <div>
-            {{ form.body.label_tag }} {{ form.body }}
-            {% if form.body.errors %}<div>{{ form.body.errors }}</div>{% endif %}
-        </div>
-        <div>
-            {{ form.url.label_tag }} {{ form.url }}
-            {% if form.url.errors %}<div>{{ form.url.errors }}</div>{% endif %}
-        </div>
-        <div>
-            <label>Post type:</label>
-            {% with pt=form.post_type.value %}
-            {% for value, label in form.post_type.field.choices %}
-                <label><input type="radio" name="post_type" value="{{ value }}" {% if pt == value %}checked{% endif %}>{{ label }}</label>
-            {% endfor %}
-            {% endwith %}
-            {% if form.post_type.errors %}<div>{{ form.post_type.errors }}</div>{% endif %}
-        </div>
-        <div>
-            {{ form.file.label_tag }} {{ form.file }}
-            {% if form.file.errors %}<div>{{ form.file.errors }}</div>{% endif %}
-        </div>
+        <input type="text" name="title" value="{{ form.title.value|default_if_none:'' }}" placeholder="Title">
+        {% if form.title.errors %}<div>{{ form.title.errors }}</div>{% endif %}
+        {% with pt=form.post_type.value|default:'text' %}
+        <select name="post_type" id="post_type">
+            <option value="text" {% if pt == 'text' %}selected{% endif %}>text</option>
+            <option value="link" {% if pt == 'link' %}selected{% endif %}>link</option>
+            <option value="image" {% if pt == 'image' %}selected{% endif %}>image</option>
+        </select>
+        {% if form.post_type.errors %}<div>{{ form.post_type.errors }}</div>{% endif %}
+        <textarea name="body" id="field-body"{% if pt != 'text' %} style="display:none"{% endif %}>{{ form.body.value|default_if_none:'' }}</textarea>
+        {% if form.body.errors %}<div>{{ form.body.errors }}</div>{% endif %}
+        <input type="url" name="url" id="field-url" value="{{ form.url.value|default_if_none:'' }}"{% if pt != 'link' %} style="display:none"{% endif %}>
+        {% if form.url.errors %}<div>{{ form.url.errors }}</div>{% endif %}
+        <input type="file" name="file" id="field-file"{% if pt != 'image' %} style="display:none"{% endif %}>
+        {% if form.file.errors %}<div>{{ form.file.errors }}</div>{% endif %}
+        {% endwith %}
         <button type="submit">Submit</button>
     </form>
+</div>
+<script>
+const sel=document.getElementById('post_type');
+const bodyField=document.getElementById('field-body');
+const urlField=document.getElementById('field-url');
+const fileField=document.getElementById('field-file');
+function update(){const v=sel.value;bodyField.style.display=v==='text'?'':'none';urlField.style.display=v==='link'?'':'none';fileField.style.display=v==='image'?'':'none';}
+sel.addEventListener('change',update);update();
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- refactor home and community templates to render posts in minimal `.postrow` layout with HTMX voting
- add minimal submit post form using a post type selector and conditional body/url/image fields

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689eadff2dd4832c8106e0068ba73b00