### PR TITLE
Hide admin path behind secret slug

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -10,7 +10,7 @@ from django.views.generic import TemplateView
 from core import views as core
 
 urlpatterns = [
-    path("admin/", admin.site.urls),
+    path("_sj-admin-8h9ks3/", admin.site.urls),
     path("healthz", lambda request: HttpResponse("ok"), name="healthz"),
     path("accounts/login/", core.RateLimitedLoginView.as_view(), name="login"),
     path(

--- a/core/tests_admin_url.py
+++ b/core/tests_admin_url.py
@@ -1,0 +1,14 @@
+from django.test import TestCase
+from django.urls import reverse
+
+
+class AdminURLTests(TestCase):
+    def test_old_admin_url_returns_404(self):
+        resp = self.client.get("/admin/", secure=True)
+        self.assertEqual(resp.status_code, 404)
+
+    def test_new_admin_url_redirects(self):
+        url = reverse("admin:index")
+        self.assertEqual(url, "/_sj-admin-8h9ks3/")
+        resp = self.client.get(url, secure=True)
+        self.assertEqual(resp.status_code, 302)


### PR DESCRIPTION
## Summary
- conceal Django admin behind `_sj-admin-8h9ks3/`
- add regression test to ensure old `/admin/` 404s and new path works

## Testing
- `pytest -q`
- `python manage.py test core.tests_admin_url -v 2`
- `python manage.py test` *(fails: KeyError 'signup_captcha_q' and many others)*


------
https://chatgpt.com/codex/tasks/task_e_68aaa397cbb8832ca9f4e9da1525473a