### PR TITLE
Exempt Fly health check from HTTPS redirect

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -59,6 +59,8 @@ CSRF_COOKIE_SECURE = not DEBUG
 
 if not DEBUG:
     SECURE_SSL_REDIRECT = True
+    # Exempt Fly’s HTTP health probe hitting internal :8000
+    SECURE_REDIRECT_EXEMPT = [r"^healthz$"]
     SECURE_HSTS_SECONDS = 31536000
     SECURE_HSTS_INCLUDE_SUBDOMAINS = True
     SECURE_HSTS_PRELOAD = True


### PR DESCRIPTION
## Summary
- allow Fly's internal health check to skip SSL redirect

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aaaa8e86cc832c93a0c421e6449796