### PR TITLE
Add mission page and header link

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -5,6 +5,7 @@ from . import views as core_views
 urlpatterns = [
     # Home / front page
     path("", core_views.home, name="home"),
+    path("mission/", core_views.mission, name="mission"),
 
     # Recovery codes
     path("accounts/recovery-codes/", core_views.recovery_codes, name="recovery_codes"),

--- a/core/views.py
+++ b/core/views.py
@@ -33,6 +33,10 @@ def healthz(_request):
     return HttpResponse("ok", content_type="text/plain")
 
 
+def mission(request):
+    return render(request, "core/mission.html")
+
+
 class SignupForm(forms.Form):
     username = forms.CharField(max_length=150)
     password = forms.CharField(widget=forms.PasswordInput)

--- a/static/css/theme.css
+++ b/static/css/theme.css
@@ -525,3 +525,11 @@ hr {
 .form-actions { margin-top:14px; font-size:11px; }
 .form-actions .button { padding:2px 8px; border:1px solid #ccc; background:#eee; cursor:pointer; }
 .form-actions a { margin-left:8px; color:#3366cc; }
+
+.brand-mission { font-size:12px; margin-left:8px; color:#3366cc; }
+.brand-mission:hover { text-decoration:underline; }
+.mission h1 { font: normal 16px/1.2 Verdana, Arial, sans-serif; margin: 0 0 8px; }
+.mission h2 { font-size:13px; margin:12px 0 6px; }
+.mission h3 { font-size:12px; margin:10px 0 6px; }
+.mission p, .mission li { font-size:12px; }
+.mission .muted { color:#777; font-size:11px; }

--- a/templates/base.html
+++ b/templates/base.html
@@ -18,6 +18,7 @@
       <a href="/">
         <img src="{% static 'SureJanLogo.png' %}" alt="SureJan Logo" class="site-logo">
       </a>
+      <a href="{% url 'mission' %}" class="brand-mission" hx-boost="false">Our Mission</a>
       <nav class="subreddit-links" style="display:flex; gap:12px;">
         <a href="/r/news/">NEWS</a>
         <a href="/r/brisbane/">BRISBANE</a>

--- a/templates/core/mission.html
+++ b/templates/core/mission.html
@@ -1,0 +1,45 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="mission page container">
+  <h1>SureJan — Brisbane’s no-nonsense forum</h1>
+  <p><strong>Our mission</strong> is to give Brisbane locals a simple, independent place to talk with each other, free from big-tech algorithms, surveillance, and astroturfing. We’re building an old-school, fast forum where real people, not manufactured campaigns, set the tone.</p>
+
+  <h2>What we stand for</h2>
+  <ul>
+    <li><strong>Local-first:</strong> Built for and by Brisbane. Community needs beat growth hacks.</li>
+    <li><strong>Authenticity over astroturf:</strong> Guardrails against coordinated manipulation; clear rules and visible moderation.</li>
+    <li><strong>Privacy by default:</strong> Minimal data collection, no tracking, and plain username/password accounts.</li>
+    <li><strong>Simplicity &amp; speed:</strong> Old-reddit style, readable on any device, no bloat.</li>
+    <li><strong>Transparency &amp; fairness:</strong> Public guidelines, community-led moderation, and decisions explained.</li>
+    <li><strong>Respectful debate:</strong> Disagree well, no harassment, no brigading.</li>
+  </ul>
+
+  <h2>What we won’t do</h2>
+  <ul>
+    <li>No algorithmic engagement traps.</li>
+    <li>No shadowy pay-to-play or undisclosed promotions.</li>
+    <li>No selling your data.</li>
+  </ul>
+
+  <h2>Why “SureJan”?</h2>
+  <p>Because we’ve all seen manufactured “grassroots” takes. This space is for Brisbane’s real voices—clear, human, and accountable.</p>
+
+  <h2>What is “Astroturfing”?</h2>
+  <p><em>Astroturfing</em> is when coordinated groups or paid operators pretend to be ordinary users to manufacture the appearance of “grass-roots” opinion—seeding posts, comments, and votes to sway what looks popular or true.</p>
+
+  <h3>Why it thrives on Reddit</h3>
+  <ul>
+    <li><strong>Low cost, high reach:</strong> Many pseudonymous accounts can reach huge audiences.</li>
+    <li><strong>Vote-driven ranking:</strong> Early, coordinated upvotes can game “Hot/Best”.</li>
+    <li><strong>Asymmetric moderation:</strong> Gaps across thousands of subreddits.</li>
+    <li><strong>Automation &amp; marketplaces:</strong> Cheap scripts and paid “engagement”.</li>
+    <li><strong>Weak identity signals:</strong> Hard to distinguish genuine locals from brigades.</li>
+  </ul>
+
+  <p><strong>Thank you,</strong><br>The SureJan Collective.<br>
+  Email: <a href="mailto:ContactSureJan@proton.me">ContactSureJan@proton.me</a></p>
+
+  <p class="muted">SureJan is an independent, Brisbane-built forum run by a small volunteer team.</p>
+</div>
+{% endblock %}
+


### PR DESCRIPTION
## Summary
- Add `/mission` route and view with SureJan mission statement
- Link "Our Mission" next to logo in header
- Style mission page and brand link with old-reddit typography

## Testing
- `make test` *(fails: no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_68aa79b84d50832cbd9f2ca5ddf9702a