### PR TITLE
Allow users to delete their comments

### DIFF
--- a/core/tests_comment_delete.py
+++ b/core/tests_comment_delete.py
@@ -1,0 +1,74 @@
+from django.contrib.auth import get_user_model
+from django.core.cache import cache
+from django.test import TestCase
+from django.urls import reverse
+
+from .models import Comment, Community, Post
+
+
+class CommentDeleteTests(TestCase):
+    def setUp(self):
+        cache.clear()
+        U = get_user_model()
+        self.user = U.objects.create_user("alice", password="pwd")
+        self.other = U.objects.create_user("bob", password="pwd")
+        self.staff = U.objects.create_user("mod", password="pwd", is_staff=True)
+        self.community = Community.objects.create(
+            slug="t", name="Test", title="Test", created_by=self.user
+        )
+        self.post = Post.objects.create(
+            community=self.community,
+            author=self.user,
+            post_type="text",
+            title="Hello",
+        )
+        self.comment = Comment.objects.create(
+            post=self.post, author=self.user, body="Hi", path="0001"
+        )
+        self.post.comment_count = 1
+        self.post.save(update_fields=["comment_count"])
+        self.url = reverse("comment_delete", args=[self.comment.pk])
+        self.client.login(username="alice", password="pwd")
+
+    def test_delete_own_comment(self):
+        resp = self.client.post(self.url, HTTP_HX_REQUEST="true")
+        self.assertEqual(resp.status_code, 200)
+        self.assertFalse(Comment.objects.filter(pk=self.comment.pk).exists())
+        self.post.refresh_from_db()
+        self.assertEqual(self.post.comment_count, 0)
+
+    def test_staff_can_delete(self):
+        self.client.logout()
+        self.client.login(username="mod", password="pwd")
+        resp = self.client.post(self.url, HTTP_HX_REQUEST="true")
+        self.assertEqual(resp.status_code, 200)
+        self.assertFalse(Comment.objects.filter(pk=self.comment.pk).exists())
+
+    def test_cannot_delete_others_comment(self):
+        self.client.logout()
+        self.client.login(username="bob", password="pwd")
+        resp = self.client.post(self.url, HTTP_HX_REQUEST="true")
+        self.assertEqual(resp.status_code, 403)
+        self.assertTrue(Comment.objects.filter(pk=self.comment.pk).exists())
+
+    def test_requires_login(self):
+        self.client.logout()
+        resp = self.client.post(self.url)
+        self.assertEqual(resp.status_code, 302)
+
+    def test_delete_subtree_decrements_count(self):
+        child = Comment.objects.create(
+            post=self.post,
+            author=self.user,
+            parent=self.comment,
+            body="child",
+            path="0001/0001",
+        )
+        self.post.comment_count = 2
+        self.post.save(update_fields=["comment_count"])
+        resp = self.client.post(self.url, HTTP_HX_REQUEST="true")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(Comment.objects.count(), 0)
+        self.post.refresh_from_db()
+        self.assertEqual(self.post.comment_count, 0)
+

--- a/core/urls.py
+++ b/core/urls.py
@@ -24,6 +24,7 @@ urlpatterns = [
     # Comments & voting
     path("comment/<int:post_id>/reply/", core_views.comment_reply, name="comment_reply"),
     path("comment/<int:post_id>/reply-form/", core_views.comment_reply_form, name="comment_reply_form"),
+    path("comment/<int:pk>/delete/", core_views.comment_delete, name="comment_delete"),
     path("vote/post/<int:pk>/", core_views.vote_post, name="vote_post"),
     path("vote/comment/<int:pk>/", core_views.vote_comment, name="vote_comment"),
 

--- a/core/views.py
+++ b/core/views.py
@@ -9,7 +9,7 @@ from django.views.decorators.csrf import csrf_protect
 from django_ratelimit.decorators import ratelimit, is_ratelimited
 from django.template.loader import render_to_string
 
-from django.http import HttpResponse, HttpResponseBadRequest
+from django.http import HttpResponse, HttpResponseBadRequest, HttpResponseForbidden
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils.text import slugify
 from django.db.models import F
@@ -264,6 +264,33 @@ def comment_reply_form(request, post_id):
         request=request,
     )
     return HttpResponse(html)
+
+
+@login_required
+@require_POST
+@csrf_protect
+def comment_delete(request, pk):
+    """Delete a comment if the requester is the author or staff."""
+
+    comment = get_object_or_404(Comment, pk=pk)
+    if request.user != comment.author and not request.user.is_staff:
+        return HttpResponseForbidden("Forbidden")
+
+    post = comment.post
+    # number of comments to remove including any descendants
+    count = Comment.objects.filter(post=post, path__startswith=comment.path).count()
+    comment.delete()
+    Post.objects.filter(pk=post.pk).update(comment_count=F("comment_count") - count)
+
+    if request.headers.get("HX-Request") == "true":
+        return HttpResponse("")
+
+    return redirect(
+        "post_detail",
+        slug=post.community.slug,
+        post_id=post.pk,
+        post_slug=slugify(post.title),
+    )
 
 
 @login_required

--- a/templates/core/partials/comment.html
+++ b/templates/core/partials/comment.html
@@ -13,5 +13,10 @@
         <button hx-get="{% url 'comment_reply_form' comment.post.pk %}?parent_id={{ comment.pk }}"
                 hx-target="#comment-{{ comment.pk }}"
                 hx-swap="afterend">reply</button>
+        {% if request.user.is_staff or request.user == comment.author %}
+        · <button hx-post="{% url 'comment_delete' comment.pk %}"
+                  hx-target="#comment-{{ comment.pk }}"
+                  hx-swap="outerHTML">delete</button>
+        {% endif %}
     </small>
 </div>


### PR DESCRIPTION
## Summary
- Add CSRF-protected POST endpoint to delete comments
- Show HTMX delete button for comment authors and staff
- Adjust post comment_count and remove comment element on delete
- Test comment deletion permissions and counters

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68aa487b5110832ca81d704ba828ecaa