### PR TITLE
Ranking utilities + safe math helpers

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -1,10 +1,10 @@
 from django.conf import settings
 from django.db import models
 from django.db.models import F
-import math
-from django.utils import timezone
 from django.db.models.signals import post_save
 from django.dispatch import receiver
+
+from .ranking import recompute_post_ranks
 
 
 class Community(models.Model):
@@ -53,13 +53,13 @@ class Post(models.Model):
             self.recompute_hot()
 
     def recompute_hot(self):
-        now = timezone.now()
-        age_hours = max((now - self.created_at).total_seconds() / 3600, 0.5)
-        hot = self.score / math.pow(age_hours + 2, 1.8)
-        self.hot_rank = hot
-        Post = self.__class__
-        Post.objects.filter(pk=self.pk).update(hot_rank=hot)
-        return hot
+        up = Vote.objects.filter(
+            target_type="post", target_id=self.pk, value=1
+        ).count()
+        down = Vote.objects.filter(
+            target_type="post", target_id=self.pk, value=-1
+        ).count()
+        return recompute_post_ranks(self, up, down)
 
 
 class Comment(models.Model):
@@ -136,7 +136,13 @@ def apply_vote(user, target_type, target_id, value):
 
     target.save(update_fields=["score"])
     if target_type == "post":
-        target.recompute_hot()
+        up = Vote.objects.filter(
+            target_type="post", target_id=target_id, value=1
+        ).count()
+        down = Vote.objects.filter(
+            target_type="post", target_id=target_id, value=-1
+        ).count()
+        recompute_post_ranks(target, up, down)
     return target.score
 
 

--- a/core/ranking.py
+++ b/core/ranking.py
@@ -1,0 +1,48 @@
+from datetime import datetime, timezone
+import math
+
+
+def now():
+    return datetime.now(timezone.utc)
+
+
+def hours_since(dt):
+    return max((now() - dt).total_seconds() / 3600, 1e-6)
+
+
+def hot(score, created_at):
+    age_h = max(hours_since(created_at), 0.5)
+    return score / pow(age_h + 2.0, 1.8)
+
+
+def rising(score, created_at):
+    age_h = max(hours_since(created_at), 0.25)
+    return score / age_h
+
+
+def controversial(up, down):
+    if up == 0 or down == 0:
+        return 0.0
+    total = up + down
+    return total * min(up, down) / max(up, down)
+
+
+def best(up, down, z=1.281551565545):  # 80% Wilson
+    n = up + down
+    if n == 0:
+        return 0.0
+    p = up / n
+    denom = 1 + z * z / n
+    centre = p + z * z / (2 * n)
+    margin = z * math.sqrt((p * (1 - p) + z * z / (4 * n)) / n)
+    return (centre - margin) / denom
+
+
+def recompute_post_ranks(post, up_count, down_count):
+    score = post.score
+    post.hot_rank = hot(score, post.created_at)
+    post.rising_rank = rising(score, post.created_at)
+    post.controversy = controversial(up_count, down_count)
+    post.best_rank = best(up_count, down_count)
+    post.save(update_fields=["hot_rank", "rising_rank", "controversy", "best_rank"])
+    return post.hot_rank


### PR DESCRIPTION
## Summary
- add ranking utility functions (hot, rising, controversial, best) with safe math helpers
- recompute post ranks (hot, rising, controversy, best) after saves and votes

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68a3e3e39e38832cb43bf0294511ae23