### PR TITLE
Add account-age aware rate limits for posting and commenting

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,12 @@
 
 **Admin-only note for MVP setup:** seed two communities (News, Brisbane) via a management command or admin page.
 
+## Rate Limits
+
+Post and comment creation are rate limited based on account age:
+
+* New users (signed up within 24 hours or with zero points) may create up to 3 posts or comments per minute.
+* Established users may create up to 10 posts or comments per minute.
+
+Exceeding these limits returns an HTTP 429 response that tells you how long to wait before trying again.
+

--- a/core/ratelimit.py
+++ b/core/ratelimit.py
@@ -1,17 +1,29 @@
 """Simple per-user rate limiting decorator using Django cache."""
 
 from functools import wraps
+from datetime import timedelta
+
 from django.core.cache import cache
-from django.http import HttpResponse
-from django.template.loader import render_to_string
+from django.shortcuts import render
+from django.utils import timezone
+
+from .models import get_points
 
 
-def ratelimit(*, key="user", action: str, limit: int, window: int = 60):
-    """Limit ``action`` executions per ``window`` seconds for the given key.
+def _is_new_user(user):
+    return (timezone.now() - user.date_joined) < timedelta(hours=24) or get_points(user) == 0
+
+
+def ratelimit(*, key="user", action: str, limit, window: int = 60):
+    """Limit ``action`` executions per ``window`` seconds.
+
+    ``limit`` may be an ``int`` or a ``(new_limit, old_limit)`` tuple. When a
+    tuple is supplied the user's signup age determines which limit applies.
 
     Only ``key='user'`` is supported. The caller must ensure the user is
     authenticated. When the limit is exceeded a ``429`` response is returned.
     If the request originated from HTMX a small message partial is rendered.
+    A ``Retry-After`` header is included so clients know when to retry.
     """
 
     if key != "user":
@@ -27,15 +39,23 @@ def ratelimit(*, key="user", action: str, limit: int, window: int = 60):
             if not request.user.is_authenticated:
                 return view_func(request, *args, **kwargs)
 
+            limit_value = limit
+            if isinstance(limit, tuple):
+                new_limit, old_limit = limit
+                limit_value = new_limit if _is_new_user(request.user) else old_limit
+
             cache_key = f"rl:{action}:{request.user.pk}"
             count = cache.get(cache_key, 0)
-            if count >= limit:
+            if count >= limit_value:
+                context = {"action": action, "retry_after": window}
                 if request.headers.get("HX-Request") == "true":
-                    html = render_to_string(
-                        "core/partials/ratelimit.html", {"action": action}, request=request
+                    resp = render(
+                        request, "core/partials/ratelimit.html", context, status=429
                     )
-                    return HttpResponse(html, status=429)
-                return HttpResponse("Too many requests", status=429)
+                else:
+                    resp = render(request, "429.html", context, status=429)
+                resp.headers["Retry-After"] = str(window)
+                return resp
 
             if count == 0:
                 cache.add(cache_key, 1, window)
@@ -47,4 +67,3 @@ def ratelimit(*, key="user", action: str, limit: int, window: int = 60):
         return _wrapped
 
     return decorator
-

--- a/core/views.py
+++ b/core/views.py
@@ -20,14 +20,13 @@ from django.http import HttpResponse, HttpResponseBadRequest, HttpResponseForbid
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils.text import slugify
 from django.db.models import F
-from django.utils import timezone
-from datetime import timedelta
 from django import forms
 
 from django.contrib.contenttypes.models import ContentType
 
 from .forms import CommentForm, PostForm, CommunityCreateForm
-from .models import Comment, Community, Post, RecoveryCode, get_points, Report
+from .models import Comment, Community, Post, RecoveryCode, Report
+from .ratelimit import ratelimit as age_ratelimit
 from .votes import apply_vote
 from .pagination import PAGE_SIZE
 
@@ -167,12 +166,6 @@ def _store_codes(user, codes):
     RecoveryCode.objects.bulk_create(
         [RecoveryCode(user=user, code_hash=make_password(c)) for c in codes]
     )
-
-
-def is_new_user(user):
-    return (timezone.now() - user.date_joined) < timedelta(hours=24) or get_points(user) == 0
-
-
 @login_required
 def recovery_codes(request):
     codes = request.session.get("new_recovery_codes")
@@ -304,25 +297,15 @@ def community(request, slug):
 
 @login_required
 @require_http_methods(["GET", "POST"])
+@age_ratelimit(action="submit_post", limit=(3, 10), window=60)
 def submit_post(request, slug):
     """Submit a new post to a community."""
 
     community = get_object_or_404(Community, slug=slug)
     if _is_banned(request.user):
         return HttpResponseForbidden("Account banned")
-    rate = "3/m" if is_new_user(request.user) else "10/m"
-    limited = is_ratelimited(
-        request,
-        key="user",
-        rate=rate,
-        method=["POST"],
-        increment=True,
-        group="submit_post",
-    )
 
     if request.method == "POST":
-        if limited:
-            return render(request, "429.html", status=429)
         form = PostForm(request.POST, request.FILES)
         if form.is_valid():
             post = form.save(commit=False)
@@ -350,15 +333,11 @@ def post_detail(request, slug, post_id, post_slug):
 
 @login_required
 @require_POST
+@age_ratelimit(action="comment_reply", limit=(3, 10), window=60)
 def comment_reply(request, post_id):
     """Create a new comment on a post or comment."""
     if _is_banned(request.user):
         return HttpResponseForbidden("Account banned")
-    rate = "3/m" if is_new_user(request.user) else "10/m"
-    if is_ratelimited(
-        request, key="user", rate=rate, increment=True, group="comment_reply"
-    ):
-        return render(request, "429.html", status=429)
 
     post = get_object_or_404(Post, pk=post_id)
 

--- a/templates/429.html
+++ b/templates/429.html
@@ -6,7 +6,6 @@
   </head>
   <body>
     <h1>Too Many Requests</h1>
-    <p>You're doing that too much. Please wait a moment and try again.</p>
+    <p>You're doing that too much. Please wait {{ retry_after }} seconds and try again.</p>
   </body>
 </html>
-

--- a/templates/core/partials/ratelimit.html
+++ b/templates/core/partials/ratelimit.html
@@ -1,1 +1,1 @@
-<div class="alert">Slow down! You're doing that too much. Try again in a minute.</div>
+<div class="alert">Slow down! You're doing that too much. Try again in {{ retry_after }} seconds.</div>


### PR DESCRIPTION
## Summary
- add reusable rate limit decorator that varies limits for new vs. established accounts and returns 429 with Retry-After
- apply rate limiting to post and comment creation views
- document posting and commenting limits for new and established users

## Testing
- `python manage.py test -v 2` *(fails: django-csp < 4.0 settings)*

------
https://chatgpt.com/codex/tasks/task_e_68aab50367a0832c8a45ca6174f03429