### PR TITLE
Add Makefile with management targets and support toggling DEBUG

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+.PHONY: bootstrap migrate seed recompute test
+
+bootstrap:
+	pip install -r requirements.txt
+
+migrate:
+	python manage.py makemigrations && python manage.py migrate
+
+seed:
+	python manage.py seed_demo
+
+recompute:
+	python manage.py recompute_ranks
+
+test:
+	pytest -q

--- a/config/settings.py
+++ b/config/settings.py
@@ -3,13 +3,14 @@ Django settings for config project (SureJan MVP).
 """
 
 from pathlib import Path
+import os
 
 # Base directory
 BASE_DIR = Path(__file__).resolve().parent.parent
 
 # SECURITY
 SECRET_KEY = 'django-insecure-d9we^%!#4i-nnbx@3fje$kc$(m^gzdobmbr)d81rh&2@tm-2t('
-DEBUG = True
+DEBUG = os.environ.get('DEBUG', '1') in ('1', 'true', 'True')
 ALLOWED_HOSTS = ["localhost", "127.0.0.1", "testserver"]
 
 # Application definition

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+Django
+django-htmx
+django-ratelimit
+csp
+pytest
+pytest-django


### PR DESCRIPTION
## Summary
- add Makefile to streamline common management commands and tests
- allow setting DEBUG via environment variable for easier configuration
- document dependencies in requirements.txt

## Testing
- `pip install -r requirements.txt`
- `python manage.py collectstatic --noinput`
- `DEBUG=0 python manage.py collectstatic --noinput`
- `pytest -q` *(no tests discovered)*
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68a405c5b318832cb7762b89f4b2cd63