### PR TITLE
Implement tabbed feed queries with pagination

### DIFF
--- a/core/tests_feed_tabs.py
+++ b/core/tests_feed_tabs.py
@@ -1,0 +1,55 @@
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+
+from .models import Community, Post
+
+
+class FeedTabOrderTests(TestCase):
+    def setUp(self):
+        user = get_user_model().objects.create_user("alice", password="pwd")
+        self.community = Community.objects.create(
+            slug="t", name="Test", title="Test", created_by=user
+        )
+        self.old = Post.objects.create(
+            community=self.community,
+            author=user,
+            post_type="text",
+            title="old",
+            score=5,
+        )
+        self.new = Post.objects.create(
+            community=self.community,
+            author=user,
+            post_type="text",
+            title="new",
+            score=3,
+        )
+        # Give the older post better rankings so ordering is obvious
+        Post.objects.filter(pk=self.old.pk).update(
+            best_rank=10, rising_rank=10, controversy=10, hot_rank=10
+        )
+        Post.objects.filter(pk=self.new.pk).update(
+            best_rank=1, rising_rank=1, controversy=1, hot_rank=1
+        )
+        self.old.refresh_from_db()
+        self.new.refresh_from_db()
+
+    def _first_post(self, tab):
+        resp = self.client.get(reverse("home") + f"?t={tab}")
+        return resp.context["posts"][0]
+
+    def test_best_order(self):
+        self.assertEqual(self._first_post("best").pk, self.old.pk)
+
+    def test_new_order(self):
+        self.assertEqual(self._first_post("new").pk, self.new.pk)
+
+    def test_rising_order(self):
+        self.assertEqual(self._first_post("rising").pk, self.old.pk)
+
+    def test_controversial_order(self):
+        self.assertEqual(self._first_post("controversial").pk, self.old.pk)
+
+    def test_top_order(self):
+        self.assertEqual(self._first_post("top").pk, self.old.pk)

--- a/core/tests_pagination.py
+++ b/core/tests_pagination.py
@@ -3,7 +3,7 @@ from django.test import TestCase
 from django.urls import reverse
 
 from .models import Community, Post
-from .pagination import PAGE_SIZE, build_cursor
+from .pagination import PAGE_SIZE
 
 
 class PaginationTests(TestCase):
@@ -21,25 +21,24 @@ class PaginationTests(TestCase):
                 title=f"Post {i}",
             )
 
-    def test_first_page_has_cursor(self):
+    def test_first_page_has_next(self):
         resp = self.client.get(reverse("home"))
         self.assertEqual(len(resp.context["posts"]), PAGE_SIZE)
-        self.assertIsNotNone(resp.context["next_before"])
+        self.assertEqual(resp.context["next_page"], 2)
 
     def test_load_more_htmx(self):
         resp1 = self.client.get(reverse("home"))
-        cursor = resp1.context["next_before"]
+        next_page = resp1.context["next_page"]
         resp2 = self.client.get(
-            reverse("home") + f"?before={cursor}", HTTP_HX_REQUEST="true"
+            reverse("home") + f"?page={next_page}", HTTP_HX_REQUEST="true"
         )
-        self.assertNotIn("<html", resp2.content.decode())
+        body = resp2.content.decode()
+        self.assertNotIn("<html", body)
         # Should have PAGE_SIZE posts again and not include the first page title
-        self.assertEqual(resp2.content.decode().count("Post"), PAGE_SIZE)
-        self.assertNotIn("Post 39", resp2.content.decode())
-        self.assertNotIn("Post 25", resp2.content.decode())
+        self.assertEqual(body.count("Post"), PAGE_SIZE)
+        self.assertNotIn("Post 39", body)
+        self.assertNotIn("Post 25", body)
 
-    def test_last_page_no_cursor(self):
-        last_post = Post.objects.order_by("created_at", "id").first()
-        cursor = build_cursor(last_post)
-        resp = self.client.get(reverse("home") + f"?before={cursor}")
-        self.assertIsNone(resp.context.get("next_before"))
+    def test_last_page_no_next(self):
+        resp = self.client.get(reverse("home") + "?page=3")
+        self.assertIsNone(resp.context.get("next_page"))

--- a/core/views.py
+++ b/core/views.py
@@ -12,17 +12,31 @@ from django.utils.text import slugify
 from .forms import CommentForm, PostForm, CommunityCreateForm
 from .models import Comment, Community, Post
 from .votes import apply_vote
-from .pagination import PAGE_SIZE, build_cursor, parse_cursor
+from .pagination import PAGE_SIZE
 
 
-def _render_posts(request, posts, next_before, show_community=False, sort_query=""):
+# Mapping of feed tabs to their ordering in the database.  Each ordering
+# includes ``-id`` as the final column to guarantee deterministic results.
+FEED_ORDER = {
+    "best": ["-best_rank", "-created_at", "-id"],
+    "hot": ["-hot_rank", "-created_at", "-id"],
+    "new": ["-created_at", "-id"],
+    "rising": ["-rising_rank", "-created_at", "-id"],
+    "controversial": ["-controversy", "-created_at", "-id"],
+    "top": ["-score", "-created_at", "-id"],
+}
+
+
+def _render_posts(request, posts, next_page, show_community=False, sort_query=""):
+    """Render a list of posts and optional pagination link."""
+
     html = render_to_string(
         "core/partials/post_list.html",
         {"posts": posts, "show_community": show_community},
         request=request,
     )
-    if next_before:
-        next_url = f"{request.path}?before={next_before}{sort_query}"
+    if next_page:
+        next_url = f"{request.path}?page={next_page}{sort_query}"
         html += render_to_string(
             "core/partials/load_more.html", {"next_url": next_url}, request=request
         )
@@ -30,37 +44,31 @@ def _render_posts(request, posts, next_before, show_community=False, sort_query=
 
 
 def home(request):
-    """Display the latest posts across all communities."""
+    """Display a feed of posts across all communities."""
 
     tab = request.GET.get("t", "best")
-    qs = Post.objects.select_related("community", "author")
-    qs = parse_cursor(qs, request.GET.get("before"))
-    qs = qs.order_by("-created_at", "-id")
-    posts = list(qs[: PAGE_SIZE + 1 ])
-    next_before = None
-    if len(posts) > PAGE_SIZE:
-        next_before = build_cursor(posts[PAGE_SIZE - 1])
-        posts = posts[:PAGE_SIZE]
-    if tab == "hot":
-        posts.sort(key=lambda p: (-p.hot_rank, -p.created_at.timestamp(), -p.id))
-        sort_query = "&t=hot"
-    else:
-        sort_query = f"&t={tab}" if tab and tab != "best" else ""
+    order = FEED_ORDER.get(tab, FEED_ORDER["best"])
+    page = int(request.GET.get("page", "1") or 1)
+
+    qs = Post.objects.select_related("community", "author").order_by(*order)
+
+    offset = (page - 1) * PAGE_SIZE
+    posts = list(qs[offset : offset + PAGE_SIZE + 1])
+    next_page = page + 1 if len(posts) > PAGE_SIZE else None
+    posts = posts[:PAGE_SIZE]
+
+    sort_query = f"&t={tab}" if tab and tab != "best" else ""
     context = {
         "posts": posts,
-        "next_before": next_before,
+        "next_page": next_page,
         "sort_query": sort_query,
         "tab": tab,
     }
     if request.headers.get("HX-Request") == "true":
         return _render_posts(
-            request, posts, next_before, show_community=True, sort_query=sort_query
+            request, posts, next_page, show_community=True, sort_query=sort_query
         )
-    return render(
-        request,
-        "core/home.html",
-        {**context},
-    )
+    return render(request, "core/home.html", context)
 
 
 def community(request, slug):
@@ -68,28 +76,25 @@ def community(request, slug):
 
     community = get_object_or_404(Community, slug=slug)
     tab = request.GET.get("t", "best")
-    qs = community.posts.select_related("author")
-    qs = parse_cursor(qs, request.GET.get("before"))
-    qs = qs.order_by("-created_at", "-id")
-    posts = list(qs[: PAGE_SIZE + 1 ])
-    next_before = None
-    if len(posts) > PAGE_SIZE:
-        next_before = build_cursor(posts[PAGE_SIZE - 1])
-        posts = posts[:PAGE_SIZE]
-    if tab == "hot":
-        posts.sort(key=lambda p: (-p.hot_rank, -p.created_at.timestamp(), -p.id))
-        sort_query = "&t=hot"
-    else:
-        sort_query = f"&t={tab}" if tab and tab != "best" else ""
+    order = FEED_ORDER.get(tab, FEED_ORDER["best"])
+    page = int(request.GET.get("page", "1") or 1)
+
+    qs = community.posts.select_related("author").order_by(*order)
+    offset = (page - 1) * PAGE_SIZE
+    posts = list(qs[offset : offset + PAGE_SIZE + 1])
+    next_page = page + 1 if len(posts) > PAGE_SIZE else None
+    posts = posts[:PAGE_SIZE]
+
+    sort_query = f"&t={tab}" if tab and tab != "best" else ""
     context = {
         "community": community,
         "posts": posts,
-        "next_before": next_before,
+        "next_page": next_page,
         "sort_query": sort_query,
         "tab": tab,
     }
     if request.headers.get("HX-Request") == "true":
-        return _render_posts(request, posts, next_before, sort_query=sort_query)
+        return _render_posts(request, posts, next_page, sort_query=sort_query)
     return render(request, "core/community.html", context)
 
 

--- a/templates/core/community.html
+++ b/templates/core/community.html
@@ -6,11 +6,14 @@
   <a href="{% url 'community' community.slug %}?t=best">Best</a>
   <a href="{% url 'community' community.slug %}?t=hot">Hot</a>
   <a href="{% url 'community' community.slug %}?t=new">New</a>
+  <a href="{% url 'community' community.slug %}?t=rising">Rising</a>
+  <a href="{% url 'community' community.slug %}?t=controversial">Controversial</a>
+  <a href="{% url 'community' community.slug %}?t=top">Top</a>
 </div>
 <div id="feed-list">
   {% include "core/partials/post_list.html" with posts=posts %}
 </div>
-{% if next_before %}
-  {% include "core/partials/load_more.html" with next_url=request.path|add:'?before='|add:next_before|add:sort_query %}
+{% if next_page %}
+  {% include "core/partials/load_more.html" with next_url=request.path|add:'?page='|add:next_page|add:sort_query %}
 {% endif %}
 {% endblock %}

--- a/templates/core/home.html
+++ b/templates/core/home.html
@@ -5,11 +5,14 @@
     <a href="{% url 'home' %}?t=best">Best</a>
     <a href="{% url 'home' %}?t=hot">Hot</a>
     <a href="{% url 'home' %}?t=new">New</a>
+    <a href="{% url 'home' %}?t=rising">Rising</a>
+    <a href="{% url 'home' %}?t=controversial">Controversial</a>
+    <a href="{% url 'home' %}?t=top">Top</a>
   </div>
   <div id="feed-list">
     {% include "core/partials/post_list.html" with posts=posts show_community=True %}
   </div>
-  {% if next_before %}
-    {% include "core/partials/load_more.html" with next_url=request.path|add:'?before='|add:next_before|add:sort_query %}
+  {% if next_page %}
+    {% include "core/partials/load_more.html" with next_url=request.path|add:'?page='|add:next_page|add:sort_query %}
   {% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- Add database-backed ordering for feed tabs (best, hot, new, rising, controversial, top)
- Support page-based pagination on front page and community feeds
- Update templates and add tests validating new feed ordering and pagination

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68a3ecbc1de8832ca0991715414433e4