### PR TITLE
Add rate limiting for new users and 429 response page

### DIFF
--- a/core/tests.py
+++ b/core/tests.py
@@ -89,14 +89,14 @@ class SubmitPostTests(TestCase):
 
     def test_rate_limit(self):
         url = reverse("submit_post", args=[self.community.slug])
-        for i in range(30):
+        for i in range(3):
             self.client.post(
                 url,
                 {"post_type": "text", "title": f"H{i}", "body": "", "url": ""},
             )
         resp = self.client.post(
             url,
-            {"post_type": "text", "title": "H30", "body": "", "url": ""},
+            {"post_type": "text", "title": "H3", "body": "", "url": ""},
         )
         self.assertEqual(resp.status_code, 429)
 

--- a/core/tests_comment_reply.py
+++ b/core/tests_comment_reply.py
@@ -52,7 +52,7 @@ class CommentReplyTests(TestCase):
         self.assertEqual(resp.status_code, 302)
 
     def test_rate_limit(self):
-        for i in range(30):
+        for i in range(3):
             self.client.post(self.url, {"body": f"c{i}"}, HTTP_HX_REQUEST="true")
-        resp = self.client.post(self.url, {"body": "c30"}, HTTP_HX_REQUEST="true")
+        resp = self.client.post(self.url, {"body": "c3"}, HTTP_HX_REQUEST="true")
         self.assertEqual(resp.status_code, 429)

--- a/core/views.py
+++ b/core/views.py
@@ -20,10 +20,12 @@ from django.http import HttpResponse, HttpResponseBadRequest, HttpResponseForbid
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils.text import slugify
 from django.db.models import F
+from django.utils import timezone
+from datetime import timedelta
 from django import forms
 
 from .forms import CommentForm, PostForm, CommunityCreateForm
-from .models import Comment, Community, Post, RecoveryCode
+from .models import Comment, Community, Post, RecoveryCode, get_points
 from .votes import apply_vote
 from .pagination import PAGE_SIZE
 
@@ -161,6 +163,10 @@ def _store_codes(user, codes):
     )
 
 
+def is_new_user(user):
+    return (timezone.now() - user.date_joined) < timedelta(hours=24) or get_points(user) <= 0
+
+
 @login_required
 def recovery_codes(request):
     codes = request.session.get("new_recovery_codes")
@@ -290,17 +296,23 @@ def community(request, slug):
 
 @login_required
 @require_http_methods(["GET", "POST"])
-@ratelimit(key="user", rate="30/m", method=["POST"], block=False)
 def submit_post(request, slug):
     """Submit a new post to a community."""
 
     community = get_object_or_404(Community, slug=slug)
+    rate = "3/m" if is_new_user(request.user) else "10/m"
+    limited = is_ratelimited(
+        request,
+        key="user",
+        rate=rate,
+        method=["POST"],
+        increment=True,
+        group="submit_post",
+    )
 
     if request.method == "POST":
-        if getattr(request, "limited", False):
-            resp = HttpResponse("Too many requests", status=429)
-            resp.headers["X-RateLimit-Triggered"] = "1"
-            return resp
+        if limited:
+            return render(request, "429.html", status=429)
         form = PostForm(request.POST, request.FILES)
         if form.is_valid():
             post = form.save(commit=False)
@@ -328,20 +340,13 @@ def post_detail(request, slug, post_id, post_slug):
 
 @login_required
 @require_POST
-@ratelimit(key="user", rate="30/m", method=["POST"], block=False)
 def comment_reply(request, post_id):
     """Create a new comment on a post or comment."""
-
-    if getattr(request, "limited", False):
-        if request.headers.get("HX-Request") == "true":
-            html = render_to_string(
-                "core/partials/ratelimit.html", {"action": "comment"}, request=request
-            )
-            resp = HttpResponse(html, status=429)
-        else:
-            resp = HttpResponse("Too many requests", status=429)
-        resp.headers["X-RateLimit-Triggered"] = "1"
-        return resp
+    rate = "3/m" if is_new_user(request.user) else "10/m"
+    if is_ratelimited(
+        request, key="user", rate=rate, increment=True, group="comment_reply"
+    ):
+        return render(request, "429.html", status=429)
 
     post = get_object_or_404(Post, pk=post_id)
 

--- a/templates/429.html
+++ b/templates/429.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Too Many Requests</title>
+  </head>
+  <body>
+    <p>You're doing that too much. Please wait a moment and try again.</p>
+  </body>
+</html>
+


### PR DESCRIPTION
## Summary
- Add `is_new_user` helper to detect accounts less than a day old or with zero points
- Apply stricter rate limits for new users on post submissions and comments
- Return a simple 429 page when limits are exceeded
- Cover new limits with tests for posts and comments

## Testing
- `DEBUG=1 python manage.py test core.tests.SubmitPostTests.test_rate_limit core.tests_comment_reply.CommentReplyTests.test_rate_limit`


------
https://chatgpt.com/codex/tasks/task_e_68aa9d71021c832c8f54cd44987a6c49