### PR TITLE
Enable public signup and secure write actions

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -115,6 +115,12 @@ STORAGES = {
     }
 }
 
+if DEBUG:
+    STORAGES["staticfiles"]["BACKEND"] = "django.contrib.staticfiles.storage.StaticFilesStorage"
+
+if DEBUG:
+    STORAGES["staticfiles"]["BACKEND"] = "django.contrib.staticfiles.storage.StaticFilesStorage"
+
 # Media (unchanged)
 MEDIA_URL = "/media/"
 MEDIA_ROOT = BASE_DIR / "media"
@@ -182,3 +188,10 @@ LOGGING = {
 # -----------------------------------------------------------------------------
 LOGIN_REDIRECT_URL = "/"
 LOGOUT_REDIRECT_URL = "/"
+
+if not DEBUG:
+    SESSION_COOKIE_SECURE = True
+    CSRF_COOKIE_SECURE = True
+    SECURE_BROWSER_XSS_FILTER = True
+    SECURE_CONTENT_TYPE_NOSNIFF = True
+    ALLOWED_HOSTS = ["surejan.fly.dev", "www.surejan.com"]

--- a/config/urls.py
+++ b/config/urls.py
@@ -5,9 +5,13 @@ from django.contrib import admin
 from django.http import HttpResponse
 from django.urls import path, include
 
+from core import views as core
+
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("healthz", lambda request: HttpResponse("ok"), name="healthz"),
+    path("accounts/", include("django.contrib.auth.urls")),
+    path("accounts/signup/", core.signup, name="signup"),
     path("", include("core.urls")),
 ]
 

--- a/core/management/commands/seed_basics.py
+++ b/core/management/commands/seed_basics.py
@@ -1,0 +1,32 @@
+from django.contrib.auth import get_user_model
+from django.core.management.base import BaseCommand
+
+from core.models import Community
+
+COMMUNITIES = [
+    ("news", "News"),
+    ("brisbane", "Brisbane"),
+]
+
+
+class Command(BaseCommand):
+    help = "Seed basic communities"
+
+    def handle(self, *args, **options):
+        User = get_user_model()
+        user = User.objects.first()
+        if not user:
+            user = User.objects.create_user("admin")
+        for slug, name in COMMUNITIES:
+            community, created = Community.objects.get_or_create(
+                slug=slug,
+                defaults={
+                    "name": name,
+                    "title": name,
+                    "created_by": user,
+                },
+            )
+            if created:
+                self.stdout.write(f"CREATED {slug}")
+            else:
+                self.stdout.write(f"EXISTS {slug}")

--- a/core/tests.py
+++ b/core/tests.py
@@ -65,14 +65,14 @@ class SubmitPostTests(TestCase):
 
     def test_rate_limit(self):
         url = reverse("submit_post", args=[self.community.slug])
-        for i in range(3):
+        for i in range(30):
             self.client.post(
                 url,
                 {"post_type": "text", "title": f"H{i}", "body": "", "url": ""},
             )
         resp = self.client.post(
             url,
-            {"post_type": "text", "title": "H3", "body": "", "url": ""},
+            {"post_type": "text", "title": "H30", "body": "", "url": ""},
         )
         self.assertEqual(resp.status_code, 429)
 
@@ -145,7 +145,7 @@ class VotePostTests(TestCase):
 
     def test_rate_limit(self):
         url = reverse("vote_post", args=[self.post.pk])
-        for _ in range(20):
+        for _ in range(120):
             resp = self.client.post(url + "?v=1")
             self.assertEqual(resp.status_code, 200)
         resp = self.client.post(url + "?v=1")

--- a/core/tests_auth_flow.py
+++ b/core/tests_auth_flow.py
@@ -1,0 +1,56 @@
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+
+from .models import Community, Post
+
+
+class AuthFlowTests(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.creator = User.objects.create_user("creator", password="pwd")
+        self.community = Community.objects.create(
+            slug="news", name="News", title="News", created_by=self.creator
+        )
+
+    def test_signup_login_flow(self):
+        resp = self.client.post(
+            reverse("signup"),
+            {"username": "alice", "password": "secret"},
+            follow=True,
+        )
+        self.assertContains(resp, "alice")
+
+    def test_submit_text_post_requires_login(self):
+        resp = self.client.post(
+            reverse("submit_post", args=[self.community.slug]),
+            {"post_type": "text", "title": "Hi"},
+        )
+        self.assertEqual(resp.status_code, 302)
+        self.assertIn(reverse("login"), resp["Location"])
+
+    def test_submit_text_post_success(self):
+        self.client.post(
+            reverse("signup"),
+            {"username": "bob", "password": "secret"},
+        )
+        resp = self.client.post(
+            reverse("submit_post", args=[self.community.slug]),
+            {"post_type": "text", "title": "Hello", "body": "World"},
+        )
+        self.assertRedirects(resp, reverse("community", args=[self.community.slug]))
+        self.assertTrue(
+            Post.objects.filter(
+                community=self.community, title="Hello", author__username="bob"
+            ).exists()
+        )
+
+    def test_vote_requires_login(self):
+        User = get_user_model()
+        author = User.objects.create_user("author", password="pwd")
+        post = Post.objects.create(
+            community=self.community, author=author, post_type="text", title="a"
+        )
+        resp = self.client.post(reverse("vote_post", args=[post.pk]) + "?v=1")
+        self.assertEqual(resp.status_code, 302)
+        self.assertIn(reverse("login"), resp["Location"])

--- a/core/tests_comment_reply.py
+++ b/core/tests_comment_reply.py
@@ -52,7 +52,7 @@ class CommentReplyTests(TestCase):
         self.assertEqual(resp.status_code, 302)
 
     def test_rate_limit(self):
-        for i in range(10):
+        for i in range(30):
             self.client.post(self.url, {"body": f"c{i}"}, HTTP_HX_REQUEST="true")
-        resp = self.client.post(self.url, {"body": "c10"}, HTTP_HX_REQUEST="true")
+        resp = self.client.post(self.url, {"body": "c30"}, HTTP_HX_REQUEST="true")
         self.assertEqual(resp.status_code, 429)

--- a/core/urls.py
+++ b/core/urls.py
@@ -23,6 +23,7 @@ urlpatterns = [
 
     # Comments & voting
     path("comment/<int:post_id>/reply/", core_views.comment_reply, name="comment_reply"),
+    path("comment/<int:post_id>/reply-form/", core_views.comment_reply_form, name="comment_reply_form"),
     path("vote/post/<int:pk>/", core_views.vote_post, name="vote_post"),
     path("vote/comment/<int:pk>/", core_views.vote_comment, name="vote_comment"),
 

--- a/core/views.py
+++ b/core/views.py
@@ -1,6 +1,9 @@
 """Core application views."""
 
+from django.contrib import messages
+from django.contrib.auth import login
 from django.contrib.auth.decorators import login_required
+from django.contrib.auth import get_user_model
 from django.views.decorators.http import require_POST, require_http_methods
 from django.views.decorators.csrf import csrf_protect
 from django_ratelimit.decorators import ratelimit as dratelimit, is_ratelimited
@@ -10,10 +13,10 @@ from django.http import HttpResponse, HttpResponseBadRequest
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils.text import slugify
 from django.db.models import F
+from django import forms
 
 from .forms import CommentForm, PostForm, CommunityCreateForm
 from .models import Comment, Community, Post
-from .ratelimit import ratelimit
 from .votes import apply_vote
 from .pagination import PAGE_SIZE
 
@@ -21,6 +24,32 @@ from .pagination import PAGE_SIZE
 def healthz(_request):
     """Simple health check endpoint."""
     return HttpResponse("ok", content_type="text/plain")
+
+
+class SignupForm(forms.ModelForm):
+    """Minimal signup form with username and password."""
+
+    password = forms.CharField(widget=forms.PasswordInput)
+
+    class Meta:
+        model = get_user_model()
+        fields = ["username", "password"]
+
+
+def signup(request):
+    """Create a new user account and log them in."""
+
+    if request.method == "POST":
+        form = SignupForm(request.POST)
+        if form.is_valid():
+            user = form.save(commit=False)
+            user.set_password(form.cleaned_data["password"])
+            user.save()
+            login(request, user)
+            return redirect("home")
+    else:
+        form = SignupForm()
+    return render(request, "registration/signup.html", {"form": form})
 
 
 # Mapping of feed tabs to their ordering in the database.  Each ordering
@@ -122,19 +151,25 @@ def community(request, slug):
 
 
 @login_required
-@ratelimit(action="post", limit=3)
+@require_http_methods(["GET", "POST"])
+@dratelimit(key="user", rate="30/m", method=["POST"], block=False)
 def submit_post(request, slug):
     """Submit a new post to a community."""
 
     community = get_object_or_404(Community, slug=slug)
 
     if request.method == "POST":
+        if getattr(request, "limited", False):
+            resp = HttpResponse("Too many requests", status=429)
+            resp.headers["X-RateLimit-Triggered"] = "1"
+            return resp
         form = PostForm(request.POST, request.FILES)
         if form.is_valid():
             post = form.save(commit=False)
             post.community = community
             post.author = request.user
             post.save()
+            messages.success(request, "Post submitted")
             return redirect("community", slug=community.slug)
     else:
         form = PostForm()
@@ -154,27 +189,23 @@ def post_detail(request, slug, post_id, post_slug):
 
 
 @login_required
-@require_http_methods(["GET", "POST"])
-@ratelimit(action="comment", limit=10)
+@require_POST
+@dratelimit(key="user", rate="30/m", method=["POST"], block=False)
 def comment_reply(request, post_id):
-    """Reply to a post or comment or render the reply form."""
+    """Create a new comment on a post or comment."""
+
+    if getattr(request, "limited", False):
+        if request.headers.get("HX-Request") == "true":
+            html = render_to_string(
+                "core/partials/ratelimit.html", {"action": "comment"}, request=request
+            )
+            resp = HttpResponse(html, status=429)
+        else:
+            resp = HttpResponse("Too many requests", status=429)
+        resp.headers["X-RateLimit-Triggered"] = "1"
+        return resp
 
     post = get_object_or_404(Post, pk=post_id)
-
-    if request.method == "GET":
-        if request.headers.get("HX-Request") != "true":
-            return HttpResponseBadRequest("Invalid request")
-        parent_id = request.GET.get("parent_id")
-        if not parent_id:
-            return HttpResponseBadRequest("Missing parent_id")
-        parent = get_object_or_404(Comment, pk=parent_id, post=post)
-        form = CommentForm()
-        html = render_to_string(
-            "core/partials/reply_form.html",
-            {"form": form, "parent": parent, "post": post},
-            request=request,
-        )
-        return HttpResponse(html)
 
     form = CommentForm(request.POST)
     if not form.is_valid():
@@ -214,11 +245,38 @@ def comment_reply(request, post_id):
 
 
 @login_required
+@require_http_methods(["GET"])
+def comment_reply_form(request, post_id):
+    """Render the comment reply form via HTMX."""
+
+    if request.headers.get("HX-Request") != "true":
+        return HttpResponseBadRequest("Invalid request")
+
+    post = get_object_or_404(Post, pk=post_id)
+    parent_id = request.GET.get("parent_id")
+    if not parent_id:
+        return HttpResponseBadRequest("Missing parent_id")
+    parent = get_object_or_404(Comment, pk=parent_id, post=post)
+    form = CommentForm()
+    html = render_to_string(
+        "core/partials/reply_form.html",
+        {"form": form, "parent": parent, "post": post},
+        request=request,
+    )
+    return HttpResponse(html)
+
+
+@login_required
 @require_POST
 @csrf_protect
-@ratelimit(action="vote", limit=20)
+@dratelimit(key="user", rate="120/m", method=["POST"], block=False)
 def vote_post(request, pk):
     """Handle voting on a post."""
+
+    if getattr(request, "limited", False):
+        resp = HttpResponse("Too many requests", status=429)
+        resp.headers["X-RateLimit-Triggered"] = "1"
+        return resp
 
     try:
         value = int(request.GET.get("v"))
@@ -237,9 +295,14 @@ def vote_post(request, pk):
 @login_required
 @require_POST
 @csrf_protect
-@ratelimit(action="vote", limit=20)
+@dratelimit(key="user", rate="120/m", method=["POST"], block=False)
 def vote_comment(request, pk):
     """Handle voting on a comment."""
+
+    if getattr(request, "limited", False):
+        resp = HttpResponse("Too many requests", status=429)
+        resp.headers["X-RateLimit-Triggered"] = "1"
+        return resp
 
     try:
         value = int(request.GET.get("v"))

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,0 +1,16 @@
+# Deployment
+
+```pwsh
+git add -A
+git commit -m "alpha: public signup + submit path"
+$REV = (Get-Date).ToString("yyyyMMddHHmmss")
+flyctl deploy -a surejan --remote-only --build-arg BUILD_REV=$REV
+flyctl ssh console -a surejan -C "python manage.py migrate --noinput"
+flyctl ssh console -a surejan -C "python manage.py seed_basics"
+```
+
+## Verify
+
+```pwsh
+flyctl logs -a surejan | Select-String -Pattern "ERROR|Traceback|favicon|collectstatic"
+```

--- a/templates/base.html
+++ b/templates/base.html
@@ -21,9 +21,17 @@
         <a href="/r/news/">NEWS</a>
         <a href="/r/brisbane/">BRISBANE</a>
       </nav>
+      {% include "partials/user_box.html" %}
     </header>
 
     <main class="container" style="max-width:980px; margin:16px auto;">
+      {% if messages %}
+        <ul class="messages">
+          {% for message in messages %}
+            <li class="{{ message.tags }}">{{ message }}</li>
+          {% endfor %}
+        </ul>
+      {% endif %}
       {% block content %}{% endblock %}
     </main>
 

--- a/templates/core/community.html
+++ b/templates/core/community.html
@@ -2,6 +2,9 @@
 {% block content %}
 <h1>{{ community.title }}</h1>
 <p>{{ community.description }}</p>
+{% if request.user.is_authenticated %}
+  <p><a class="button" href="{% url 'submit_post' community.slug %}">Submit</a></p>
+{% endif %}
 {% include "partials/sort_tabs.html" with active_sort=sort community_slug=community_slug sort_tabs=sort_tabs %}
 <div id="feed-list">
   {% include "core/partials/post_list.html" with posts=posts %}

--- a/templates/core/partials/comment.html
+++ b/templates/core/partials/comment.html
@@ -4,13 +4,13 @@
         by {{ comment.author.username }} ·
         <button hx-post="{% url 'vote_comment' comment.pk %}?v=1"
                 hx-target="#comment-score-{{ comment.pk }}"
-                hx-swap="outerHTML">▲</button>
+                hx-swap="outerHTML" aria-label="Upvote">▲</button>
         <span id="comment-score-{{ comment.pk }}">{{ comment.score }}</span>
         <button hx-post="{% url 'vote_comment' comment.pk %}?v=-1"
                 hx-target="#comment-score-{{ comment.pk }}"
-                hx-swap="outerHTML">▼</button>
+                hx-swap="outerHTML" aria-label="Downvote">▼</button>
         · {{ comment.created_at|timesince }} ago ·
-        <button hx-get="{% url 'comment_reply' comment.post.pk %}?parent_id={{ comment.pk }}"
+        <button hx-get="{% url 'comment_reply_form' comment.post.pk %}?parent_id={{ comment.pk }}"
                 hx-target="#comment-{{ comment.pk }}"
                 hx-swap="afterend">reply</button>
     </small>

--- a/templates/core/partials/post_list.html
+++ b/templates/core/partials/post_list.html
@@ -1,5 +1,5 @@
 {% for post in posts %}
   {% include "core/partials/post_row.html" with post=post %}
 {% empty %}
-  <p>No posts yet.</p>
+  <p>No posts yet. Be the first to submit!</p>
 {% endfor %}

--- a/templates/core/partials/post_row.html
+++ b/templates/core/partials/post_row.html
@@ -1,9 +1,9 @@
 {% load url_domain %}
 <div class="post-row">
   <div class="vote-col">
-    <button hx-post="{% url 'vote_post' post.pk %}?v=1" hx-target="#post-score-{{ post.pk }}" hx-swap="outerHTML">▲</button>
+    <button hx-post="{% url 'vote_post' post.pk %}?v=1" hx-target="#post-score-{{ post.pk }}" hx-swap="outerHTML" aria-label="Upvote">▲</button>
     <span id="post-score-{{ post.pk }}">{{ post.score }}</span>
-    <button hx-post="{% url 'vote_post' post.pk %}?v=-1" hx-target="#post-score-{{ post.pk }}" hx-swap="outerHTML">▼</button>
+    <button hx-post="{% url 'vote_post' post.pk %}?v=-1" hx-target="#post-score-{{ post.pk }}" hx-swap="outerHTML" aria-label="Downvote">▼</button>
   </div>
   <div class="post-body">
     <h2>

--- a/templates/partials/user_box.html
+++ b/templates/partials/user_box.html
@@ -1,8 +1,13 @@
 {% load points %}
 <div class="user-box">
   {% if request.user.is_authenticated %}
-    {{ request.user.username }} | Points: {{ request.user|get_points }} | <a href="{% url 'admin:logout' %}">logout</a>
+    <a href="{% url 'user_overview' request.user.username %}">{{ request.user.username }}</a>
+    | Points: {{ request.user|get_points }} |
+    <a href="{% url 'user_overview' request.user.username %}">Profile</a> |
+    <a href="{% url 'user_submitted' request.user.username %}">Submitted</a> |
+    <a href="{% url 'user_comments' request.user.username %}">Comments</a> |
+    <a href="{% url 'logout' %}">logout</a>
   {% else %}
-    <a href="{% url 'admin:login' %}">login</a> | <a href="#">register</a>
+    <a href="{% url 'login' %}">login</a> | <a href="{% url 'signup' %}">register</a>
   {% endif %}
 </div>

--- a/templates/registration/logged_out.html
+++ b/templates/registration/logged_out.html
@@ -1,0 +1,5 @@
+{% extends "base.html" %}
+{% block content %}
+<p>You have been logged out.</p>
+<a href="{% url 'login' %}">Login again</a>
+{% endblock %}

--- a/templates/registration/login.html
+++ b/templates/registration/login.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Login</h1>
+<form method="post">
+  {% csrf_token %}
+  {{ form.as_p }}
+  <button type="submit">Login</button>
+</form>
+{% endblock %}

--- a/templates/registration/signup.html
+++ b/templates/registration/signup.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Sign up</h1>
+<form method="post">
+  {% csrf_token %}
+  {{ form.as_p }}
+  <button type="submit">Sign up</button>
+</form>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Add public authentication routes with a custom signup view and templates.
- Show user profile links and auth actions in the header; add submit button on community pages.
- Secure write endpoints with login, POST-only, and rate limits; add seed_basics command and deployment docs.

## Testing
- `DEBUG=1 python manage.py test --verbosity 0`


------
https://chatgpt.com/codex/tasks/task_e_68a95a6c8284832c88926069fc7b761a