### PR TITLE
Tighten new user rate limiting

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -170,7 +170,7 @@ def _store_codes(user, codes):
 
 
 def is_new_user(user):
-    return (timezone.now() - user.date_joined) < timedelta(hours=24) or get_points(user) <= 0
+    return (timezone.now() - user.date_joined) < timedelta(hours=24) or get_points(user) == 0
 
 
 @login_required

--- a/templates/429.html
+++ b/templates/429.html
@@ -5,6 +5,7 @@
     <title>Too Many Requests</title>
   </head>
   <body>
+    <h1>Too Many Requests</h1>
     <p>You're doing that too much. Please wait a moment and try again.</p>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- refine new-user detection to check for zero points exactly
- display a clearer heading on the 429 Too Many Requests page

## Testing
- `DEBUG=1 DJANGO_TESTS=1 python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68aaafb47050832c84d51e0f73367bbe