### PR TITLE
fix(ui): render sort tabs horizontally with flexbox

### DIFF
--- a/static/css/old.css
+++ b/static/css/old.css
@@ -27,6 +27,26 @@ a:hover{text-decoration:underline}
 .meta{color:#6a6a6a;font-size:12px;margin-top:3px}
 .thumb{width:70px;height:auto;vertical-align:middle;margin-right:6px}
 .comment{border-left:2px solid #eee;margin:8px 0 8px 10px;padding-left:8px}
-.sort-tabs ul { list-style:none; padding:0; margin:0; display:flex; gap:16px; }
-.sort-tabs a { text-decoration:none; color:#1a1a1a; }
-.sort-tabs a.active { font-weight:700; border-bottom:3px solid #2b6cb0; padding-bottom:3px; }
+.sort-tabs ul {
+  display: flex;               /* lay out horizontally */
+  flex-wrap: nowrap;           /* keep them in one row */
+  gap: 16px;                   /* space between tabs */
+  list-style: none;            /* remove bullets */
+  padding: 0;
+  margin: 0;
+}
+
+.sort-tabs li {
+  display: inline;             /* ensure list items are inline */
+}
+
+.sort-tabs a {
+  text-decoration: none;
+  color: #1a1a1a;
+}
+
+.sort-tabs a.active {
+  font-weight: bold;
+  border-bottom: 2px solid #2b6cb0;
+  padding-bottom: 3px;
+}


### PR DESCRIPTION
## Summary
- style sort tabs with flexbox for horizontal layout
- highlight active tab with underline and bold text

## Testing
- `pytest -q` (no tests discovered)
- `python manage.py collectstatic --noinput`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68a5384b9f98832c84f1de2791cd97ce