### PR TITLE
ui: old.reddit post layout (thing grid, meta, actions, tree, tabs)

### DIFF
--- a/static/css/theme.css
+++ b/static/css/theme.css
@@ -461,3 +461,41 @@ hr {
   text-decoration: underline;
   cursor: pointer;
 }
+
+/* Post page wrapper + 2-column thing */
+.post-page { max-width: 740px; margin: 12px auto 48px; }
+.post-thing { display: grid; grid-template-columns: 40px 1fr; gap: 10px; background:#fff; border:1px solid #ddd; padding:10px; }
+
+/* Vote rail like old reddit */
+.vote { display:flex; flex-direction:column; align-items:center; gap:2px; width:40px; color:#888; }
+.vote .up, .vote .down { background:none; border:0; cursor:pointer; }
+.vote .score { font-weight:bold; font-size:11px; }
+.vote .up[aria-pressed="true"] { color:#ff8b60; } /* up */
+.vote .down[aria-pressed="true"] { color:#5f99cf; } /* down */
+
+/* Title + meta + actions */
+.post-head h1 { font: normal 16px/1.2 Verdana, Arial, sans-serif; margin:0 0 4px; }
+.post-head h1 a { color:#3366cc; }
+.post-head h1 a:visited { color:#551a8b; }
+.post-meta { color:#777; font-size:11px; margin-bottom:6px; }
+.post-actions { font-size:11px; color:#777; margin-top:6px; }
+.post-actions a { color:#3366cc; margin-right:8px; position:relative; }
+.post-actions a + a:before { content:"•"; color:#aaa; position:absolute; left:-6px; }
+
+/* Image */
+.post-content .post-image { border:1px solid #e6e6e6; box-shadow:0 1px 0 #eee; }
+
+/* Comment tree */
+.comment { background:#fff; border:1px solid #ddd; padding:8px; margin:8px 0; font-size:11px; }
+.comment .meta { color:#777; margin-bottom:4px; }
+.comment .children { border-left:1px solid #e6e6e6; margin-left:10px; padding-left:10px; }
+
+/* Tabs (top of post) */
+.sort-tabs { font-size:11px; text-transform:uppercase; letter-spacing:.02em; }
+.sort-tabs a { color:#777; }
+.sort-tabs a.active { color:#111; border-bottom:2px solid #3366cc; }
+
+@media (max-width: 768px) {
+  .post-page { margin:8px auto 32px; }
+  .post-thing { grid-template-columns: 32px 1fr; }
+}

--- a/templates/core/partials/comment.html
+++ b/templates/core/partials/comment.html
@@ -1,28 +1,29 @@
-<div id="comment-{{ comment.pk }}" style="margin-left: {% widthratio comment.depth 1 20 %}px">
-    <p>{{ comment.body }}</p>
-    <small>
-        by {{ comment.author.username }} ·
-        <button hx-post="{% url 'vote_comment' comment.pk %}?v=1"
-                hx-target="#comment-score-{{ comment.pk }}"
-                hx-swap="outerHTML" aria-label="Upvote">▲</button>
-        <span id="comment-score-{{ comment.pk }}">{{ comment.score }}</span>
-        <button hx-post="{% url 'vote_comment' comment.pk %}?v=-1"
-                hx-target="#comment-score-{{ comment.pk }}"
-                hx-swap="outerHTML" aria-label="Downvote">▼</button>
-        · {{ comment.created_at|timesince }} ago ·
-        <button hx-get="{% url 'comment_reply_form' comment.post.pk %}?parent_id={{ comment.pk }}"
-                hx-target="#comment-{{ comment.pk }}"
-                hx-swap="afterend">reply</button>
-        {% if request.user.id == comment.author_id or request.user.is_staff %}
-        · <form method="post"
-                action="{% url 'comment_delete' comment.pk %}"
-                style="display:inline"
-                hx-post="{% url 'comment_delete' comment.pk %}"
-                hx-target="#comment-{{ comment.pk }}"
-                hx-swap="outerHTML">
-            {% csrf_token %}
-            <button type="submit" class="linklike" aria-label="Delete comment">delete</button>
-          </form>
-        {% endif %}
-    </small>
+<div id="comment-{{ comment.pk }}" class="comment">
+  <div class="meta">
+    by <a href="{% url 'user_overview' comment.author.username %}">{{ comment.author.username }}</a>
+    • {{ comment.created_at|timesince }} ago
+    <button hx-post="{% url 'vote_comment' comment.pk %}?v=1"
+            hx-target="#comment-score-{{ comment.pk }}"
+            hx-swap="outerHTML" aria-label="Upvote" class="up">▲</button>
+    <span id="comment-score-{{ comment.pk }}">{{ comment.score }}</span>
+    <button hx-post="{% url 'vote_comment' comment.pk %}?v=-1"
+            hx-target="#comment-score-{{ comment.pk }}"
+            hx-swap="outerHTML" aria-label="Downvote" class="down">▼</button>
+    <button hx-get="{% url 'comment_reply_form' comment.post.pk %}?parent_id={{ comment.pk }}"
+            hx-target="#comment-{{ comment.pk }}" hx-swap="afterend">reply</button>
+    {% if request.user.id == comment.author_id or request.user.is_staff %}
+      <form method="post" action="{% url 'comment_delete' comment.pk %}" style="display:inline"
+            hx-post="{% url 'comment_delete' comment.pk %}" hx-target="#comment-{{ comment.pk }}" hx-swap="outerHTML">
+        {% csrf_token %}
+        <button type="submit" class="linklike" aria-label="Delete comment">delete</button>
+      </form>
+    {% endif %}
+  </div>
+  <div class="body">{{ comment.body|linebreaksbr }}</div>
+  <div class="children">
+    {% for child in comment.children.all %}
+      {% include "core/partials/comment.html" with comment=child %}
+    {% endfor %}
+  </div>
 </div>
+

--- a/templates/core/post_detail.html
+++ b/templates/core/post_detail.html
@@ -1,21 +1,49 @@
 {% extends "base.html" %}
 
 {% block content %}
-<article class="post">
-  <h1>{{ post.title }}</h1>
-  {% if post.image %}
-    <img src="{{ post.image.url }}" alt="" class="post-image" loading="lazy" decoding="async" referrerpolicy="no-referrer">
-  {% endif %}
-  {% if post.body %}
-    <p>{{ post.body }}</p>
-  {% endif %}
-  {% if post.url %}
-    <p><a href="{{ post.url }}">{{ post.url }}</a></p>
-  {% endif %}
-</article>
+<div class="post-page">
+  <article class="post-thing">
+    <div class="vote">
+      <button class="up" hx-post="{% url 'vote_post' post.pk %}?v=1" hx-target="#post-score-{{ post.pk }}" hx-swap="outerHTML" aria-label="Upvote">▲</button>
+      <span id="post-score-{{ post.pk }}" class="score">{{ post.score }}</span>
+      <button class="down" hx-post="{% url 'vote_post' post.pk %}?v=-1" hx-target="#post-score-{{ post.pk }}" hx-swap="outerHTML" aria-label="Downvote">▼</button>
+    </div>
+    <div class="post-body">
+      <header class="post-head">
+        <h1>
+          {% if post.url %}<a href="{{ post.url }}" rel="noopener nofollow">{{ post.title }}</a>{% else %}{{ post.title }}{% endif %}
+        </h1>
+        <div class="post-meta">
+          submitted {{ post.created_at|timesince }} ago by
+          <a href="{% url 'user_overview' post.author.username %}">{{ post.author.username }}</a>
+          to <a href="{% url 'community' post.community.slug %}">r/{{ post.community.slug }}</a>
+        </div>
+      </header>
+      <div class="post-content">
+        {% if post.image %}
+          <img src="{{ post.image.url }}" alt="" class="post-image" loading="lazy" decoding="async" referrerpolicy="no-referrer">
+        {% endif %}
+        {% if post.body %}
+          <p>{{ post.body }}</p>
+        {% endif %}
+        {% if post.url %}
+          <p><a href="{{ post.url }}">{{ post.url }}</a></p>
+        {% endif %}
+      </div>
+      <nav class="post-actions">
+        <a href="#comments">{{ post.comment_count }} comments</a>
+        <a href="#" onclick="navigator.clipboard.writeText(window.location.href);return false;">share</a>
+        <a href="{% url 'community' post.community.slug %}">back to r/{{ post.community.slug }}</a>
+      </nav>
+    </div>
+  </article>
+</div>
+
 <div id="comments">
   {% for comment in comments %}
-    {% include "core/partials/comment.html" %}
+    {% if not comment.parent_id %}
+      {% include "core/partials/comment.html" %}
+    {% endif %}
   {% empty %}
     <p>No comments yet.</p>
   {% endfor %}

--- a/templates/partials/sort_tabs.html
+++ b/templates/partials/sort_tabs.html
@@ -1,18 +1,17 @@
 {% comment %} Reusable sort nav for home/community {% endcomment %}
 <nav id="sort-tabs" class="sort-tabs">
-  <ul>
-    {% for key,label in sort_tabs %}
-      {% if community_slug %}
-        {% if key == 'wiki' %}
-          <li><a href="{% url 'community_wiki' community_slug %}" class="{% if active_sort == key %}active{% endif %}">{{ label }}</a></li>
-        {% else %}
-          <li><a href="{% url 'community' community_slug %}?sort={{ key }}" class="{% if active_sort == key %}active{% endif %}">{{ label }}</a></li>
-        {% endif %}
+  {% for key,label in sort_tabs %}
+    {% if community_slug %}
+      {% if key == 'wiki' %}
+        <a href="{% url 'community_wiki' community_slug %}" class="{% if active_sort == key %}active{% endif %}">{{ label }}</a>
       {% else %}
-        {% if key != 'wiki' %}
-          <li><a href="/?sort={{ key }}" class="{% if active_sort == key %}active{% endif %}">{{ label }}</a></li>
-        {% endif %}
+        <a href="{% url 'community' community_slug %}?sort={{ key }}" class="{% if active_sort == key %}active{% endif %}">{{ label }}</a>
       {% endif %}
-    {% endfor %}
-  </ul>
+    {% else %}
+      {% if key != 'wiki' %}
+        <a href="/?sort={{ key }}" class="{% if active_sort == key %}active{% endif %}">{{ label }}</a>
+      {% endif %}
+    {% endif %}
+  {% endfor %}
 </nav>
+


### PR DESCRIPTION
## Summary
- restyle post detail page with two-column grid and vote rail
- update post template with classic title, meta, actions, and comment tree wrappers
- simplify sort tabs and comment markup for old-reddit look

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68aa5f9eff3c832c96c33decddd94132