### PR TITLE
fix(templates): reference png favicon at static/site/

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html lang="en">
 <head>
+  {% load static %}
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>SureJan</title>
@@ -8,8 +9,6 @@
   <!-- HTMX -->
   <script src="https://unpkg.com/htmx.org@1.9.12" defer></script>
 
-  {% load static %}
-  <!-- ✅ PNG-only favicon reference -->
   <link rel="icon" type="image/png" href="{% static 'site/favicon-16x16.png' %}">
   <link rel="apple-touch-icon" href="{% static 'site/favicon-16x16.png' %}">
 </head>


### PR DESCRIPTION
## Summary
- ensure base template loads static at head start and uses PNG favicon from `static/site`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a79e17e1b0832cbc4e9b2434947f74