### PR TITLE
Rebuild site header into responsive 3-column layout

### DIFF
--- a/static/css/theme.css
+++ b/static/css/theme.css
@@ -533,3 +533,67 @@ hr {
 .mission h3 { font-size:12px; margin:10px 0 6px; }
 .mission p, .mission li { font-size:12px; }
 .mission .muted { color:#777; font-size:11px; }
+
+/* 3-column header layout */
+.header-3col {
+  max-width: 960px;
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: auto 1fr auto; /* left | center | right */
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+}
+
+/* Left cluster: logo sits already, mission sits beside it */
+.hdr-left { display: flex; align-items: center; gap: 10px; }
+.brand-mission { font-size:12px; color:#3366cc; }
+.brand-mission:hover { text-decoration: underline; }
+
+/* Center communities */
+.hdr-center {
+  display:flex; justify-content:center; gap:16px;
+  text-transform: uppercase; font-size:12px;
+}
+.hdr-center a { color:#3366cc; }
+.hdr-center a:hover { text-decoration: underline; }
+
+/* Right: user menu sits inline */
+.hdr-right { display:flex; justify-content:flex-end; }
+.hdr-right .user-box a { color:#3366cc; }
+
+/* Mobile */
+@media (max-width: 768px) {
+  .header-3col {
+    grid-template-columns: 1fr auto; /* left + right */
+    grid-template-areas:
+      "left  right"
+      "center center";
+    row-gap: 6px;
+  }
+  .hdr-left  { grid-area: left; }
+  .hdr-right { grid-area: right; }
+  .hdr-center{
+    grid-area: center; justify-content: center; gap: 12px;
+    overflow-x: auto; white-space: nowrap; padding-bottom: 2px;
+  }
+}
+
+/* Bump header link sizes a bit */
+.brand-mission { font-size:14px; margin-left:0; }
+.hdr-center a   { font-size:14px; }
+.hdr-right .user-box,
+.hdr-right .user-box a { font-size:14px; }
+
+/* Keep tap targets comfy without changing layout */
+.hdr-center a,
+.brand-mission,
+.hdr-right .user-box a { line-height: 1.2; padding: 2px 2px; }
+
+/* Mobile: nudge down slightly if needed */
+@media (max-width: 768px) {
+  .brand-mission,
+  .hdr-center a,
+  .hdr-right .user-box,
+  .hdr-right .user-box a { font-size:13px; }
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -14,17 +14,29 @@
     <script src="https://unpkg.com/htmx.org@1.9.12" defer></script>
   </head>
   <body>
-    <header class="site-header" style="display:flex; justify-content:space-between; align-items:center; padding:8px 12px; border-bottom:1px solid #ccc;">
-      <a href="/">
-        <img src="{% static 'SureJanLogo.png' %}" alt="SureJan Logo" class="site-logo">
-      </a>
-      <a href="{% url 'mission' %}" class="brand-mission" hx-boost="false">Our Mission</a>
-      <nav class="subreddit-links" style="display:flex; gap:12px;">
-        <a href="/r/news/">NEWS</a>
-        <a href="/r/brisbane/">BRISBANE</a>
-      </nav>
-      {% include "partials/user_box.html" %}
+    <header class="site-header">
+      <div class="header-inner header-3col">
+
+        <!-- Left: Logo + Our Mission -->
+        <div class="hdr-left">
+          <a href="{% url 'home' %}" class="site-brand"><img src="{% static 'SureJanLogo.png' %}" alt="SureJan" class="site-logo"></a>
+          <a href="{% url 'mission' %}" class="brand-mission" hx-boost="false">Our Mission</a>
+        </div>
+
+        <!-- Center: NEWS / BRISBANE -->
+        <nav class="hdr-center" aria-label="Communities">
+          <a href="{% url 'community' 'news' %}">NEWS</a>
+          <a href="{% url 'community' 'brisbane' %}">BRISBANE</a>
+        </nav>
+
+        <!-- Right: Login/Register or username menu -->
+        <div class="hdr-right">
+          {% include "partials/user_box.html" %}
+        </div>
+
+      </div>
     </header>
+    {% comment %} old subreddit bar removed in favor of hdr-center {% endcomment %}
 
     <main class="container" style="max-width:980px; margin:16px auto;">
       {% if messages %}


### PR DESCRIPTION
## Summary
- Restructured base template header into a 3-column grid with logo & mission left, NEWS/BRISBANE links centered, and user menu on the right.
- Added responsive grid and link styling for new header layout with font size bumps for mission, community, and auth links.
- Included note removing legacy subreddit bar.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa88568dd4832c919679b9f4859fad