### PR TITLE
Style and lazy-load post images

### DIFF
--- a/static/css/base.css
+++ b/static/css/base.css
@@ -426,3 +426,30 @@ hr {
   }
 }
 
+/* Post images: responsive + bounded */
+.post-image {
+  display: block;
+  max-width: 100%;
+  height: auto;         /* preserve aspect ratio */
+  border-radius: 4px;
+  margin: 8px 0;
+}
+
+/* Tighter in feed cards so they don’t eat the page */
+.feed .post-image {
+  width: 100%;
+  max-height: 360px;    /* tweak: 300–480px depending on taste */
+  object-fit: cover;    /* crops gracefully to the box */
+}
+
+/* Roomier on the post detail page */
+.post .post-image {
+  width: 100%;
+  max-height: 640px;    /* show more of the image on detail */
+  object-fit: contain;  /* avoid cropping on detail view */
+}
+
+@media (max-width: 768px) {
+  .feed .post-image { max-height: 240px; }
+  .post .post-image { max-height: 480px; }
+}

--- a/templates/core/partials/post_row.html
+++ b/templates/core/partials/post_row.html
@@ -15,7 +15,7 @@
     {% endif %}
     </h2>
     {% if post.image %}
-      <img src="{{ post.image.url }}" alt="" class="post-image">
+      <img src="{{ post.image.url }}" alt="" class="post-image" loading="lazy" decoding="async" referrerpolicy="no-referrer">
     {% endif %}
     <p class="meta">
       <a href="{% url 'community' post.community.slug %}">/r/{{ post.community.slug }}/</a>

--- a/templates/core/post_detail.html
+++ b/templates/core/post_detail.html
@@ -4,7 +4,7 @@
 <article class="post">
   <h1>{{ post.title }}</h1>
   {% if post.image %}
-    <img src="{{ post.image.url }}" alt="" class="post-image">
+    <img src="{{ post.image.url }}" alt="" class="post-image" loading="lazy" decoding="async" referrerpolicy="no-referrer">
   {% endif %}
   {% if post.body %}
     <p>{{ post.body }}</p>


### PR DESCRIPTION
## Summary
- constrain post images with responsive CSS and context-specific sizing
- lazy-load post images with `loading="lazy"`, `decoding="async"`, and `referrerpolicy="no-referrer"`

## Testing
- `python manage.py test` *(fails: ValueError: The file 'css/base.css' could not be found with <whitenoise.storage.CompressedManifestStaticFilesStorage object at ...>)*

------
https://chatgpt.com/codex/tasks/task_e_68a998e48704832cbc93c1ba2af39a25