### PR TITLE
Implement per-user post and comment voting

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -15,6 +15,7 @@ urlpatterns = [
     path("post/<int:pk>/", core_views.post_detail, name="post_detail"),
     path("post/<int:pk>/comment/", core_views.add_comment, name="add_comment"),
     path("vote/post/<int:pk>/", core_views.vote_post, name="vote_post"),
+    path("vote/comment/<int:pk>/", core_views.vote_comment, name="vote_comment"),
     path("admin/", admin.site.urls),
 ]
 

--- a/core/models.py
+++ b/core/models.py
@@ -44,3 +44,39 @@ class Vote(models.Model):
 
     class Meta:
         unique_together = ("user", "target_type", "target_id")
+
+
+def apply_vote(user, target_type, target_id, value):
+    """Apply a vote to a post or comment and return the new score."""
+    if value not in (-1, 1):
+        raise ValueError("Invalid vote value")
+
+    if target_type == "post":
+        model = Post
+    elif target_type == "comment":
+        model = Comment
+    else:
+        raise ValueError("Invalid target type")
+
+    target = model.objects.get(pk=target_id)
+    vote, created = Vote.objects.get_or_create(
+        user=user,
+        target_type=target_type,
+        target_id=target_id,
+        defaults={"value": value},
+    )
+
+    if created:
+        target.score += value
+    else:
+        if vote.value == value:
+            target.score -= value
+            vote.delete()
+        else:
+            delta = value - vote.value
+            vote.value = value
+            vote.save(update_fields=["value"])
+            target.score += delta
+
+    target.save(update_fields=["score"])
+    return target.score

--- a/core/tests.py
+++ b/core/tests.py
@@ -4,7 +4,7 @@ from django.contrib.auth import get_user_model
 from django.test import TestCase
 from django.urls import reverse
 
-from .models import Community, Post
+from .models import Comment, Community, Post
 
 
 class SubmitPostTests(TestCase):
@@ -51,8 +51,8 @@ class SubmitPostTests(TestCase):
         self.assertEqual(post.body, "")
 
 
-class VoteTests(TestCase):
-    """Ensure voting adjusts post scores."""
+class VotePostTests(TestCase):
+    """Ensure voting adjusts post scores per user."""
 
     def setUp(self):
         user_model = get_user_model()
@@ -64,6 +64,7 @@ class VoteTests(TestCase):
             post_type="text",
             title="Hello",
         )
+        self.client.login(username="alice", password="pwd")
 
     def test_upvote_post(self):
         url = reverse("vote_post", args=[self.post.pk])
@@ -79,10 +80,77 @@ class VoteTests(TestCase):
         self.post.refresh_from_db()
         self.assertEqual(self.post.score, -1)
 
+    def test_toggle_off_post_vote(self):
+        url = reverse("vote_post", args=[self.post.pk])
+        self.client.post(url, {"v": "1"})
+        self.client.post(url, {"v": "1"})
+        self.post.refresh_from_db()
+        self.assertEqual(self.post.score, 0)
+
+    def test_switch_post_vote_direction(self):
+        url = reverse("vote_post", args=[self.post.pk])
+        self.client.post(url, {"v": "1"})
+        self.client.post(url, {"v": "-1"})
+        self.post.refresh_from_db()
+        self.assertEqual(self.post.score, -1)
+
     def test_invalid_vote(self):
         url = reverse("vote_post", args=[self.post.pk])
         resp = self.client.post(url, {"v": "0"})
         self.assertEqual(resp.status_code, 400)
         self.post.refresh_from_db()
         self.assertEqual(self.post.score, 0)
+
+    def test_requires_login(self):
+        self.client.logout()
+        url = reverse("vote_post", args=[self.post.pk])
+        resp = self.client.post(url, {"v": "1"})
+        self.assertEqual(resp.status_code, 302)
+
+
+class VoteCommentTests(TestCase):
+    """Ensure voting works for comments."""
+
+    def setUp(self):
+        user_model = get_user_model()
+        self.user = user_model.objects.create_user("alice", password="pwd")
+        self.community = Community.objects.create(name="t", title="Test")
+        self.post = Post.objects.create(
+            community=self.community,
+            author=self.user,
+            post_type="text",
+            title="Hello",
+        )
+        self.comment = Comment.objects.create(
+            post=self.post, author=self.user, body="Hi"
+        )
+        self.client.login(username="alice", password="pwd")
+
+    def test_upvote_comment(self):
+        url = reverse("vote_comment", args=[self.comment.pk])
+        resp = self.client.post(url, {"v": "1"})
+        self.assertEqual(resp.status_code, 200)
+        self.comment.refresh_from_db()
+        self.assertEqual(self.comment.score, 1)
+
+    def test_downvote_comment(self):
+        url = reverse("vote_comment", args=[self.comment.pk])
+        resp = self.client.post(url, {"v": "-1"})
+        self.assertEqual(resp.status_code, 200)
+        self.comment.refresh_from_db()
+        self.assertEqual(self.comment.score, -1)
+
+    def test_toggle_off_comment_vote(self):
+        url = reverse("vote_comment", args=[self.comment.pk])
+        self.client.post(url, {"v": "1"})
+        self.client.post(url, {"v": "1"})
+        self.comment.refresh_from_db()
+        self.assertEqual(self.comment.score, 0)
+
+    def test_switch_comment_vote_direction(self):
+        url = reverse("vote_comment", args=[self.comment.pk])
+        self.client.post(url, {"v": "1"})
+        self.client.post(url, {"v": "-1"})
+        self.comment.refresh_from_db()
+        self.assertEqual(self.comment.score, -1)
 

--- a/core/views.py
+++ b/core/views.py
@@ -1,13 +1,14 @@
 """Core application views."""
 
 from django.contrib.auth.decorators import login_required
+from django_ratelimit.decorators import ratelimit
 
 from django.http import HttpResponse, HttpResponseBadRequest
 from django.shortcuts import get_object_or_404, redirect, render
 from django.views.decorators.http import require_POST
 
 from .forms import CommentForm, PostForm
-from .models import Comment, Community, Post
+from .models import Comment, Community, Post, apply_vote
 
 
 def home(request):
@@ -76,7 +77,9 @@ def add_comment(request, pk):
     return redirect("post_detail", pk=post.pk)
 
 
+@login_required
 @require_POST
+@ratelimit(key="user_or_ip", rate="20/m", block=True)
 def vote_post(request, pk):
     """Handle voting on a post."""
 
@@ -84,12 +87,29 @@ def vote_post(request, pk):
         value = int(request.POST.get("v"))
     except (TypeError, ValueError):
         return HttpResponseBadRequest("Invalid vote")
-    if value not in (-1, 1):
+
+    try:
+        new_score = apply_vote(request.user, "post", pk, value)
+    except ValueError:
         return HttpResponseBadRequest("Invalid vote")
 
-    post = get_object_or_404(Post, pk=pk)
-    post.score += value
-    post.save(update_fields=["score"])
-    return HttpResponse(
-        f"<span id='post-score-{post.pk}'>{post.score}</span>"
-    )
+    return HttpResponse(f"<span id='post-score-{pk}'>{new_score}</span>")
+
+
+@login_required
+@require_POST
+@ratelimit(key="user_or_ip", rate="20/m", block=True)
+def vote_comment(request, pk):
+    """Handle voting on a comment."""
+
+    try:
+        value = int(request.POST.get("v"))
+    except (TypeError, ValueError):
+        return HttpResponseBadRequest("Invalid vote")
+
+    try:
+        new_score = apply_vote(request.user, "comment", pk, value)
+    except ValueError:
+        return HttpResponseBadRequest("Invalid vote")
+
+    return HttpResponse(f"<span id='comment-score-{pk}'>{new_score}</span>")


### PR DESCRIPTION
## Summary
- implement shared `apply_vote` helper to toggle/switch votes and update scores
- secure post/comment voting endpoints with login and rate limiting, returning HTMX fragments
- cover post and comment voting behaviors and auth checks in tests

## Testing
- `python manage.py makemigrations`
- `python manage.py migrate`
- `python manage.py test`
- `python manage.py runserver`


------
https://chatgpt.com/codex/tasks/task_e_68a2a4a9c474832ca5b34c6c37d10292