### PR TITLE
Ensure HTMX votes include CSRF token

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -440,7 +440,7 @@ def vote_post(request, pk):
         return resp
 
     try:
-        value = int(request.GET.get("v"))
+        value = int(request.GET.get("v") or request.POST.get("v"))
     except (TypeError, ValueError):
         return HttpResponseBadRequest("Invalid vote")
 
@@ -466,7 +466,7 @@ def vote_comment(request, pk):
         return resp
 
     try:
-        value = int(request.GET.get("v"))
+        value = int(request.GET.get("v") or request.POST.get("v"))
     except (TypeError, ValueError):
         return HttpResponseBadRequest("Invalid vote")
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -36,6 +36,7 @@
       {% block content %}{% endblock %}
     </main>
 
-    {% block scripts %}{% endblock %}
-  </body>
-</html>
+      {% block scripts %}{% endblock %}
+      {% include "core/_htmx_csrf.html" %}
+    </body>
+  </html>


### PR DESCRIPTION
## Summary
- include HTMX CSRF helper globally so HTMX POSTs carry CSRF token
- allow vote endpoints to read vote value from GET or POST

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa59efaf50832c9f5e7aab52530f00