### PR TITLE
Ensure CSRF token is sent on HTMX requests

### DIFF
--- a/templates/core/_htmx_csrf.html
+++ b/templates/core/_htmx_csrf.html
@@ -1,0 +1,5 @@
+<script>
+  document.body.addEventListener('htmx:configRequest', function (e) {
+    e.detail.headers['X-CSRFToken'] = '{{ csrf_token }}';
+  });
+</script>

--- a/templates/core/post_detail.html
+++ b/templates/core/post_detail.html
@@ -60,4 +60,5 @@
     {{ form.as_p }}
     <button type="submit">Comment</button>
 </form>
+{% include "core/_htmx_csrf.html" %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- Add reusable template partial that attaches the CSRF token to all HTMX requests
- Include the partial in post detail template so vote buttons send the token

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68a2a1b7802c832c83e74e3fbf12f679