### PR TITLE
Implement threaded comments with inline HTMX replies

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -76,6 +76,11 @@ class Comment(models.Model):
     class Meta:
         indexes = [models.Index(fields=["post", "path"])]
 
+    @property
+    def depth(self):
+        """Return the nesting depth based on the comment path."""
+        return self.path.count("/")
+
 
 class Vote(models.Model):
     user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)

--- a/core/views.py
+++ b/core/views.py
@@ -132,11 +132,27 @@ def post_detail(request, slug, post_id, post_slug):
 
 
 @login_required
-@require_POST
+@require_http_methods(["GET", "POST"])
 def comment_reply(request, post_id):
-    """Reply to a post or comment."""
+    """Reply to a post or comment or render the reply form."""
 
     post = get_object_or_404(Post, pk=post_id)
+
+    if request.method == "GET":
+        if request.headers.get("HX-Request") != "true":
+            return HttpResponseBadRequest("Invalid request")
+        parent_id = request.GET.get("parent_id")
+        if not parent_id:
+            return HttpResponseBadRequest("Missing parent_id")
+        parent = get_object_or_404(Comment, pk=parent_id, post=post)
+        form = CommentForm()
+        html = render_to_string(
+            "core/partials/reply_form.html",
+            {"form": form, "parent": parent, "post": post},
+            request=request,
+        )
+        return HttpResponse(html)
+
     form = CommentForm(request.POST)
     if not form.is_valid():
         return HttpResponseBadRequest("Invalid comment")

--- a/templates/core/partials/comment.html
+++ b/templates/core/partials/comment.html
@@ -1,4 +1,4 @@
-<li id="comment-{{ comment.pk }}">
+<div id="comment-{{ comment.pk }}" style="margin-left: {% widthratio comment.depth 1 20 %}px">
     <p>{{ comment.body }}</p>
     <small>
         by {{ comment.author.username }} ·
@@ -9,7 +9,9 @@
         <button hx-post="{% url 'vote_comment' comment.pk %}?v=-1"
                 hx-target="#comment-score-{{ comment.pk }}"
                 hx-swap="outerHTML">▼</button>
-        · {{ comment.created_at|timesince }} ago
+        · {{ comment.created_at|timesince }} ago ·
+        <button hx-get="{% url 'comment_reply' comment.post.pk %}?parent_id={{ comment.pk }}"
+                hx-target="#comment-{{ comment.pk }}"
+                hx-swap="afterend">reply</button>
     </small>
-    <ul id="replies-{{ comment.pk }}"></ul>
-</li>
+</div>

--- a/templates/core/partials/reply_form.html
+++ b/templates/core/partials/reply_form.html
@@ -1,0 +1,10 @@
+<div style="margin-left: {% widthratio parent.depth|add:'1' 1 20 %}px" hx-on="htmx:afterRequest:this.remove()">
+    <form hx-post="{% url 'comment_reply' post.pk %}"
+          hx-target="#comment-{{ parent.pk }}"
+          hx-swap="afterend">
+        {% csrf_token %}
+        {{ form.body }}
+        <input type="hidden" name="parent_id" value="{{ parent.pk }}">
+        <button type="submit">Reply</button>
+    </form>
+</div>

--- a/templates/core/post_detail.html
+++ b/templates/core/post_detail.html
@@ -3,7 +3,7 @@
 <link rel="stylesheet" href="/static/css/old.css">
 <h1>{{ post.title }}</h1>
 {% if post.post_type == 'text' and post.body %}
-<p>{{ post.body }}</p>
+<p>{{ post.body|linebreaksbr }}</p>
 {% elif post.post_type == 'link' %}
 <p><a href="{{ post.url }}">{{ post.url }}</a></p>
 {% endif %}
@@ -21,20 +21,19 @@
     · {{ post.created_at|timesince }} ago
 </p>
 <h2>Comments</h2>
-<ul id="comment-list">
-    {% for comment in comments %}
-        {% include "core/partials/comment.html" %}
-    {% empty %}
-    <li>No comments yet.</li>
-    {% endfor %}
-</ul>
-<h3>Add comment</h3>
 <form hx-post="{% url 'comment_reply' post.pk %}"
       hx-target="#comment-list"
       hx-swap="beforeend">
     {% csrf_token %}
     {{ form.as_p }}
     <button type="submit">Comment</button>
-</form>
+    </form>
+<div id="comment-list">
+    {% for c in comments %}
+        {% include "core/partials/comment.html" with comment=c %}
+    {% empty %}
+    <p>No comments yet.</p>
+    {% endfor %}
+</div>
 {% include "core/_htmx_csrf.html" %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- Render text post bodies with line breaks and move comment form to top of post detail page
- Add depth property and HTMX reply workflow for nested comments
- Provide inline reply form partial with comment indentation and voting controls

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68a3fa970d50832c9f99a67dc4a400ed