### PR TITLE
Disable HTMX boost on logout link

### DIFF
--- a/templates/partials/user_box.html
+++ b/templates/partials/user_box.html
@@ -3,7 +3,7 @@
   {% if request.user.is_authenticated %}
     <a href="{% url 'user_overview' request.user.username %}">{{ request.user.username }}</a>
     | Points: {{ request.user|get_points }}
-    | <a href="{% url 'logout' %}?next=/" hx-boost="false">logout</a>
+    | <a href="{% url 'logout' %}?next=/" hx-boost="false" data-hx-boost="false">logout</a>
   {% else %}
     <a href="{% url 'login' %}">login</a> | <a href="{% url 'signup' %}">register</a>
   {% endif %}


### PR DESCRIPTION
## Summary
- ensure logout link performs full navigation by disabling HTMX boost

## Testing
- `make test` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa3fdfcb2c832c837716e44b5c85ce