### PR TITLE
Pin psycopg and whitenoise dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,10 +9,9 @@ argon2-cffi==23.1.0
 gunicorn==23.0.0
 packaging==25.0
 pillow==11.3.0
-psycopg==3.2.9
-psycopg-binary==3.2.9
+psycopg[binary]==3.2.9
 sentry-sdk==2.35.0
 sqlparse==0.5.3
 typing_extensions==4.14.1
 tzdata==2025.2
-whitenoise>=6.6
+whitenoise==6.6.0


### PR DESCRIPTION
## Summary
- Consolidate `psycopg` and `psycopg-binary` into a single `psycopg[binary]` requirement.
- Pin `whitenoise` to a specific version for reproducible installs.

## Testing
- `python -m pip install -r requirements.txt`
- `python -m pip check`


------
https://chatgpt.com/codex/tasks/task_e_68aab361b1a0832c86f598fa668f9982