### PR TITLE
style: refine vote arrows

### DIFF
--- a/static/css/base.css
+++ b/static/css/base.css
@@ -144,6 +144,45 @@ a:hover {
   font-weight: bold;
 }
 
+.vote {
+  width: 40px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+}
+
+.vote button {
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: none;
+  background: none;
+  color: #888;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.vote .score {
+  font-weight: bold;
+  font-size: 11px;
+  text-align: center;
+}
+
+.vote .up:hover,
+.vote .up:active,
+.vote .up[aria-pressed="true"] {
+  color: #ff4500;
+}
+
+.vote .down:hover,
+.vote .down:active,
+.vote .down[aria-pressed="true"] {
+  color: #7193ff;
+}
+
 .post-body {
   flex: 1;
 }


### PR DESCRIPTION
## Summary
- style stacked vote arrows and score like classic Reddit
- add hover and aria-pressed states for up/down votes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a51dc98d78832c8a20bf17266aa489