### PR TITLE
deploy: run collectstatic before migrate on release

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -13,7 +13,7 @@ primary_region = "syd"
 
 # Run DB migrations in the same environment the app uses
 [deploy]
-  release_command = "python manage.py migrate --noinput"
+  release_command = "bash -lc 'python manage.py collectstatic --noinput && python manage.py migrate --noinput'"
 
 [http_service]
   internal_port = 8000


### PR DESCRIPTION
## Summary
- ensure fly deploy release command runs `collectstatic` before `migrate`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a7a47a78e0832c8bcdce77cc5bf14f