### PR TITLE
Add legal pages and auth notices

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -5,6 +5,7 @@ from django.contrib import admin
 from django.contrib.auth.views import LogoutView
 from django.http import HttpResponse
 from django.urls import path, include
+from django.views.generic import TemplateView
 
 from core import views as core
 
@@ -19,6 +20,9 @@ urlpatterns = [
     ),
     path("accounts/", include("django.contrib.auth.urls")),
     path("accounts/signup/", core.signup, name="signup"),
+    path("terms/", TemplateView.as_view(template_name="legal/terms.html"), name="terms"),
+    path("privacy/", TemplateView.as_view(template_name="legal/privacy.html"), name="privacy"),
+    path("rules/", TemplateView.as_view(template_name="legal/rules.html"), name="rules"),
     path("", include("core.urls")),
 ]
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -48,6 +48,15 @@
       {% endif %}
       {% block content %}{% endblock %}
     </main>
+    <footer class="site-footer">
+      <div class="container" style="max-width:980px; margin:16px auto; text-align:center;">
+        <a href="{% url 'terms' %}">Terms</a>
+        &middot;
+        <a href="{% url 'privacy' %}">Privacy</a>
+        &middot;
+        <a href="{% url 'rules' %}">Rules</a>
+      </div>
+    </footer>
 
       {% block scripts %}{% endblock %}
       {% include "core/_htmx_csrf.html" %}

--- a/templates/legal/privacy.html
+++ b/templates/legal/privacy.html
@@ -1,0 +1,5 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Privacy Policy</h1>
+<p>How we handle your data.</p>
+{% endblock %}

--- a/templates/legal/rules.html
+++ b/templates/legal/rules.html
@@ -1,0 +1,5 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Community Rules</h1>
+<p>Please be respectful and follow the rules.</p>
+{% endblock %}

--- a/templates/legal/terms.html
+++ b/templates/legal/terms.html
@@ -1,0 +1,5 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Terms of Service</h1>
+<p>These are the terms for using SureJan.</p>
+{% endblock %}

--- a/templates/registration/login.html
+++ b/templates/registration/login.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% block content %}
 <h1>Log in</h1>
-<div class="notice">Password reset will be enabled soon. For now, keep your password safe.</div>
+<div class="notice">No email resets during beta—save your password and recovery codes.</div>
 <form method="post" action="{% url 'login' %}" hx-boost="false" hx-swap="none">
   {% csrf_token %}
   {{ form.as_p }}

--- a/templates/registration/signup.html
+++ b/templates/registration/signup.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% block content %}
 <h1>Sign up</h1>
-<div class="notice">Password reset will be enabled soon. For now, keep your password safe.</div>
+<div class="notice">No email resets during beta—save your password and recovery codes.</div>
 <form method="post" hx-boost="false" hx-swap="none">
   {% csrf_token %}
   {{ form.username.errors }}


### PR DESCRIPTION
## Summary
- Add static pages for terms, privacy, and community rules
- Link legal pages in a new site footer
- Clarify beta email reset policy on login and signup forms

## Testing
- `pytest -q`
- `python manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_68aaa2bb25a8832c81bcde3867077b51