### PR TITLE
Add Fly.io configuration file

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,31 @@
+app = "surejan"
+primary_region = "syd"
+
+[env]
+  PORT = "8000"
+
+[deploy]
+  release_command = "bash -lc 'python manage.py migrate --noinput && python manage.py collectstatic --noinput'"
+
+[http_service]
+  internal_port = 8000
+  force_https = true
+  auto_start_machines = true
+  auto_stop_machines = false
+  min_machines_running = 1
+  processes = ["app"]
+
+  [[http_service.checks]]
+    interval = "30s"
+    timeout = "5s"
+    grace_period = "10s"
+    method = "GET"
+    path = "/healthz"
+
+[[statics]]
+  guest_path = "/app/staticfiles"
+  url_prefix = "/static/"
+
+[[vm]]
+  size = "shared-cpu-1x"
+  memory = "1gb"


### PR DESCRIPTION
## Summary
- add `fly.toml` to configure deployment on Fly.io

## Testing
- `pytest`
- `python manage.py test` *(fails: Missing staticfiles manifest entry for 'favicon.ico')*


------
https://chatgpt.com/codex/tasks/task_e_68a560b01cc4832c916ca5469c3e9f10