### PR TITLE
Use POST form for logout

### DIFF
--- a/static/css/base.css
+++ b/static/css/base.css
@@ -453,3 +453,11 @@ hr {
   .feed .post-image { max-height: 240px; }
   .post .post-image { max-height: 480px; }
 }
+
+.linklike {
+  background: none;
+  border: 0;
+  padding: 0;
+  text-decoration: underline;
+  cursor: pointer;
+}

--- a/templates/partials/user_box.html
+++ b/templates/partials/user_box.html
@@ -3,7 +3,11 @@
   {% if request.user.is_authenticated %}
     <a href="{% url 'user_overview' request.user.username %}">{{ request.user.username }}</a>
     | Points: {{ request.user|get_points }}
-    | <a href="{% url 'logout' %}?next=/" hx-boost="false" data-hx-boost="false">logout</a>
+    | <form method="post" action="{% url 'logout' %}" style="display:inline" hx-boost="false" hx-swap="none">
+      {% csrf_token %}
+      <input type="hidden" name="next" value="/" />
+      <button type="submit" class="linklike">logout</button>
+    </form>
   {% else %}
     <a href="{% url 'login' %}">login</a> | <a href="{% url 'signup' %}">register</a>
   {% endif %}


### PR DESCRIPTION
## Summary
- Replace logout link with a CSRF-protected POST form in user box
- Add `.linklike` CSS to style logout button like a link

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa42749ec0832c850c5b4f33b96098