### PR TITLE
Add tab bar and post row templates with HTMX voting

### DIFF
--- a/core/templatetags/url_domain.py
+++ b/core/templatetags/url_domain.py
@@ -1,0 +1,12 @@
+from urllib.parse import urlparse
+from django import template
+
+register = template.Library()
+
+
+@register.filter
+def domain(url: str) -> str:
+    """Return the domain/host for a URL."""
+    if not url:
+        return ""
+    return urlparse(url).netloc

--- a/templates/core/community.html
+++ b/templates/core/community.html
@@ -2,14 +2,7 @@
 {% block content %}
 <h1>{{ community.title }}</h1>
 <p>{{ community.description }}</p>
-<div>
-  <a href="{% url 'community' community.slug %}?t=best">Best</a>
-  <a href="{% url 'community' community.slug %}?t=hot">Hot</a>
-  <a href="{% url 'community' community.slug %}?t=new">New</a>
-  <a href="{% url 'community' community.slug %}?t=rising">Rising</a>
-  <a href="{% url 'community' community.slug %}?t=controversial">Controversial</a>
-  <a href="{% url 'community' community.slug %}?t=top">Top</a>
-</div>
+{% include "core/partials/tab_bar.html" %}
 <div id="feed-list">
   {% include "core/partials/post_list.html" with posts=posts %}
 </div>

--- a/templates/core/home.html
+++ b/templates/core/home.html
@@ -1,16 +1,9 @@
 {% extends "base.html" %}
 {% block content %}
   <h1>SureJan</h1>
-  <div>
-    <a href="{% url 'home' %}?t=best">Best</a>
-    <a href="{% url 'home' %}?t=hot">Hot</a>
-    <a href="{% url 'home' %}?t=new">New</a>
-    <a href="{% url 'home' %}?t=rising">Rising</a>
-    <a href="{% url 'home' %}?t=controversial">Controversial</a>
-    <a href="{% url 'home' %}?t=top">Top</a>
-  </div>
+  {% include "core/partials/tab_bar.html" %}
   <div id="feed-list">
-    {% include "core/partials/post_list.html" with posts=posts show_community=True %}
+    {% include "core/partials/post_list.html" with posts=posts %}
   </div>
   {% if next_page %}
     {% include "core/partials/load_more.html" with next_url=request.path|add:'?page='|add:next_page|add:sort_query %}

--- a/templates/core/partials/post_list.html
+++ b/templates/core/partials/post_list.html
@@ -1,21 +1,5 @@
 {% for post in posts %}
-  <div>
-    {% if show_community %}
-      <a href="{% url 'community' post.community.slug %}">/r/{{ post.community.slug }}/</a>
-    {% endif %}
-    <strong><a href="{% url 'post_detail' post.community.slug post.pk post.title|slugify %}">{{ post.title }}</a></strong>
-    · {{ post.author.username }}
-    · {{ post.created_at }}
-    <div>
-      <button hx-post="{% url 'vote_post' post.pk %}?v=1"
-              hx-target="#post-score-{{post.pk}}"
-              hx-swap="outerHTML">▲</button>
-      <span id="post-score-{{post.pk}}">{{ post.score }}</span>
-      <button hx-post="{% url 'vote_post' post.pk %}?v=-1"
-              hx-target="#post-score-{{post.pk}}"
-              hx-swap="outerHTML">▼</button>
-    </div>
-  </div>
+  {% include "core/partials/post_row.html" with post=post %}
 {% empty %}
   <p>No posts yet.</p>
 {% endfor %}

--- a/templates/core/partials/post_row.html
+++ b/templates/core/partials/post_row.html
@@ -1,0 +1,24 @@
+{% load url_domain %}
+<div class="post-row">
+  <div class="vote-col">
+    <button hx-post="{% url 'vote_post' post.pk %}?v=1" hx-target="#post-score-{{ post.pk }}" hx-swap="outerHTML">▲</button>
+    <span id="post-score-{{ post.pk }}">{{ post.score }}</span>
+    <button hx-post="{% url 'vote_post' post.pk %}?v=-1" hx-target="#post-score-{{ post.pk }}" hx-swap="outerHTML">▼</button>
+  </div>
+  <div class="post-body">
+    <h2>
+    {% if post.url %}
+      <a href="{{ post.url }}">{{ post.title }}</a>
+      <span class="domain">({{ post.url|domain }})</span>
+    {% else %}
+      <a href="{% url 'post_detail' post.community.slug post.pk post.title|slugify %}">{{ post.title }}</a>
+    {% endif %}
+    </h2>
+    <p class="meta">
+      <a href="{% url 'community' post.community.slug %}">/r/{{ post.community.slug }}/</a>
+      · {{ post.author.username }}
+      · {{ post.created_at|timesince }} ago
+      · <a href="{% url 'post_detail' post.community.slug post.pk post.title|slugify %}">{{ post.comment_count }} comments</a>
+    </p>
+  </div>
+</div>

--- a/templates/core/partials/tab_bar.html
+++ b/templates/core/partials/tab_bar.html
@@ -1,0 +1,11 @@
+{% comment %}Feed tab bar{% endcomment %}
+{% with current=tab|default:'best' %}
+<nav class="tab-bar">
+  <a href="{{ request.path }}?t=best" class="{% if current == 'best' %}active{% endif %}">Best</a>
+  <a href="{{ request.path }}?t=hot" class="{% if current == 'hot' %}active{% endif %}">Hot</a>
+  <a href="{{ request.path }}?t=new" class="{% if current == 'new' %}active{% endif %}">New</a>
+  <a href="{{ request.path }}?t=rising" class="{% if current == 'rising' %}active{% endif %}">Rising</a>
+  <a href="{{ request.path }}?t=controversial" class="{% if current == 'controversial' %}active{% endif %}">Controversial</a>
+  <a href="{{ request.path }}?t=top" class="{% if current == 'top' %}active{% endif %}">Top</a>
+</nav>
+{% endwith %}


### PR DESCRIPTION
## Summary
- add template filter to extract domain from post URLs
- introduce reusable feed tab bar partial that highlights the active tab
- render posts via a new post row partial with HTMX voting and metadata
- update home and community pages to use the new partials

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68a3f87ad568832c938dadb9b6be4f6b