### PR TITLE
Add base template with old Reddit header and favicons

### DIFF
--- a/static/css/base.css
+++ b/static/css/base.css
@@ -1,0 +1,72 @@
+body {
+  margin: 0;
+  font-family: Arial, sans-serif;
+}
+
+.site-header .header-top {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 4px 8px;
+  background: #fbfbfb;
+  border-bottom: 1px solid #ccc;
+}
+
+.subreddit-bar {
+  display: flex;
+  gap: 8px;
+  overflow-x: auto;
+}
+
+.subreddit-bar a {
+  white-space: nowrap;
+  color: #000;
+  text-decoration: none;
+  padding: 2px 4px;
+}
+
+.user-info {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.9rem;
+}
+
+.user-info .avatar {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: #ccc;
+  display: inline-block;
+}
+
+.tab-bar {
+  display: flex;
+  gap: 8px;
+  padding: 4px 8px;
+  background: #f6f6f6;
+  border-bottom: 1px solid #ccc;
+}
+
+.tab-bar a {
+  color: #336699;
+  text-decoration: none;
+  font-size: 0.9rem;
+}
+
+.container {
+  max-width: 960px;
+  margin: 0 auto;
+  display: flex;
+  gap: 16px;
+  padding: 16px;
+}
+
+.feed {
+  flex: 1;
+  max-width: 640px;
+}
+
+.sidebar {
+  width: 300px;
+}

--- a/static/favicon-16.png
+++ b/static/favicon-16.png
@@ -1,0 +1,1 @@
+placeholder icon

--- a/static/favicon-32.png
+++ b/static/favicon-32.png
@@ -1,0 +1,1 @@
+placeholder icon

--- a/static/favicon.ico
+++ b/static/favicon.ico
@@ -1,0 +1,1 @@
+placeholder icon

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,18 +1,51 @@
+{% load static points %}
 <!doctype html>
 <html lang="en">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>SureJan</title>
-  <script src="https://unpkg.com/htmx.org@1.9.12" defer></script>
+  <link rel="icon" href="{% static 'favicon.ico' %}">
+  <link rel="icon" type="image/png" sizes="16x16" href="{% static 'favicon-16.png' %}">
+  <link rel="icon" type="image/png" sizes="32x32" href="{% static 'favicon-32.png' %}">
+  <link rel="stylesheet" href="{% static 'css/base.css' %}">
+  {% block head_extra %}{% endblock %}
 </head>
 <body>
-  <header>
-    <a href="/">SureJan</a>
-    <input type="text" placeholder="Search" />
-    {% include "partials/user_box.html" %}
+  <header class="site-header">
+    <div class="header-top">
+      <nav class="subreddit-bar">
+        <a href="/r/news/">News</a>
+        <a href="/r/brisbane/">Brisbane</a>
+        <a href="#">More ▾</a>
+      </nav>
+      <div class="user-info">
+        {% if request.user.is_authenticated %}
+          <span class="username">{{ request.user.username }}</span>
+          <span class="points">{{ request.user|get_points }} points</span>
+        {% else %}
+          <a href="{% url 'admin:login' %}">login</a>
+        {% endif %}
+        <span class="avatar"></span>
+      </div>
+    </div>
+    <nav class="tab-bar">
+      <a href="#">Best</a>
+      <a href="#">Hot</a>
+      <a href="#">New</a>
+      <a href="#">Rising</a>
+      <a href="#">Controversial</a>
+      <a href="#">Top</a>
+      <a href="#">Wiki</a>
+    </nav>
   </header>
-  {% include "partials/subreddit_bar.html" %}
-  {% block content %}{% endblock %}
+  <main class="container">
+    <div class="feed">
+      {% block content %}{% endblock %}
+    </div>
+    <aside class="sidebar">
+      {% block sidebar %}{% endblock %}
+    </aside>
+  </main>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Build new base.html layout with old Reddit-style header, user info, and content/sidebar blocks
- Add favicon links and CSS for site chrome and two-column layout
- Replace binary favicon files with text placeholders to allow PR

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a503a3e3d4832cadda8b06167762b6