### PR TITLE
Add URL routing and view stubs for feeds, voting, and user pages

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -11,12 +11,20 @@ from core import views as core_views
 urlpatterns = [
     path("", core_views.home, name="home"),
     path("c/new/", core_views.create_community, name="community_create"),
-    path("c/<slug:slug>/", core_views.community, name="community"),
-    path("c/<slug:slug>/submit/", core_views.submit_post, name="submit_post"),
-    path("post/<int:pk>/", core_views.post_detail, name="post_detail"),
-    path("post/<int:pk>/comment/", core_views.add_comment, name="add_comment"),
+    path("r/<slug:slug>/", core_views.community, name="community"),
+    path("r/<slug:slug>/submit/", core_views.submit_post, name="submit_post"),
+    path("r/<slug:slug>/wiki/", core_views.community_wiki, name="community_wiki"),
+    path(
+        "r/<slug:slug>/comments/<int:post_id>/<slug:post_slug>/",
+        core_views.post_detail,
+        name="post_detail",
+    ),
+    path("comment/<int:post_id>/reply/", core_views.comment_reply, name="comment_reply"),
     path("vote/post/<int:pk>/", core_views.vote_post, name="vote_post"),
     path("vote/comment/<int:pk>/", core_views.vote_comment, name="vote_comment"),
+    path("u/<str:username>/", core_views.user_overview, name="user_overview"),
+    path("u/<str:username>/comments/", core_views.user_comments, name="user_comments"),
+    path("u/<str:username>/submitted/", core_views.user_submitted, name="user_submitted"),
     path("admin/", admin.site.urls),
 ]
 

--- a/core/tests.py
+++ b/core/tests.py
@@ -72,42 +72,42 @@ class VotePostTests(TestCase):
 
     def test_upvote_post(self):
         url = reverse("vote_post", args=[self.post.pk])
-        resp = self.client.post(url, {"v": "1"})
+        resp = self.client.post(url + "?v=1")
         self.assertEqual(resp.status_code, 200)
         self.post.refresh_from_db()
         self.assertEqual(self.post.score, 1)
 
     def test_downvote_post(self):
         url = reverse("vote_post", args=[self.post.pk])
-        resp = self.client.post(url, {"v": "-1"})
+        resp = self.client.post(url + "?v=-1")
         self.assertEqual(resp.status_code, 200)
         self.post.refresh_from_db()
         self.assertEqual(self.post.score, -1)
 
     def test_toggle_off_post_vote(self):
         url = reverse("vote_post", args=[self.post.pk])
-        self.client.post(url, {"v": "1"})
-        self.client.post(url, {"v": "1"})
+        self.client.post(url + "?v=1")
+        self.client.post(url + "?v=1")
         self.post.refresh_from_db()
         self.assertEqual(self.post.score, 0)
 
     def test_switch_post_vote_direction(self):
         url = reverse("vote_post", args=[self.post.pk])
-        self.client.post(url, {"v": "1"})
-        self.client.post(url, {"v": "-1"})
+        self.client.post(url + "?v=1")
+        self.client.post(url + "?v=-1")
         self.post.refresh_from_db()
         self.assertEqual(self.post.score, -1)
 
     def test_switch_post_vote_back_up(self):
         url = reverse("vote_post", args=[self.post.pk])
-        self.client.post(url, {"v": "-1"})
-        self.client.post(url, {"v": "1"})
+        self.client.post(url + "?v=-1")
+        self.client.post(url + "?v=1")
         self.post.refresh_from_db()
         self.assertEqual(self.post.score, 1)
 
     def test_invalid_vote(self):
         url = reverse("vote_post", args=[self.post.pk])
-        resp = self.client.post(url, {"v": "0"})
+        resp = self.client.post(url + "?v=0")
         self.assertEqual(resp.status_code, 400)
         self.post.refresh_from_db()
         self.assertEqual(self.post.score, 0)
@@ -115,7 +115,7 @@ class VotePostTests(TestCase):
     def test_requires_login(self):
         self.client.logout()
         url = reverse("vote_post", args=[self.post.pk])
-        resp = self.client.post(url, {"v": "1"})
+        resp = self.client.post(url + "?v=1")
         self.assertEqual(resp.status_code, 302)
 
 
@@ -141,42 +141,42 @@ class VoteCommentTests(TestCase):
 
     def test_upvote_comment(self):
         url = reverse("vote_comment", args=[self.comment.pk])
-        resp = self.client.post(url, {"v": "1"})
+        resp = self.client.post(url + "?v=1")
         self.assertEqual(resp.status_code, 200)
         self.comment.refresh_from_db()
         self.assertEqual(self.comment.score, 1)
 
     def test_downvote_comment(self):
         url = reverse("vote_comment", args=[self.comment.pk])
-        resp = self.client.post(url, {"v": "-1"})
+        resp = self.client.post(url + "?v=-1")
         self.assertEqual(resp.status_code, 200)
         self.comment.refresh_from_db()
         self.assertEqual(self.comment.score, -1)
 
     def test_toggle_off_comment_vote(self):
         url = reverse("vote_comment", args=[self.comment.pk])
-        self.client.post(url, {"v": "1"})
-        self.client.post(url, {"v": "1"})
+        self.client.post(url + "?v=1")
+        self.client.post(url + "?v=1")
         self.comment.refresh_from_db()
         self.assertEqual(self.comment.score, 0)
 
     def test_switch_comment_vote_direction(self):
         url = reverse("vote_comment", args=[self.comment.pk])
-        self.client.post(url, {"v": "1"})
-        self.client.post(url, {"v": "-1"})
+        self.client.post(url + "?v=1")
+        self.client.post(url + "?v=-1")
         self.comment.refresh_from_db()
         self.assertEqual(self.comment.score, -1)
 
     def test_switch_comment_vote_back_up(self):
         url = reverse("vote_comment", args=[self.comment.pk])
-        self.client.post(url, {"v": "-1"})
-        self.client.post(url, {"v": "1"})
+        self.client.post(url + "?v=-1")
+        self.client.post(url + "?v=1")
         self.comment.refresh_from_db()
         self.assertEqual(self.comment.score, 1)
 
     def test_invalid_comment_vote(self):
         url = reverse("vote_comment", args=[self.comment.pk])
-        resp = self.client.post(url, {"v": "0"})
+        resp = self.client.post(url + "?v=0")
         self.assertEqual(resp.status_code, 400)
         self.comment.refresh_from_db()
         self.assertEqual(self.comment.score, 0)
@@ -184,6 +184,6 @@ class VoteCommentTests(TestCase):
     def test_comment_vote_requires_login(self):
         self.client.logout()
         url = reverse("vote_comment", args=[self.comment.pk])
-        resp = self.client.post(url, {"v": "1"})
+        resp = self.client.post(url + "?v=1")
         self.assertEqual(resp.status_code, 302)
 

--- a/core/tests_hot.py
+++ b/core/tests_hot.py
@@ -67,5 +67,5 @@ class HotRankTests(TestCase):
             score=2,
         )
         p2.recompute_hot()
-        resp = self.client.get(reverse("home") + "?sort=hot")
+        resp = self.client.get(reverse("home") + "?t=hot")
         self.assertEqual(resp.context["posts"][0].pk, p1.pk)

--- a/core/views.py
+++ b/core/views.py
@@ -7,6 +7,7 @@ from django.template.loader import render_to_string
 
 from django.http import HttpResponse, HttpResponseBadRequest
 from django.shortcuts import get_object_or_404, redirect, render
+from django.utils.text import slugify
 
 from .forms import CommentForm, PostForm, CommunityCreateForm
 from .models import Comment, Community, Post
@@ -31,7 +32,7 @@ def _render_posts(request, posts, next_before, show_community=False, sort_query=
 def home(request):
     """Display the latest posts across all communities."""
 
-    sort = request.GET.get("sort")
+    tab = request.GET.get("t", "best")
     qs = Post.objects.select_related("community", "author")
     qs = parse_cursor(qs, request.GET.get("before"))
     qs = qs.order_by("-created_at", "-id")
@@ -40,18 +41,21 @@ def home(request):
     if len(posts) > PAGE_SIZE:
         next_before = build_cursor(posts[PAGE_SIZE - 1])
         posts = posts[:PAGE_SIZE]
-    if sort == "hot":
+    if tab == "hot":
         posts.sort(key=lambda p: (-p.hot_rank, -p.created_at.timestamp(), -p.id))
-        sort_query = "&sort=hot"
+        sort_query = "&t=hot"
     else:
-        sort_query = ""
+        sort_query = f"&t={tab}" if tab and tab != "best" else ""
     context = {
         "posts": posts,
         "next_before": next_before,
         "sort_query": sort_query,
+        "tab": tab,
     }
     if request.headers.get("HX-Request") == "true":
-        return _render_posts(request, posts, next_before, show_community=True, sort_query=sort_query)
+        return _render_posts(
+            request, posts, next_before, show_community=True, sort_query=sort_query
+        )
     return render(
         request,
         "core/home.html",
@@ -63,7 +67,7 @@ def community(request, slug):
     """Display posts for a specific community."""
 
     community = get_object_or_404(Community, slug=slug)
-    sort = request.GET.get("sort")
+    tab = request.GET.get("t", "best")
     qs = community.posts.select_related("author")
     qs = parse_cursor(qs, request.GET.get("before"))
     qs = qs.order_by("-created_at", "-id")
@@ -72,16 +76,17 @@ def community(request, slug):
     if len(posts) > PAGE_SIZE:
         next_before = build_cursor(posts[PAGE_SIZE - 1])
         posts = posts[:PAGE_SIZE]
-    if sort == "hot":
+    if tab == "hot":
         posts.sort(key=lambda p: (-p.hot_rank, -p.created_at.timestamp(), -p.id))
-        sort_query = "&sort=hot"
+        sort_query = "&t=hot"
     else:
-        sort_query = ""
+        sort_query = f"&t={tab}" if tab and tab != "best" else ""
     context = {
         "community": community,
         "posts": posts,
         "next_before": next_before,
         "sort_query": sort_query,
+        "tab": tab,
     }
     if request.headers.get("HX-Request") == "true":
         return _render_posts(request, posts, next_before, sort_query=sort_query)
@@ -109,10 +114,10 @@ def submit_post(request, slug):
     return render(request, "core/submit_post.html", context)
 
 
-def post_detail(request, pk):
+def post_detail(request, slug, post_id, post_slug):
     """Display a single post and its comments."""
 
-    post = get_object_or_404(Post, pk=pk)
+    post = get_object_or_404(Post, pk=post_id, community__slug=slug)
     comments = post.comments.select_related("author").order_by("created_at")
     form = CommentForm()
     context = {"post": post, "comments": comments, "form": form}
@@ -121,16 +126,25 @@ def post_detail(request, pk):
 
 @login_required
 @require_POST
-def add_comment(request, pk):
-    """Add a comment to a post."""
+def comment_reply(request, post_id):
+    """Reply to a post or comment."""
 
-    post = get_object_or_404(Post, pk=pk)
+    post = get_object_or_404(Post, pk=post_id)
+    parent_id = request.POST.get("parent_id")
     form = CommentForm(request.POST)
     if form.is_valid():
         Comment.objects.create(
-            post=post, author=request.user, body=form.cleaned_data["body"]
+            post=post,
+            author=request.user,
+            body=form.cleaned_data["body"],
+            parent_id=parent_id or None,
         )
-    return redirect("post_detail", pk=post.pk)
+    return redirect(
+        "post_detail",
+        slug=post.community.slug,
+        post_id=post.pk,
+        post_slug=slugify(post.title),
+    )
 
 
 @login_required
@@ -140,7 +154,7 @@ def vote_post(request, pk):
     """Handle voting on a post."""
 
     try:
-        value = int(request.POST.get("v"))
+        value = int(request.GET.get("v"))
     except (TypeError, ValueError):
         return HttpResponseBadRequest("Invalid vote")
 
@@ -160,7 +174,7 @@ def vote_comment(request, pk):
     """Handle voting on a comment."""
 
     try:
-        value = int(request.POST.get("v"))
+        value = int(request.GET.get("v"))
     except (TypeError, ValueError):
         return HttpResponseBadRequest("Invalid vote")
 
@@ -171,6 +185,30 @@ def vote_comment(request, pk):
 
     score = Comment.objects.get(pk=pk).score
     return HttpResponse(f"<span id='comment-score-{pk}'>{score}</span>")
+
+
+def community_wiki(request, slug):
+    """Placeholder view for community wiki."""
+
+    return HttpResponse("wiki")
+
+
+def user_overview(request, username):
+    """User overview page stub."""
+
+    return HttpResponse(f"Profile for {username}")
+
+
+def user_comments(request, username):
+    """User comments page stub."""
+
+    return HttpResponse(f"Comments by {username}")
+
+
+def user_submitted(request, username):
+    """User submitted posts page stub."""
+
+    return HttpResponse(f"Submissions by {username}")
 
 
 @login_required

--- a/templates/core/community.html
+++ b/templates/core/community.html
@@ -3,8 +3,9 @@
 <h1>{{ community.title }}</h1>
 <p>{{ community.description }}</p>
 <div>
-  <a href="{% url 'community' community.slug %}">New</a>
-  <a href="{% url 'community' community.slug %}?sort=hot">Hot</a>
+  <a href="{% url 'community' community.slug %}?t=best">Best</a>
+  <a href="{% url 'community' community.slug %}?t=hot">Hot</a>
+  <a href="{% url 'community' community.slug %}?t=new">New</a>
 </div>
 <div id="feed-list">
   {% include "core/partials/post_list.html" with posts=posts %}

--- a/templates/core/home.html
+++ b/templates/core/home.html
@@ -2,8 +2,9 @@
 {% block content %}
   <h1>SureJan</h1>
   <div>
-    <a href="{% url 'home' %}">New</a>
-    <a href="{% url 'home' %}?sort=hot">Hot</a>
+    <a href="{% url 'home' %}?t=best">Best</a>
+    <a href="{% url 'home' %}?t=hot">Hot</a>
+    <a href="{% url 'home' %}?t=new">New</a>
   </div>
   <div id="feed-list">
     {% include "core/partials/post_list.html" with posts=posts show_community=True %}

--- a/templates/core/partials/post_list.html
+++ b/templates/core/partials/post_list.html
@@ -1,19 +1,17 @@
 {% for post in posts %}
   <div>
     {% if show_community %}
-      <a href="{% url 'community' post.community.slug %}">/c/{{ post.community.slug }}/</a>
+      <a href="{% url 'community' post.community.slug %}">/r/{{ post.community.slug }}/</a>
     {% endif %}
-    <strong><a href="{% url 'post_detail' post.pk %}">{{ post.title }}</a></strong>
+    <strong><a href="{% url 'post_detail' post.community.slug post.pk post.title|slugify %}">{{ post.title }}</a></strong>
     · {{ post.author.username }}
     · {{ post.created_at }}
     <div>
-      <button hx-post="{% url 'vote_post' post.pk %}"
-              hx-vals='{"v":1}'
+      <button hx-post="{% url 'vote_post' post.pk %}?v=1"
               hx-target="#post-score-{{post.pk}}"
               hx-swap="outerHTML">▲</button>
       <span id="post-score-{{post.pk}}">{{ post.score }}</span>
-      <button hx-post="{% url 'vote_post' post.pk %}"
-              hx-vals='{"v":-1}'
+      <button hx-post="{% url 'vote_post' post.pk %}?v=-1"
               hx-target="#post-score-{{post.pk}}"
               hx-swap="outerHTML">▼</button>
     </div>

--- a/templates/core/post_detail.html
+++ b/templates/core/post_detail.html
@@ -11,19 +11,13 @@
     in <a href="{% url 'community' post.community.slug %}" style="color: blue;">{{ post.community.title }}</a>
     by {{ post.author.username }}
     ·
-    <button hx-post="{% url 'vote_post' post.pk %}"
+    <button hx-post="{% url 'vote_post' post.pk %}?v=1"
             hx-target="#post-score-{{ post.pk }}"
-            hx-swap="outerHTML"
-            hx-include="[name='v']">
-        ▲<input type="hidden" name="v" value="1">
-    </button>
+            hx-swap="outerHTML">▲</button>
     <span id="post-score-{{ post.pk }}">{{ post.score }}</span>
-    <button hx-post="{% url 'vote_post' post.pk %}"
+    <button hx-post="{% url 'vote_post' post.pk %}?v=-1"
             hx-target="#post-score-{{ post.pk }}"
-            hx-swap="outerHTML"
-            hx-include="[name='v']">
-        ▼<input type="hidden" name="v" value="-1">
-    </button>
+            hx-swap="outerHTML">▼</button>
     · {{ post.created_at|timesince }} ago
 </p>
 <h2>Comments</h2>
@@ -34,19 +28,13 @@
         <small>
             by {{ comment.author.username }}
             ·
-            <button hx-post="{% url 'vote_comment' comment.pk %}"
+            <button hx-post="{% url 'vote_comment' comment.pk %}?v=1"
                     hx-target="#comment-score-{{ comment.pk }}"
-                    hx-swap="outerHTML"
-                    hx-include="[name='v']">
-                ▲<input type="hidden" name="v" value="1">
-            </button>
+                    hx-swap="outerHTML">▲</button>
             <span id="comment-score-{{ comment.pk }}">{{ comment.score }}</span>
-            <button hx-post="{% url 'vote_comment' comment.pk %}"
+            <button hx-post="{% url 'vote_comment' comment.pk %}?v=-1"
                     hx-target="#comment-score-{{ comment.pk }}"
-                    hx-swap="outerHTML"
-                    hx-include="[name='v']">
-                ▼<input type="hidden" name="v" value="-1">
-            </button>
+                    hx-swap="outerHTML">▼</button>
             · {{ comment.created_at|timesince }} ago
         </small>
     </li>
@@ -55,7 +43,7 @@
     {% endfor %}
 </ul>
 <h3>Add comment</h3>
-<form method="post" action="{% url 'add_comment' post.pk %}">
+<form method="post" action="{% url 'comment_reply' post.pk %}">
     {% csrf_token %}
     {{ form.as_p }}
     <button type="submit">Comment</button>


### PR DESCRIPTION
## Summary
- add tab-based feed routing for home and communities
- stub out community wiki, comment reply, and user profile endpoints
- switch vote endpoints to querystring parameters and update templates

## Testing
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_68a3ea999a00832c8cb882d6675f7e54