### PR TITLE
Add strict Content Security Policy

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -2,7 +2,6 @@
 from pathlib import Path
 import os
 import dj_database_url
-from csp.constants import SELF, UNSAFE_INLINE  # django-csp v4
 
 # -----------------------------------------------------------------------------
 # Base
@@ -55,6 +54,17 @@ if not DEBUG:
     SECURE_HSTS_INCLUDE_SUBDOMAINS = True
     SECURE_HSTS_PRELOAD = True
     SECURE_CONTENT_TYPE_NOSNIFF = True
+    CONTENT_SECURITY_POLICY = {
+        "DIRECTIVES": {
+            "default-src": ("'self'",),
+            "script-src": ("'self'",),  # htmx is local
+            "style-src": ("'self'", "'unsafe-inline'"),  # inline styles allowed for now
+            "img-src": ("'self'", "https:", "data:"),
+            "connect-src": ("'self'",),
+            "frame-ancestors": ("'self'",),
+            "upgrade-insecure-requests": True,
+        }
+    }
 
 # -----------------------------------------------------------------------------
 # Apps / Middleware


### PR DESCRIPTION
## Summary
- configure django-csp with strict default sources and allow inline styles

## Testing
- `pytest -q`
- `python - <<'PY'
import os
os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'config.settings')
import django
django.setup()
from django.test import Client
client = Client()
response = client.get('/nonexistent', secure=True, HTTP_HOST='localhost')
print('status', response.status_code)
print('header', response.headers.get('Content-Security-Policy'))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68aa9aa8ee54832caa2237edce0e2af5