### PR TITLE
Add Sentry error tracking

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -2,6 +2,8 @@
 from pathlib import Path
 import os
 import dj_database_url
+import sentry_sdk
+from sentry_sdk.integrations.django import DjangoIntegration
 
 # -----------------------------------------------------------------------------
 # Base
@@ -13,6 +15,13 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # -----------------------------------------------------------------------------
 SECRET_KEY = os.environ.get("SECRET_KEY", "dev-secret-key")
 DEBUG = os.environ.get("DEBUG", "0") in ("1", "true", "True")
+
+if not DEBUG and (dsn := os.getenv("SENTRY_DSN")):
+    sentry_sdk.init(
+        dsn=dsn,
+        integrations=[DjangoIntegration()],
+        traces_sample_rate=0.1,
+    )
 
 # -----------------------------------------------------------------------------
 # Hosts / CSRF (Fly + optional Render) with env overrides

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ packaging==25.0
 pillow==11.3.0
 psycopg==3.2.9
 psycopg-binary==3.2.9
+sentry-sdk==2.35.0
 sqlparse==0.5.3
 typing_extensions==4.14.1
 tzdata==2025.2


### PR DESCRIPTION
## Summary
- install sentry-sdk dependency
- initialize Sentry in production settings

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aaa5162938832c9bfe1b5f661d6f88