### PR TITLE
Add Dockerfile and dockerignore for remote build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.venv
+__pycache__/
+*.pyc
+.git
+media

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.11-slim
+ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1 PORT=8000
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --upgrade pip && pip install -r requirements.txt
+COPY . .
+CMD ["gunicorn","config.wsgi:application","--bind","0.0.0.0:8000","--workers","2","--threads","2"]


### PR DESCRIPTION
## Summary
- containerize app with Python 3.11 gunicorn runtime
- add .dockerignore to prevent development artifacts in build

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a55da3b464832caf2192f93c49f4a5