### PR TITLE
Enable password reset flow and Argon2 hashing

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -117,6 +117,14 @@ AUTH_PASSWORD_VALIDATORS = [
     }
 ]
 
+PASSWORD_HASHERS = [
+    "django.contrib.auth.hashers.Argon2PasswordHasher",
+    "django.contrib.auth.hashers.PBKDF2PasswordHasher",
+    "django.contrib.auth.hashers.PBKDF2SHA1PasswordHasher",
+    "django.contrib.auth.hashers.BCryptSHA256PasswordHasher",
+    "django.contrib.auth.hashers.ScryptPasswordHasher",
+]
+
 # -----------------------------------------------------------------------------
 # I18N
 # -----------------------------------------------------------------------------
@@ -159,6 +167,22 @@ if USE_S3_MEDIA:
     STORAGES["default"] = {"BACKEND": "storages.backends.s3boto3.S3Boto3Storage"}
 else:
     STORAGES["default"] = {"BACKEND": "django.core.files.storage.FileSystemStorage"}
+
+# -----------------------------------------------------------------------------
+# Email
+# -----------------------------------------------------------------------------
+if DEBUG:
+    EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
+else:
+    EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
+    EMAIL_HOST = os.getenv("EMAIL_HOST", "")
+    EMAIL_PORT = int(os.getenv("EMAIL_PORT", "25"))
+    EMAIL_HOST_USER = os.getenv("EMAIL_HOST_USER", "")
+    EMAIL_HOST_PASSWORD = os.getenv("EMAIL_HOST_PASSWORD", "")
+    EMAIL_USE_TLS = os.environ.get("EMAIL_USE_TLS", "0") in ("1", "true", "True")
+    EMAIL_USE_SSL = os.environ.get("EMAIL_USE_SSL", "0") in ("1", "true", "True")
+
+DEFAULT_FROM_EMAIL = os.getenv("DEFAULT_FROM_EMAIL", "no-reply@surejan.fly.dev")
 
 # -----------------------------------------------------------------------------
 # Misc

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ Django==5.2.5
 django-csp==4.0
 django-htmx==1.23.2
 django-ratelimit==4.1.0
+argon2-cffi==23.1.0
 gunicorn==23.0.0
 packaging==25.0
 pillow==11.3.0

--- a/templates/core/community.html
+++ b/templates/core/community.html
@@ -3,7 +3,7 @@
 <h1>{{ community.title }}</h1>
 <p>{{ community.description }}</p>
 {% if request.user.is_authenticated %}
-  <p><a class="button" href="{% url 'submit_post' community.slug %}">Submit</a></p>
+  <p><a class="button" href="{% url 'submit_post' community.slug %}" hx-boost="false">Submit</a></p>
 {% endif %}
 {% include "partials/sort_tabs.html" with active_sort=sort community_slug=community_slug sort_tabs=sort_tabs %}
 <div id="feed-list">

--- a/templates/partials/user_box.html
+++ b/templates/partials/user_box.html
@@ -9,6 +9,6 @@
       <button type="submit" class="linklike">logout</button>
     </form>
   {% else %}
-    <a href="{% url 'login' %}">login</a> | <a href="{% url 'signup' %}">register</a>
+    <a href="{% url 'login' %}" hx-boost="false">login</a> | <a href="{% url 'signup' %}" hx-boost="false">register</a>
   {% endif %}
 </div>

--- a/templates/registration/login.html
+++ b/templates/registration/login.html
@@ -1,6 +1,9 @@
 {% extends "base.html" %}
 {% block content %}
 <h1>Log in</h1>
-<form method="post">{% csrf_token %}{{ form.as_p }}<button>Log in</button></form>
+<form method="post" action="{% url 'login' %}" hx-boost="false" hx-swap="none">
+  {% csrf_token %}{{ form.as_p }}<button>Log in</button>
+</form>
+<p><a href="{% url 'password_reset' %}" hx-boost="false">Forgot your password?</a></p>
 <p>No account? <a href="{% url 'signup' %}">Sign up</a></p>
 {% endblock %}

--- a/templates/registration/password_reset_complete.html
+++ b/templates/registration/password_reset_complete.html
@@ -1,0 +1,6 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Password reset complete</h1>
+<p>Your password has been set. You may now <a href="{% url 'login' %}" hx-boost="false">log in</a>.</p>
+{% endblock %}
+

--- a/templates/registration/password_reset_confirm.html
+++ b/templates/registration/password_reset_confirm.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Reset your password</h1>
+<form method="post" hx-boost="false" hx-swap="none">
+  {% csrf_token %}
+  {{ form.as_p }}
+  <button type="submit">Change password</button>
+</form>
+{% endblock %}
+

--- a/templates/registration/password_reset_done.html
+++ b/templates/registration/password_reset_done.html
@@ -1,0 +1,6 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Password reset sent</h1>
+<p>If an account exists for the email provided, you will receive a password reset link.</p>
+{% endblock %}
+

--- a/templates/registration/password_reset_form.html
+++ b/templates/registration/password_reset_form.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Password reset</h1>
+<form method="post" action="{% url 'password_reset' %}" hx-boost="false" hx-swap="none">
+  {% csrf_token %}
+  {{ form.as_p }}
+  <button type="submit">Reset password</button>
+</form>
+{% endblock %}
+


### PR DESCRIPTION
## Summary
- add password reset templates and console/SMTP email backend
- switch to Argon2 as primary password hasher
- ensure auth forms and submit CTA use full navigation

## Testing
- `python manage.py collectstatic --noinput`
- `python manage.py test`
- `python manage.py shell -c "from django.conf import settings; print(settings.PASSWORD_HASHERS[0])"`
- `python manage.py shell -c "from django.contrib.auth import get_user_model; U=get_user_model(); u=U.objects.create_user('tempuser', password='longpassword1'); print(u.password)"`
- `DEBUG=1 python manage.py shell -c "from django.conf import settings; print(settings.EMAIL_BACKEND)"`


------
https://chatgpt.com/codex/tasks/task_e_68aa46a59454832c8a4eadd51a9a1a95