### PR TITLE
Add health check endpoint

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -6,6 +6,7 @@ from django.contrib import admin
 from django.urls import path
 
 from core import views as core_views
+from core.views import healthz
 
 
 urlpatterns = [
@@ -27,6 +28,8 @@ urlpatterns = [
     path("u/<str:username>/submitted/", core_views.user_submitted, name="user_submitted"),
     path("admin/", admin.site.urls),
 ]
+
+urlpatterns += [path("healthz", healthz, name="healthz")]
 
 if settings.DEBUG:
     urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/core/tests_healthz.py
+++ b/core/tests_healthz.py
@@ -1,0 +1,9 @@
+from django.test import TestCase
+from django.urls import reverse
+
+
+class HealthzTests(TestCase):
+    def test_healthz_endpoint(self):
+        resp = self.client.get(reverse("healthz"))
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.content, b"ok")

--- a/core/views.py
+++ b/core/views.py
@@ -18,6 +18,11 @@ from .votes import apply_vote
 from .pagination import PAGE_SIZE
 
 
+def healthz(_request):
+    """Simple health check endpoint."""
+    return HttpResponse("ok", content_type="text/plain")
+
+
 # Mapping of feed tabs to their ordering in the database.  Each ordering
 # includes ``-id`` as the final column to guarantee deterministic results.
 FEED_ORDER = {


### PR DESCRIPTION
## Summary
- add simple `/healthz` endpoint for health checks
- cover `/healthz` with test ensuring 200 OK response

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68a55f739f8c832c841a6d0802ba9835