### PR TITLE
Constrain feed image height and add feed wrapper

### DIFF
--- a/static/css/theme.css
+++ b/static/css/theme.css
@@ -499,3 +499,15 @@ hr {
   .post-page { margin:8px auto 32px; }
   .post-thing { grid-template-columns: 32px 1fr; }
 }
+
+/* Feed images: compact cards (does not affect post detail) */
+.feed .post-image {
+  width: 100%;
+  max-height: 360px;
+  object-fit: cover;        /* crop to fit the card */
+  border: 1px solid #e6e6e6;
+  box-shadow: 0 1px 0 #eee;
+}
+@media (max-width: 768px) {
+  .feed .post-image { max-height: 240px; }
+}

--- a/templates/core/community.html
+++ b/templates/core/community.html
@@ -6,8 +6,10 @@
   <p><a class="button" href="{% url 'submit_post' community.slug %}" hx-boost="false">Submit</a></p>
 {% endif %}
 {% include "partials/sort_tabs.html" with active_sort=sort community_slug=community_slug sort_tabs=sort_tabs %}
-<div id="feed-list">
-  {% include "core/partials/post_list.html" with posts=posts %}
+<div class="feed">
+  <div id="feed-list">
+    {% include "core/partials/post_list.html" with posts=posts %}
+  </div>
 </div>
 {% if next_page %}
   {% include "core/partials/load_more.html" with next_url=request.path|add:'?page='|add:next_page|add:sort_query %}

--- a/templates/core/home.html
+++ b/templates/core/home.html
@@ -2,8 +2,10 @@
 {% block content %}
   <h1>SureJan</h1>
   {% include "partials/sort_tabs.html" with active_sort=sort sort_tabs=sort_tabs %}
-  <div id="feed-list">
-    {% include "core/partials/post_list.html" with posts=posts %}
+  <div class="feed">
+    <div id="feed-list">
+      {% include "core/partials/post_list.html" with posts=posts %}
+    </div>
   </div>
   {% if next_page %}
     {% include "core/partials/load_more.html" with next_url=request.path|add:'?page='|add:next_page|add:sort_query %}


### PR DESCRIPTION
## Summary
- Constrain feed images with new `.feed .post-image` rules for compact, cropped cards
- Wrap home and community post lists in a `.feed` container to scope new styling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68aa63e02674832cba5714dc13fb26a3