### PR TITLE
Ensure logout uses hard redirect

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -2,6 +2,7 @@
 from django.conf import settings
 from django.conf.urls.static import static as serve_static
 from django.contrib import admin
+from django.contrib.auth.views import LogoutView
 from django.http import HttpResponse
 from django.urls import path, include
 
@@ -10,6 +11,11 @@ from core import views as core
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("healthz", lambda request: HttpResponse("ok"), name="healthz"),
+    path(
+        "accounts/logout/",
+        LogoutView.as_view(next_page="/"),
+        name="logout",
+    ),
     path("accounts/", include("django.contrib.auth.urls")),
     path("accounts/signup/", core.signup, name="signup"),
     path("", include("core.urls")),

--- a/templates/partials/user_box.html
+++ b/templates/partials/user_box.html
@@ -3,7 +3,7 @@
   {% if request.user.is_authenticated %}
     <a href="{% url 'user_overview' request.user.username %}">{{ request.user.username }}</a>
     | Points: {{ request.user|get_points }}
-    | <a href="{% url 'logout' %}">logout</a>
+    | <a href="{% url 'logout' %}?next=/" hx-boost="false">logout</a>
   {% else %}
     <a href="{% url 'login' %}">login</a> | <a href="{% url 'signup' %}">register</a>
   {% endif %}


### PR DESCRIPTION
## Summary
- Override logout URL to force redirect to home
- Disable HTMX boost on logout link to prevent blank pages

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9997b4508832ca15bf862ed47b676