### PR TITLE
Implement vote service and model signals

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from django.db import models
 from django.db.models import F
-from django.db.models.signals import post_save
+from django.db.models.signals import post_save, post_delete, pre_save
 from django.dispatch import receiver
 
 from .ranking import recompute_post_ranks
@@ -102,50 +102,6 @@ class Vote(models.Model):
         unique_together = ("user", "target_type", "target_id")
 
 
-def apply_vote(user, target_type, target_id, value):
-    """Apply a vote to a post or comment and return the new score."""
-    if value not in (-1, 1):
-        raise ValueError("Invalid vote value")
-
-    if target_type == "post":
-        model = Post
-    elif target_type == "comment":
-        model = Comment
-    else:
-        raise ValueError("Invalid target type")
-
-    target = model.objects.get(pk=target_id)
-    vote, created = Vote.objects.get_or_create(
-        user=user,
-        target_type=target_type,
-        target_id=target_id,
-        defaults={"value": value},
-    )
-
-    if created:
-        target.score += value
-    else:
-        if vote.value == value:
-            target.score -= value
-            vote.delete()
-        else:
-            delta = value - vote.value
-            vote.value = value
-            vote.save(update_fields=["value"])
-            target.score += delta
-
-    target.save(update_fields=["score"])
-    if target_type == "post":
-        up = Vote.objects.filter(
-            target_type="post", target_id=target_id, value=1
-        ).count()
-        down = Vote.objects.filter(
-            target_type="post", target_id=target_id, value=-1
-        ).count()
-        recompute_post_ranks(target, up, down)
-    return target.score
-
-
 class UserProfile(models.Model):
     user = models.OneToOneField(
         settings.AUTH_USER_MODEL, on_delete=models.CASCADE, related_name="profile"
@@ -163,3 +119,60 @@ def get_points(user):
     if hasattr(user, "points_cached"):
         return user.points_cached
     return getattr(user, "profile", None).points_cached if hasattr(user, "profile") else 0
+
+
+# -- Vote side effects ------------------------------------------------------
+
+
+@receiver(pre_save, sender=Vote)
+def _store_old_vote_value(sender, instance, **kwargs):
+    """Store the previous vote value on the instance before saving."""
+    if instance.pk:
+        instance._old_value = (
+            Vote.objects.filter(pk=instance.pk).values_list("value", flat=True).first()
+            or 0
+        )
+    else:
+        instance._old_value = 0
+
+
+def _apply_vote_delta(instance, delta):
+    """Apply the vote delta to the target object and author points."""
+    if delta == 0:
+        return
+    if instance.target_type == "post":
+        Post.objects.filter(pk=instance.target_id).update(score=F("score") + delta)
+        post = Post.objects.get(pk=instance.target_id)
+        # recompute ranking based on current vote counts
+        up = Vote.objects.filter(
+            target_type="post", target_id=instance.target_id, value=1
+        ).count()
+        down = Vote.objects.filter(
+            target_type="post", target_id=instance.target_id, value=-1
+        ).count()
+        recompute_post_ranks(post, up, down)
+        UserProfile.objects.filter(user=post.author_id).update(
+            points_cached=F("points_cached") + delta
+        )
+    else:
+        Comment.objects.filter(pk=instance.target_id).update(score=F("score") + delta)
+        comment = Comment.objects.get(pk=instance.target_id)
+        UserProfile.objects.filter(user=comment.author_id).update(
+            points_cached=F("points_cached") + delta
+        )
+
+
+@receiver(post_save, sender=Vote)
+def _update_scores_on_vote_save(sender, instance, created, **kwargs):
+    old = getattr(instance, "_old_value", 0)
+    delta = instance.value - old
+    _apply_vote_delta(instance, delta)
+
+
+@receiver(post_delete, sender=Vote)
+def _update_scores_on_vote_delete(sender, instance, **kwargs):
+    _apply_vote_delta(instance, -instance.value)
+
+
+# Re-export apply_vote for backwards compatibility
+from .votes import apply_vote  # noqa: E402

--- a/core/views.py
+++ b/core/views.py
@@ -9,7 +9,8 @@ from django.http import HttpResponse, HttpResponseBadRequest
 from django.shortcuts import get_object_or_404, redirect, render
 
 from .forms import CommentForm, PostForm, CommunityCreateForm
-from .models import Comment, Community, Post, apply_vote
+from .models import Comment, Community, Post
+from .votes import apply_vote
 from .pagination import PAGE_SIZE, build_cursor, parse_cursor
 
 
@@ -144,11 +145,12 @@ def vote_post(request, pk):
         return HttpResponseBadRequest("Invalid vote")
 
     try:
-        new_score = apply_vote(request.user, "post", pk, value)
+        apply_vote(request.user, "post", pk, value)
     except ValueError:
         return HttpResponseBadRequest("Invalid vote")
 
-    return HttpResponse(f"<span id='post-score-{pk}'>{new_score}</span>")
+    score = Post.objects.get(pk=pk).score
+    return HttpResponse(f"<span id='post-score-{pk}'>{score}</span>")
 
 
 @login_required
@@ -163,11 +165,12 @@ def vote_comment(request, pk):
         return HttpResponseBadRequest("Invalid vote")
 
     try:
-        new_score = apply_vote(request.user, "comment", pk, value)
+        apply_vote(request.user, "comment", pk, value)
     except ValueError:
         return HttpResponseBadRequest("Invalid vote")
 
-    return HttpResponse(f"<span id='comment-score-{pk}'>{new_score}</span>")
+    score = Comment.objects.get(pk=pk).score
+    return HttpResponse(f"<span id='comment-score-{pk}'>{score}</span>")
 
 
 @login_required

--- a/core/votes.py
+++ b/core/votes.py
@@ -1,0 +1,42 @@
+"""Vote application service functions."""
+
+from django.db import transaction
+
+from .models import Vote  # models: Post and Comment imported lazily via signals
+
+
+def apply_vote(user, target_type, target_id, value):
+    """Apply a vote and return (delta_score, old_value, new_value).
+
+    The returned ``delta_score`` represents the change applied to the target's
+    score. ``old_value`` and ``new_value`` represent the previous and new vote
+    values (0 if no vote).
+    """
+    if value not in (-1, 1):
+        raise ValueError("Invalid vote value")
+
+    with transaction.atomic():
+        try:
+            vote = Vote.objects.select_for_update().get(
+                user=user, target_type=target_type, target_id=target_id
+            )
+            old_value = vote.value
+            if old_value == value:
+                vote.delete()
+                new_value = 0
+            else:
+                vote.value = value
+                vote.save(update_fields=["value"])
+                new_value = value
+        except Vote.DoesNotExist:
+            Vote.objects.create(
+                user=user,
+                target_type=target_type,
+                target_id=target_id,
+                value=value,
+            )
+            old_value = 0
+            new_value = value
+
+    delta_score = new_value - old_value
+    return delta_score, old_value, new_value


### PR DESCRIPTION
## Summary
- add dedicated `votes` service with `apply_vote` returning delta and old/new values
- use model signals to keep post/comment scores and author points in sync
- update views to use new vote service

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68a3e60bfa40832cbc2c28e856225410