### PR TITLE
Enlarge site header logo

### DIFF
--- a/static/css/base.css
+++ b/static/css/base.css
@@ -74,7 +74,7 @@ a:hover {
 }
 
 .site-logo {
-  height: 96px;
+  height: 108px;
   width: auto;
   display: block;
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -14,8 +14,8 @@
   </head>
   <body>
     <header class="site-header" style="display:flex; justify-content:space-between; align-items:center; padding:8px 12px; border-bottom:1px solid #ccc;">
-      <a href="/" class="site-logo">
-        <img src="{% static 'SureJanLogo.png' %}" alt="SureJan Logo" style="height:60px; width:auto;">
+      <a href="/">
+        <img src="{% static 'SureJanLogo.png' %}" alt="SureJan Logo" class="site-logo">
       </a>
       <nav class="subreddit-links" style="display:flex; gap:12px;">
         <a href="/r/news/">NEWS</a>


### PR DESCRIPTION
## Summary
- Increase `.site-logo` height to 108px to scale logo 1.8×
- Apply `.site-logo` class directly to header logo image

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a917229638832ca755f643efc9d718