### PR TITLE
Add user profile pages with tabbed activity views

### DIFF
--- a/core/tests_user_profile.py
+++ b/core/tests_user_profile.py
@@ -1,0 +1,69 @@
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+
+from .models import Comment, Community, Post
+
+
+class UserProfileTests(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.user = User.objects.create_user("alice", password="pwd")
+        self.other = User.objects.create_user("bob", password="pwd")
+        self.community = Community.objects.create(
+            slug="t", name="Test", title="Test", created_by=self.user
+        )
+        # Create 11 posts for user and one for other
+        for i in range(11):
+            Post.objects.create(
+                community=self.community,
+                author=self.user,
+                post_type="text",
+                title=f"post{i}",
+            )
+        self.other_post = Post.objects.create(
+            community=self.community,
+            author=self.other,
+            post_type="text",
+            title="other",
+        )
+        # Create 11 comments for user and one for other
+        for i in range(11):
+            Comment.objects.create(
+                post=self.other_post,
+                author=self.user,
+                body=f"comment{i}",
+            )
+        Comment.objects.create(
+            post=self.other_post,
+            author=self.other,
+            body="othercomment",
+        )
+
+    def test_overview_lists_recent_activity(self):
+        url = reverse("user_overview", args=[self.user.username])
+        resp = self.client.get(url)
+        self.assertContains(resp, f"u/{self.user.username}")
+        # newest post and comment present, oldest omitted
+        self.assertContains(resp, "post10")
+        self.assertContains(resp, "comment10")
+        self.assertNotContains(resp, "post0")
+        self.assertNotContains(resp, "comment0")
+        self.assertContains(resp, 'class="active">Overview</a>')
+
+    def test_comments_page_lists_comments(self):
+        url = reverse("user_comments", args=[self.user.username])
+        resp = self.client.get(url)
+        self.assertContains(resp, "comment10")
+        self.assertNotContains(resp, "post10")
+        self.assertNotContains(resp, "othercomment")
+        self.assertContains(resp, 'class="active">Comments</a>')
+
+    def test_submitted_page_lists_posts(self):
+        url = reverse("user_submitted", args=[self.user.username])
+        resp = self.client.get(url)
+        self.assertContains(resp, "post10")
+        self.assertNotContains(resp, "comment10")
+        self.assertNotContains(resp, "other")
+        self.assertContains(resp, 'class="active">Submitted</a>')
+

--- a/core/views.py
+++ b/core/views.py
@@ -238,22 +238,77 @@ def community_wiki(request, slug):
     return HttpResponse("wiki")
 
 
-def user_overview(request, username):
-    """User overview page stub."""
+def _get_profile_user(username):
+    """Return the user object for the given username or 404."""
 
-    return HttpResponse(f"Profile for {username}")
+    from django.contrib.auth import get_user_model
+
+    return get_object_or_404(get_user_model(), username=username)
+
+
+def user_overview(request, username):
+    """Display recent activity for a user."""
+
+    profile_user = _get_profile_user(username)
+    posts = list(
+        Post.objects.filter(author=profile_user)
+        .select_related("community")
+        .order_by("-created_at")[:10]
+    )
+    comments = list(
+        Comment.objects.filter(author=profile_user)
+        .select_related("post__community")
+        .order_by("-created_at")[:10]
+    )
+
+    activity = [
+        {"type": "post", "obj": p, "created_at": p.created_at} for p in posts
+    ] + [
+        {"type": "comment", "obj": c, "created_at": c.created_at} for c in comments
+    ]
+    activity.sort(key=lambda a: a["created_at"], reverse=True)
+    activity = activity[:20]
+
+    context = {
+        "profile_user": profile_user,
+        "activity": activity,
+        "tab": "overview",
+    }
+    return render(request, "core/user_overview.html", context)
 
 
 def user_comments(request, username):
-    """User comments page stub."""
+    """Display all comments made by a user."""
 
-    return HttpResponse(f"Comments by {username}")
+    profile_user = _get_profile_user(username)
+    comments = (
+        Comment.objects.filter(author=profile_user)
+        .select_related("post__community")
+        .order_by("-created_at")
+    )
+    context = {
+        "profile_user": profile_user,
+        "comments": comments,
+        "tab": "comments",
+    }
+    return render(request, "core/user_comments.html", context)
 
 
 def user_submitted(request, username):
-    """User submitted posts page stub."""
+    """Display all posts submitted by a user."""
 
-    return HttpResponse(f"Submissions by {username}")
+    profile_user = _get_profile_user(username)
+    posts = (
+        Post.objects.filter(author=profile_user)
+        .select_related("community")
+        .order_by("-created_at")
+    )
+    context = {
+        "profile_user": profile_user,
+        "posts": posts,
+        "tab": "submitted",
+    }
+    return render(request, "core/user_submitted.html", context)
 
 
 @login_required

--- a/templates/core/partials/comment_row.html
+++ b/templates/core/partials/comment_row.html
@@ -1,0 +1,10 @@
+{% comment %}Row for displaying a single comment in user profile views{% endcomment %}
+<div class="comment-row">
+  <p>{{ comment.body }}</p>
+  <small>
+    in <a href="{% url 'community' comment.post.community.slug %}">/r/{{ comment.post.community.slug }}/</a>
+    on <a href="{% url 'post_detail' comment.post.community.slug comment.post.pk comment.post.title|slugify %}">{{ comment.post.title }}</a>
+    · {{ comment.created_at|timesince }} ago
+  </small>
+</div>
+

--- a/templates/core/partials/user_tab_bar.html
+++ b/templates/core/partials/user_tab_bar.html
@@ -1,0 +1,9 @@
+{% comment %}Tab bar for user profile pages{% endcomment %}
+{% with current=tab %}
+<nav class="tab-bar">
+  <a href="{% url 'user_overview' profile_user.username %}" class="{% if current == 'overview' %}active{% endif %}">Overview</a>
+  <a href="{% url 'user_comments' profile_user.username %}" class="{% if current == 'comments' %}active{% endif %}">Comments</a>
+  <a href="{% url 'user_submitted' profile_user.username %}" class="{% if current == 'submitted' %}active{% endif %}">Submitted</a>
+</nav>
+{% endwith %}
+

--- a/templates/core/user_comments.html
+++ b/templates/core/user_comments.html
@@ -1,0 +1,11 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>u/{{ profile_user.username }}</h1>
+{% include "core/partials/user_tab_bar.html" %}
+{% for comment in comments %}
+  {% include "core/partials/comment_row.html" %}
+{% empty %}
+  <p>No comments yet.</p>
+{% endfor %}
+{% endblock %}
+

--- a/templates/core/user_overview.html
+++ b/templates/core/user_overview.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>u/{{ profile_user.username }}</h1>
+{% include "core/partials/user_tab_bar.html" %}
+{% for item in activity %}
+  {% if item.type == 'post' %}
+    {% include "core/partials/post_row.html" with post=item.obj %}
+  {% else %}
+    {% include "core/partials/comment_row.html" with comment=item.obj %}
+  {% endif %}
+{% empty %}
+  <p>No activity yet.</p>
+{% endfor %}
+{% endblock %}
+

--- a/templates/core/user_submitted.html
+++ b/templates/core/user_submitted.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>u/{{ profile_user.username }}</h1>
+{% include "core/partials/user_tab_bar.html" %}
+<div id="feed-list">
+  {% include "core/partials/post_list.html" with posts=posts %}
+</div>
+{% endblock %}
+


### PR DESCRIPTION
## Summary
- implement user overview, comments, and submitted views
- add templates and tab bar for user profiles
- test user profile routes

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68a3fc9d3db0832cb29ca18be27a40d2