### PR TITLE
build: add BUILD_REV to bust collectstatic cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
 # ---------- Base ----------
 FROM python:3.12-slim
 
+# Build arg to bust cache for collectstatic
+ARG BUILD_REV=dev
+ENV BUILD_REV=${BUILD_REV}
+
 # Prevent .pyc files and enable unbuffered logs
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \


### PR DESCRIPTION
## Summary
- allow passing BUILD_REV arg to rebuild static assets during Docker build

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7a16d5484832c94a722fec86e5f68