### PR TITLE
Parse allowed hosts from env and send host header in health check

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -147,9 +147,12 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 # -----------------------------------------------------------------------------
 # Hosts / CSRF
 # -----------------------------------------------------------------------------
-ALLOWED_HOSTS = [h for h in os.getenv("DJANGO_ALLOWED_HOSTS", "").split(",") if h]
+_raw = os.getenv("DJANGO_ALLOWED_HOSTS", "")
+ALLOWED_HOSTS = [h.strip() for h in _raw.split(",") if h.strip()]
+if not ALLOWED_HOSTS:
+    ALLOWED_HOSTS = ["surejan.fly.dev"]  # safe default
 
-# Keep CSRF tight even if ALLOWED_HOSTS is broad
+# keep CSRF tight even if ALLOWED_HOSTS includes '*'
 CSRF_TRUSTED_ORIGINS = [
     "https://surejan.fly.dev",
     "https://www.surejan.com",

--- a/fly.toml
+++ b/fly.toml
@@ -21,11 +21,11 @@ primary_region = "syd"
   processes = ["app"]
 
   [[http_service.checks]]
-    grace_period = "10s"
-    interval = "30s"
-    timeout = "5s"
-    method = "GET"
-    path = "/healthz"
+    method   = "get"
+    path     = "/healthz"
+    interval = "10s"
+    timeout  = "2s"
+    headers  = ["Host: surejan.fly.dev"]
 
 [[vm]]
   cpu_kind = "shared"


### PR DESCRIPTION
## Summary
- Robustly parse `ALLOWED_HOSTS` from environment with a safe default
- Update Fly health check to include the real Host header

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a97e0212fc832cb3b8cde959aee6f6