### PR TITLE
Configure WhiteNoise static file handling

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -13,7 +13,7 @@ SECRET_KEY = os.environ.get("SECRET_KEY", "dev-secret-key")  # override in Rende
 DEBUG = os.environ.get("DEBUG", "0") in ("1", "true", "True")
 
 # Hosts / CSRF for Render
-ALLOWED_HOSTS = ["localhost", "127.0.0.1", "testserver"]
+ALLOWED_HOSTS = ["surejan.onrender.com", "localhost", "127.0.0.1"]
 RENDER_EXTERNAL_HOSTNAME = os.environ.get("RENDER_EXTERNAL_HOSTNAME")
 if RENDER_EXTERNAL_HOSTNAME:
     ALLOWED_HOSTS.append(RENDER_EXTERNAL_HOSTNAME)
@@ -45,6 +45,7 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
+    "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
@@ -114,6 +115,12 @@ USE_TZ = True
 STATIC_URL = "/static/"
 STATICFILES_DIRS = [BASE_DIR / "static"]
 STATIC_ROOT = BASE_DIR / "staticfiles"
+STORAGES = {
+    "default": {"BACKEND": "django.core.files.storage.FileSystemStorage"},
+    "staticfiles": {
+        "BACKEND": "whitenoise.storage.CompressedManifestStaticFilesStorage"
+    },
+}
 MEDIA_URL = "/media/"
 MEDIA_ROOT = BASE_DIR / "media"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ django-ratelimit>=4,<5
 django-csp>=4,<5
 psycopg[binary,pool]>=3.2,<4
 gunicorn>=22,<23
+whitenoise>=6,<7


### PR DESCRIPTION
## Summary
- integrate WhiteNoise middleware and storage configuration
- add Render domain to `ALLOWED_HOSTS`
- include `whitenoise` package in requirements

## Testing
- `python manage.py check`
- `python manage.py collectstatic --noinput`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68a527b5f228832c95dc79446091000e