### PR TITLE
Add per-user rate limiting for content creation

### DIFF
--- a/core/ratelimit.py
+++ b/core/ratelimit.py
@@ -1,0 +1,50 @@
+"""Simple per-user rate limiting decorator using Django cache."""
+
+from functools import wraps
+from django.core.cache import cache
+from django.http import HttpResponse
+from django.template.loader import render_to_string
+
+
+def ratelimit(*, key="user", action: str, limit: int, window: int = 60):
+    """Limit ``action`` executions per ``window`` seconds for the given key.
+
+    Only ``key='user'`` is supported. The caller must ensure the user is
+    authenticated. When the limit is exceeded a ``429`` response is returned.
+    If the request originated from HTMX a small message partial is rendered.
+    """
+
+    if key != "user":
+        raise ValueError("Only user-based rate limiting is supported")
+
+    def decorator(view_func):
+        @wraps(view_func)
+        def _wrapped(request, *args, **kwargs):
+            # Only count POST requests that actually perform the action.
+            if request.method != "POST":
+                return view_func(request, *args, **kwargs)
+
+            if not request.user.is_authenticated:
+                return view_func(request, *args, **kwargs)
+
+            cache_key = f"rl:{action}:{request.user.pk}"
+            count = cache.get(cache_key, 0)
+            if count >= limit:
+                if request.headers.get("HX-Request") == "true":
+                    html = render_to_string(
+                        "core/partials/ratelimit.html", {"action": action}, request=request
+                    )
+                    return HttpResponse(html, status=429)
+                return HttpResponse("Too many requests", status=429)
+
+            if count == 0:
+                cache.add(cache_key, 1, window)
+            else:
+                cache.incr(cache_key)
+
+            return view_func(request, *args, **kwargs)
+
+        return _wrapped
+
+    return decorator
+

--- a/core/tests.py
+++ b/core/tests.py
@@ -1,6 +1,7 @@
 """Tests for post submission and voting endpoints."""
 
 from django.contrib.auth import get_user_model
+from django.core.cache import cache
 from django.test import TestCase
 from django.urls import reverse
 
@@ -11,6 +12,7 @@ class SubmitPostTests(TestCase):
     """Ensure users can submit text and link posts."""
 
     def setUp(self):
+        cache.clear()
         user_model = get_user_model()
         self.user = user_model.objects.create_user("alice", password="pwd")
         self.community = Community.objects.create(
@@ -52,11 +54,34 @@ class SubmitPostTests(TestCase):
         self.assertEqual(post.url, "https://example.com")
         self.assertEqual(post.body, "")
 
+    def test_requires_login(self):
+        self.client.logout()
+        url = reverse("submit_post", args=[self.community.slug])
+        resp = self.client.post(
+            url,
+            {"post_type": "text", "title": "Hello", "body": "", "url": ""},
+        )
+        self.assertEqual(resp.status_code, 302)
+
+    def test_rate_limit(self):
+        url = reverse("submit_post", args=[self.community.slug])
+        for i in range(3):
+            self.client.post(
+                url,
+                {"post_type": "text", "title": f"H{i}", "body": "", "url": ""},
+            )
+        resp = self.client.post(
+            url,
+            {"post_type": "text", "title": "H3", "body": "", "url": ""},
+        )
+        self.assertEqual(resp.status_code, 429)
+
 
 class VotePostTests(TestCase):
     """Ensure voting adjusts post scores per user."""
 
     def setUp(self):
+        cache.clear()
         user_model = get_user_model()
         self.user = user_model.objects.create_user("alice", password="pwd")
         self.community = Community.objects.create(
@@ -118,11 +143,20 @@ class VotePostTests(TestCase):
         resp = self.client.post(url + "?v=1")
         self.assertEqual(resp.status_code, 302)
 
+    def test_rate_limit(self):
+        url = reverse("vote_post", args=[self.post.pk])
+        for _ in range(20):
+            resp = self.client.post(url + "?v=1")
+            self.assertEqual(resp.status_code, 200)
+        resp = self.client.post(url + "?v=1")
+        self.assertEqual(resp.status_code, 429)
+
 
 class VoteCommentTests(TestCase):
     """Ensure voting works for comments."""
 
     def setUp(self):
+        cache.clear()
         user_model = get_user_model()
         self.user = user_model.objects.create_user("alice", password="pwd")
         self.community = Community.objects.create(

--- a/core/tests_comment_reply.py
+++ b/core/tests_comment_reply.py
@@ -1,4 +1,5 @@
 from django.contrib.auth import get_user_model
+from django.core.cache import cache
 from django.test import TestCase
 from django.urls import reverse
 
@@ -7,6 +8,7 @@ from .models import Comment, Community, Post
 
 class CommentReplyTests(TestCase):
     def setUp(self):
+        cache.clear()
         user_model = get_user_model()
         self.user = user_model.objects.create_user("alice", password="pwd")
         self.community = Community.objects.create(
@@ -48,3 +50,9 @@ class CommentReplyTests(TestCase):
         self.client.logout()
         resp = self.client.post(self.url, {"body": "Hi"})
         self.assertEqual(resp.status_code, 302)
+
+    def test_rate_limit(self):
+        for i in range(10):
+            self.client.post(self.url, {"body": f"c{i}"}, HTTP_HX_REQUEST="true")
+        resp = self.client.post(self.url, {"body": "c10"}, HTTP_HX_REQUEST="true")
+        self.assertEqual(resp.status_code, 429)

--- a/core/views.py
+++ b/core/views.py
@@ -3,7 +3,7 @@
 from django.contrib.auth.decorators import login_required
 from django.views.decorators.http import require_POST, require_http_methods
 from django.views.decorators.csrf import csrf_protect
-from django_ratelimit.decorators import ratelimit, is_ratelimited
+from django_ratelimit.decorators import ratelimit as dratelimit, is_ratelimited
 from django.template.loader import render_to_string
 
 from django.http import HttpResponse, HttpResponseBadRequest
@@ -13,6 +13,7 @@ from django.db.models import F
 
 from .forms import CommentForm, PostForm, CommunityCreateForm
 from .models import Comment, Community, Post
+from .ratelimit import ratelimit
 from .votes import apply_vote
 from .pagination import PAGE_SIZE
 
@@ -101,6 +102,7 @@ def community(request, slug):
 
 
 @login_required
+@ratelimit(action="post", limit=3)
 def submit_post(request, slug):
     """Submit a new post to a community."""
 
@@ -133,6 +135,7 @@ def post_detail(request, slug, post_id, post_slug):
 
 @login_required
 @require_http_methods(["GET", "POST"])
+@ratelimit(action="comment", limit=10)
 def comment_reply(request, post_id):
     """Reply to a post or comment or render the reply form."""
 
@@ -193,7 +196,7 @@ def comment_reply(request, post_id):
 @login_required
 @require_POST
 @csrf_protect
-@ratelimit(key="user_or_ip", rate="20/m", block=True)
+@ratelimit(action="vote", limit=20)
 def vote_post(request, pk):
     """Handle voting on a post."""
 
@@ -214,7 +217,7 @@ def vote_post(request, pk):
 @login_required
 @require_POST
 @csrf_protect
-@ratelimit(key="user_or_ip", rate="20/m", block=True)
+@ratelimit(action="vote", limit=20)
 def vote_comment(request, pk):
     """Handle voting on a comment."""
 
@@ -313,7 +316,7 @@ def user_submitted(request, username):
 
 @login_required
 @require_http_methods(["GET", "POST"])
-@ratelimit(key="user", rate="5/m", method=["POST"], block=False)
+@dratelimit(key="user", rate="5/m", method=["POST"], block=False)
 def create_community(request):
     if not request.user.is_staff:
         from django.core.exceptions import PermissionDenied

--- a/templates/core/partials/ratelimit.html
+++ b/templates/core/partials/ratelimit.html
@@ -1,0 +1,1 @@
+<div class="alert">Slow down! You're doing that too much. Try again in a minute.</div>


### PR DESCRIPTION
## Summary
- add cache-based `ratelimit` decorator with HTMX partial response
- throttle post (3/min), comment (10/min), and vote (20/min) creation
- expand tests for authentication and rate limiting across endpoints

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68a3fe392f08832ca8c744973d3c8d21