### PR TITLE
Secure Django admin behind secret path with IP allowlist

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -85,6 +85,16 @@ if not DEBUG:
     }
 
 # -----------------------------------------------------------------------------
+# Admin
+# -----------------------------------------------------------------------------
+ADMIN_URL = os.environ.get("DJANGO_ADMIN_URL", "secret-admin/").strip("/") + "/"
+ADMIN_IP_ALLOWLIST = {
+    ip.strip()
+    for ip in os.environ.get("ADMIN_IP_ALLOWLIST", "").split(",")
+    if ip.strip()
+}
+
+# -----------------------------------------------------------------------------
 # Apps / Middleware
 # -----------------------------------------------------------------------------
 INSTALLED_APPS = [
@@ -101,6 +111,7 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
+    "core.middleware.AdminIPAllowlistMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",  # static files
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",

--- a/config/urls.py
+++ b/config/urls.py
@@ -10,7 +10,7 @@ from django.views.generic import TemplateView
 from core import views as core
 
 urlpatterns = [
-    path("_sj-admin-8h9ks3/", admin.site.urls),
+    path(settings.ADMIN_URL, admin.site.urls),
     path("healthz", lambda request: HttpResponse("ok"), name="healthz"),
     path("accounts/login/", core.RateLimitedLoginView.as_view(), name="login"),
     path(

--- a/core/middleware.py
+++ b/core/middleware.py
@@ -1,0 +1,21 @@
+from django.conf import settings
+from django.http import HttpResponseForbidden
+
+
+class AdminIPAllowlistMiddleware:
+    """Restrict admin access to IPs in settings.ADMIN_IP_ALLOWLIST."""
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+        self.prefix = "/" + settings.ADMIN_URL
+
+    def __call__(self, request):
+        allowlist = getattr(settings, "ADMIN_IP_ALLOWLIST", set())
+        if allowlist and request.path.startswith(self.prefix):
+            # Prefer X-Forwarded-For header if present (take first IP)
+            ip = request.META.get("HTTP_X_FORWARDED_FOR", "").split(",")[0].strip()
+            if not ip:
+                ip = request.META.get("REMOTE_ADDR", "")
+            if ip not in allowlist:
+                return HttpResponseForbidden("Forbidden")
+        return self.get_response(request)

--- a/core/tests_admin_url.py
+++ b/core/tests_admin_url.py
@@ -1,4 +1,4 @@
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.urls import reverse
 
 
@@ -9,6 +9,16 @@ class AdminURLTests(TestCase):
 
     def test_new_admin_url_redirects(self):
         url = reverse("admin:index")
-        self.assertEqual(url, "/_sj-admin-8h9ks3/")
+        self.assertEqual(url, "/secret-admin/")
         resp = self.client.get(url, secure=True)
+        self.assertEqual(resp.status_code, 302)
+
+    @override_settings(ADMIN_IP_ALLOWLIST={"1.1.1.1"})
+    def test_admin_blocked_for_non_allowlisted_ip(self):
+        resp = self.client.get("/secret-admin/", REMOTE_ADDR="2.2.2.2", secure=True)
+        self.assertEqual(resp.status_code, 403)
+
+    @override_settings(ADMIN_IP_ALLOWLIST={"1.1.1.1"})
+    def test_admin_allowed_for_allowlisted_ip(self):
+        resp = self.client.get("/secret-admin/", REMOTE_ADDR="1.1.1.1", secure=True)
         self.assertEqual(resp.status_code, 302)

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -2,7 +2,10 @@
 
 ## Environment
 
-Set `SENTRY_DSN` via Fly secrets or environment variables before deploying.
+Set `SENTRY_DSN` via Fly secrets or environment variables before deploying. The
+Django admin lives at `/secret-admin/`; restrict it by setting an
+`ADMIN_IP_ALLOWLIST` environment variable with a comma-separated list of
+allowed IPs.
 
 ```bash
 git add -A
@@ -20,3 +23,4 @@ flyctl logs -a surejan | Select-String -Pattern "ERROR|Traceback|favicon|collect
 * `/accounts/signup/` → create user, header shows username.
 * `/r/news/` → "Submit" visible (logged-in), post appears in feed.
 * Vote/comment work; anonymous users get redirected to login for writes.
+* `/secret-admin/` → admin login loads (only from allowlisted IPs if set).


### PR DESCRIPTION
## Summary
- Move admin interface to `/secret-admin/`
- Add middleware to optionally allowlist admin access by IP
- Document new admin URL and allowlist environment variable

## Testing
- `python manage.py test core.tests_admin_url` *(fails: django-csp settings E001)*

------
https://chatgpt.com/codex/tasks/task_e_68aac41394b0832cb438e1d5008226ae