### PR TITLE
Add feed template for post listings

### DIFF
--- a/templates/core/feed.html
+++ b/templates/core/feed.html
@@ -1,0 +1,27 @@
+{% extends "base.html" %}
+
+{% block content %}
+  {% for _ in "12345"|make_list %}
+  <article class="thing">
+    <div class="vote">
+      <button class="up" aria-label="upvote">▲</button>
+      <div class="score">123</div>
+      <button class="down" aria-label="downvote">▼</button>
+    </div>
+    <div class="entry">
+      <h3 class="title"><a href="#">Example post title</a> <span class="domain">(example.com)</span></h3>
+      <div class="byline">submitted 5 hours ago by <a href="#">username</a> to <a href="#">r/brisbane</a></div>
+      <ul class="flat-list actions">
+        <li><a href="#">123 comments</a></li>
+        <li><a href="#">share</a></li>
+        <li><a href="#">save</a></li>
+        <li><a href="#">hide</a></li>
+        <li><a href="#">report</a></li>
+      </ul>
+    </div>
+  </article>
+  {% endfor %}
+  <div class="paginator">
+    <a href="#">prev</a> | <a href="#">next</a>
+  </div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add feed template to render a list of posts with vote controls and actions
- include pagination links for navigating between pages

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68a5080e7c90832c83eb13e612f76343