### PR TITLE
Add SureJan logo brand to header

### DIFF
--- a/static/css/base.css
+++ b/static/css/base.css
@@ -44,22 +44,45 @@ a:hover {
 .site-header {
   background: var(--panel);
   border-bottom: 1px solid var(--border);
-  box-shadow: 0 2px 3px rgba(0, 0, 0, 0.08);
+  position: sticky;
+  top: 0;
+  z-index: 1000;
 }
 
-.header-main {
+.header-inner {
   max-width: 960px;
   margin: 0 auto;
-  padding: 8px;
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  gap: 16px;
+  padding: 8px 12px;
 }
 
-.logo img {
-  display: block;
-  height: 40px;
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  text-decoration: none;
+}
+
+.brand-logo {
+  height: 32px;
   width: auto;
+  display: block;
+}
+
+.brand-text {
+  font: 700 16px/1 Verdana, Arial, sans-serif;
+  color: var(--text);
+  letter-spacing: 0.2px;
+}
+
+.header-nav {
+  margin-left: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  align-items: flex-end;
 }
 
 .user-info {
@@ -75,15 +98,10 @@ a:hover {
 }
 
 .tab-bar {
-  max-width: 960px;
-  margin: 0 auto;
   display: flex;
   gap: 4px;
   padding: 4px 6px;
   background: var(--panel);
-  position: sticky;
-  top: 32px;
-  z-index: 900;
 }
 
 .tab-bar a {
@@ -122,9 +140,6 @@ a:hover {
   background: #f2f2f2;
   border-bottom: 1px solid var(--border);
   overflow-x: auto;
-  position: sticky;
-  top: 0;
-  z-index: 901;
   white-space: nowrap;
 }
 
@@ -350,6 +365,9 @@ hr {
 
 /* Responsive --------------------------------------------------------- */
 @media (max-width: 768px) {
+  .brand-logo { height: 24px; }
+  .brand-text { display: none; }
+  .header-inner { padding: 6px 10px; }
   .layout {
     flex-direction: column;
   }

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,4 +1,5 @@
-{% load static points %}
+{% load static %}
+{% load points %}
 <!doctype html>
 <html lang="en">
 <head>
@@ -13,33 +14,43 @@
 </head>
 <body>
   <header class="site-header">
-    <div class="header-main">
-      <a href="/" class="logo">
-        <img src="{% static 'img/SureJanLogo.png' %}" alt="SureJan logo">
+    <div class="container header-inner">
+      <a href="/" class="brand" aria-label="SureJan home">
+        <img
+          src="{% static 'img/SureJanLogo.png' %}"
+          alt="SureJan"
+          class="brand-logo"
+          width="200"
+          height="100"
+          decoding="async"
+        />
+        <span class="brand-text">SureJan</span>
       </a>
-      <div class="user-info">
-        {% if request.user.is_authenticated %}
-          <span class="username">{{ request.user.username }}</span>
-          <span class="points">Points: {{ request.user|get_points }}</span>
-        {% else %}
-          <a href="{% url 'admin:login' %}">login</a>
-        {% endif %}
-      </div>
+      <nav class="header-nav">
+        <div class="user-info">
+          {% if request.user.is_authenticated %}
+            <span class="username">{{ request.user.username }}</span>
+            <span class="points">Points: {{ request.user|get_points }}</span>
+          {% else %}
+            <a href="{% url 'admin:login' %}">login</a>
+          {% endif %}
+        </div>
+        <nav class="tab-bar">
+          <a href="#" class="active" aria-current="page">Best</a>
+          <a href="#">Hot</a>
+          <a href="#">New</a>
+          <a href="#">Rising</a>
+          <a href="#">Controversial</a>
+          <a href="#">Top</a>
+          <a href="#">Wiki</a>
+        </nav>
+        <nav class="subreddit-bar">
+          <a href="/r/news/">News</a>
+          <a href="/r/brisbane/">Brisbane</a>
+          <a href="#">More ▾</a>
+        </nav>
+      </nav>
     </div>
-    <nav class="tab-bar">
-      <a href="#" class="active" aria-current="page">Best</a>
-      <a href="#">Hot</a>
-      <a href="#">New</a>
-      <a href="#">Rising</a>
-      <a href="#">Controversial</a>
-      <a href="#">Top</a>
-      <a href="#">Wiki</a>
-    </nav>
-    <nav class="subreddit-bar">
-      <a href="/r/news/">News</a>
-      <a href="/r/brisbane/">Brisbane</a>
-      <a href="#">More ▾</a>
-    </nav>
   </header>
   <main class="container layout">
     <div class="feed main">


### PR DESCRIPTION
## Summary
- Add SureJan logo and brand text link at top-left of every page
- Style header for compact sticky layout with responsive logo text

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a523a992d4832c8c5957136126ea7d