### PR TITLE
Remove WhiteNoise manifest override

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -178,10 +178,6 @@ if os.getenv("DJANGO_TESTS") in ("1", "true", "True"):
         "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage"
     }
 
-# Temporary guard to avoid 500s from missing manifest entries while iterating.
-# REMOVE once favicon/static references are correct and collectstatic is clean.
-WHITENOISE_MANIFEST_STRICT = False
-
 MEDIA_URL = "/media/"
 MEDIA_ROOT = BASE_DIR / "media"
 


### PR DESCRIPTION
## Summary
- remove temporary `WHITENOISE_MANIFEST_STRICT` override in settings

## Testing
- `python manage.py collectstatic --noinput`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aaa7b67f78832cadecb92b8fa5e0f0