### PR TITLE
Force Fly to use Dockerfile builds and configure hosts

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,3 +12,5 @@ staticfiles/
 dist/
 build/
 .DS_Store
+.tool-versions
+.mise.toml

--- a/config/settings.py
+++ b/config/settings.py
@@ -14,13 +14,8 @@ SECRET_KEY = os.environ.get("SECRET_KEY", "dev-secret-key")  # override in Rende
 DEBUG = os.environ.get("DEBUG", "0") in ("1", "true", "True")
 
 # Hosts / CSRF for Fly
-APP_NAME = os.getenv("FLY_APP_NAME", "")
 ALLOWED_HOSTS = ["localhost", "127.0.0.1", ".fly.dev"]
-if APP_NAME:
-    ALLOWED_HOSTS.append(f"{APP_NAME}.fly.dev")
-# allow extra hosts from env
-ALLOWED_HOSTS += [h for h in os.getenv("ALLOWED_HOSTS", "").split(",") if h]
-CSRF_TRUSTED_ORIGINS = ["https://*.fly.dev"] + [o for o in os.getenv("CSRF_TRUSTED_ORIGINS", "").split(",") if o]
+CSRF_TRUSTED_ORIGINS = ["https://*.fly.dev"]
 
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 

--- a/fly.toml
+++ b/fly.toml
@@ -26,3 +26,6 @@ primary_region = "syd"
   cpu_kind = "shared"
   cpus = 1
   memory_mb = 256
+
+[build]
+  dockerfile = "Dockerfile"


### PR DESCRIPTION
## Summary
- Add mise/asdf files to .dockerignore
- Configure Fly to build from Dockerfile
- Set Django host and CSRF settings for Fly

## Testing
- `fly apps create surejan || true` *(fails: command not found)*
- `fly deploy --remote-only --dockerfile Dockerfile` *(fails: command not found)*
- `fly status` *(fails: command not found)*
- `fly logs --since 15m` *(fails: command not found)*
- `curl -I https://surejan.fly.dev/` *(fails: 403)*
- `python manage.py test` *(fails: Missing staticfiles manifest entry for 'favicon.ico')*


------
https://chatgpt.com/codex/tasks/task_e_68a66570dce8832c8e6d616c9f485372