### PR TITLE
fix(ui): display sort tabs horizontally with flexbox

### DIFF
--- a/static/css/base.css
+++ b/static/css/base.css
@@ -164,6 +164,31 @@ a:hover {
   color: var(--link);
 }
 
+/* Sort tabs ---------------------------------------------------------- */
+.sort-tabs ul {
+  display: flex;
+  flex-wrap: nowrap;
+  gap: 16px;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.sort-tabs li {
+  display: inline;
+}
+
+.sort-tabs a {
+  text-decoration: none;
+  color: #1a1a1a;
+}
+
+.sort-tabs a.active {
+  font-weight: bold;
+  border-bottom: 2px solid #2b6cb0;
+  padding-bottom: 3px;
+}
+
 /* Layout ------------------------------------------------------------- */
 .layout {
   max-width: 960px;


### PR DESCRIPTION
## Summary
- add flexbox styles so sort tab list displays in a single row

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a54083b270832c88c311e147e7e7da