### PR TITLE
Add strict HTTPS headers for production

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -49,6 +49,13 @@ SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 SESSION_COOKIE_SECURE = not DEBUG
 CSRF_COOKIE_SECURE = not DEBUG
 
+if not DEBUG:
+    SECURE_SSL_REDIRECT = True
+    SECURE_HSTS_SECONDS = 31536000
+    SECURE_HSTS_INCLUDE_SUBDOMAINS = True
+    SECURE_HSTS_PRELOAD = True
+    SECURE_CONTENT_TYPE_NOSNIFF = True
+
 # -----------------------------------------------------------------------------
 # Apps / Middleware
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Enforce strict HTTPS-related headers when DEBUG is false

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa9a4cd064832c87f7d187f48b451d