### PR TITLE
docs: mention SENTRY_DSN setup before deployment

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,5 +1,9 @@
 # Deployment
 
+## Environment
+
+Set `SENTRY_DSN` via Fly secrets or environment variables before deploying.
+
 ```bash
 git add -A
 git commit -m "alpha: public signup + header auth + submit CTA + seeds"


### PR DESCRIPTION
## Summary
- Add environment section with reminder to configure `SENTRY_DSN` before deploying

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aaa795a0f4832c995d82da3b87ccaa