### PR TITLE
Implement HTMX comment replies with materialized paths

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -76,19 +76,6 @@ class Comment(models.Model):
     class Meta:
         indexes = [models.Index(fields=["post", "path"])]
 
-    def save(self, *args, **kwargs):
-        is_new = self._state.adding
-        super().save(*args, **kwargs)
-        if is_new:
-            if self.parent:
-                self.path = f"{self.parent.path}/{self.pk:04d}"
-            else:
-                self.path = f"{self.pk:04d}"
-            Comment.objects.filter(pk=self.pk).update(path=self.path)
-            Post.objects.filter(pk=self.post_id).update(
-                comment_count=F("comment_count") + 1
-            )
-
 
 class Vote(models.Model):
     user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)

--- a/core/tests_comment_reply.py
+++ b/core/tests_comment_reply.py
@@ -1,0 +1,50 @@
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+
+from .models import Comment, Community, Post
+
+
+class CommentReplyTests(TestCase):
+    def setUp(self):
+        user_model = get_user_model()
+        self.user = user_model.objects.create_user("alice", password="pwd")
+        self.community = Community.objects.create(
+            slug="t", name="Test", title="Test", created_by=self.user
+        )
+        self.post = Post.objects.create(
+            community=self.community,
+            author=self.user,
+            post_type="text",
+            title="Hello",
+        )
+        self.url = reverse("comment_reply", args=[self.post.pk])
+        self.client.login(username="alice", password="pwd")
+
+    def test_create_root_comment(self):
+        resp = self.client.post(self.url, {"body": "Hi"}, HTTP_HX_REQUEST="true")
+        self.assertEqual(resp.status_code, 200)
+        comment = Comment.objects.get()
+        self.assertEqual(comment.path, "0001")
+        self.post.refresh_from_db()
+        self.assertEqual(self.post.comment_count, 1)
+        self.assertIn(b"Hi", resp.content)
+
+    def test_reply_to_comment(self):
+        self.client.post(self.url, {"body": "Root"}, HTTP_HX_REQUEST="true")
+        root = Comment.objects.get()
+        resp = self.client.post(
+            self.url,
+            {"body": "Child", "parent_id": root.pk},
+            HTTP_HX_REQUEST="true",
+        )
+        self.assertEqual(resp.status_code, 200)
+        child = Comment.objects.exclude(pk=root.pk).get()
+        self.assertEqual(child.path, "0001/0001")
+        self.post.refresh_from_db()
+        self.assertEqual(self.post.comment_count, 2)
+
+    def test_requires_login(self):
+        self.client.logout()
+        resp = self.client.post(self.url, {"body": "Hi"})
+        self.assertEqual(resp.status_code, 302)

--- a/core/tests_community_create.py
+++ b/core/tests_community_create.py
@@ -38,7 +38,11 @@ class CommunityCreateTests(TestCase):
             {"slug": "dup", "name": "Dup", "title": "Another", "description": ""},
         )
         self.assertEqual(resp.status_code, 200)
-        self.assertFormError(resp, "form", "slug", "Community with this slug already exists.")
+        self.assertFormError(
+            resp.context["form"],
+            "slug",
+            "Community with this slug already exists.",
+        )
 
     def test_d_rate_limit(self):
         self.client.login(username="staff", password="pwd")

--- a/core/views.py
+++ b/core/views.py
@@ -9,6 +9,7 @@ from django.template.loader import render_to_string
 from django.http import HttpResponse, HttpResponseBadRequest
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils.text import slugify
+from django.db.models import F
 
 from .forms import CommentForm, PostForm, CommunityCreateForm
 from .models import Comment, Community, Post
@@ -124,7 +125,7 @@ def post_detail(request, slug, post_id, post_slug):
     """Display a single post and its comments."""
 
     post = get_object_or_404(Post, pk=post_id, community__slug=slug)
-    comments = post.comments.select_related("author").order_by("created_at")
+    comments = post.comments.select_related("author").order_by("path")
     form = CommentForm()
     context = {"post": post, "comments": comments, "form": form}
     return render(request, "core/post_detail.html", context)
@@ -136,15 +137,35 @@ def comment_reply(request, post_id):
     """Reply to a post or comment."""
 
     post = get_object_or_404(Post, pk=post_id)
-    parent_id = request.POST.get("parent_id")
     form = CommentForm(request.POST)
-    if form.is_valid():
-        Comment.objects.create(
-            post=post,
-            author=request.user,
-            body=form.cleaned_data["body"],
-            parent_id=parent_id or None,
+    if not form.is_valid():
+        return HttpResponseBadRequest("Invalid comment")
+
+    parent_id = request.POST.get("parent_id")
+    parent = None
+    if parent_id:
+        parent = get_object_or_404(Comment, pk=parent_id, post=post)
+        child_seq = parent.children.count() + 1
+        path = f"{parent.path}/{child_seq:04d}"
+    else:
+        root_seq = post.comments.filter(parent__isnull=True).count() + 1
+        path = f"{root_seq:04d}"
+
+    comment = Comment.objects.create(
+        post=post,
+        author=request.user,
+        parent=parent,
+        body=form.cleaned_data["body"],
+        path=path,
+    )
+    Post.objects.filter(pk=post.pk).update(comment_count=F("comment_count") + 1)
+
+    if request.headers.get("HX-Request") == "true":
+        html = render_to_string(
+            "core/partials/comment.html", {"comment": comment}, request=request
         )
+        return HttpResponse(html)
+
     return redirect(
         "post_detail",
         slug=post.community.slug,

--- a/templates/core/partials/comment.html
+++ b/templates/core/partials/comment.html
@@ -1,0 +1,15 @@
+<li id="comment-{{ comment.pk }}">
+    <p>{{ comment.body }}</p>
+    <small>
+        by {{ comment.author.username }} ·
+        <button hx-post="{% url 'vote_comment' comment.pk %}?v=1"
+                hx-target="#comment-score-{{ comment.pk }}"
+                hx-swap="outerHTML">▲</button>
+        <span id="comment-score-{{ comment.pk }}">{{ comment.score }}</span>
+        <button hx-post="{% url 'vote_comment' comment.pk %}?v=-1"
+                hx-target="#comment-score-{{ comment.pk }}"
+                hx-swap="outerHTML">▼</button>
+        · {{ comment.created_at|timesince }} ago
+    </small>
+    <ul id="replies-{{ comment.pk }}"></ul>
+</li>

--- a/templates/core/post_detail.html
+++ b/templates/core/post_detail.html
@@ -21,29 +21,17 @@
     · {{ post.created_at|timesince }} ago
 </p>
 <h2>Comments</h2>
-<ul>
+<ul id="comment-list">
     {% for comment in comments %}
-    <li>
-        <p>{{ comment.body }}</p>
-        <small>
-            by {{ comment.author.username }}
-            ·
-            <button hx-post="{% url 'vote_comment' comment.pk %}?v=1"
-                    hx-target="#comment-score-{{ comment.pk }}"
-                    hx-swap="outerHTML">▲</button>
-            <span id="comment-score-{{ comment.pk }}">{{ comment.score }}</span>
-            <button hx-post="{% url 'vote_comment' comment.pk %}?v=-1"
-                    hx-target="#comment-score-{{ comment.pk }}"
-                    hx-swap="outerHTML">▼</button>
-            · {{ comment.created_at|timesince }} ago
-        </small>
-    </li>
+        {% include "core/partials/comment.html" %}
     {% empty %}
     <li>No comments yet.</li>
     {% endfor %}
 </ul>
 <h3>Add comment</h3>
-<form method="post" action="{% url 'comment_reply' post.pk %}">
+<form hx-post="{% url 'comment_reply' post.pk %}"
+      hx-target="#comment-list"
+      hx-swap="beforeend">
     {% csrf_token %}
     {{ form.as_p }}
     <button type="submit">Comment</button>


### PR DESCRIPTION
## Summary
- Add POST `/comment/<post_id>/reply/` endpoint that builds materialized-path identifiers for new comments, increments `Post.comment_count`, and returns an HTMX fragment
- Render individual comments via new `core/partials/comment.html` and wire up the post detail page for HTMX submissions
- Test comment reply paths and ensure community creation form errors work under Django 5

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68a3f39f2dcc832cbc082461cc39e965