### PR TITLE
Add legal pages and update authentication notices

### DIFF
--- a/templates/legal/privacy.html
+++ b/templates/legal/privacy.html
@@ -1,5 +1,13 @@
 {% extends "base.html" %}
 {% block content %}
-<h1>Privacy Policy</h1>
-<p>How we handle your data.</p>
+<h1>🔒 Privacy Policy (SureJan)</h1>
+<p>Your privacy matters. Here’s how SureJan handles your information:</p>
+<ul>
+  <li><strong>Data We Collect</strong> – Username, email (if provided), and posts/comments you create.</li>
+  <li><strong>How We Use It</strong> – To run the site, maintain accounts, and improve community experience.</li>
+  <li><strong>What We Don’t Do</strong> – We don’t sell your data.</li>
+  <li><strong>Cookies</strong> – Basic cookies may be used to keep you logged in and improve browsing.</li>
+  <li><strong>Third Parties</strong> – If we use outside services (like hosting or analytics), they’ll only receive what’s needed to keep the site running.</li>
+  <li><strong>Your Control</strong> – You can delete your account or request removal of content by contacting the admin.</li>
+</ul>
 {% endblock %}

--- a/templates/legal/rules.html
+++ b/templates/legal/rules.html
@@ -1,5 +1,14 @@
 {% extends "base.html" %}
 {% block content %}
-<h1>Community Rules</h1>
-<p>Please be respectful and follow the rules.</p>
+<h1>📖 Community Rules (SureJan)</h1>
+<p>SureJan is about open, respectful discussion. These are the ground rules:</p>
+<ul>
+  <li><strong>Be Free, But Respectful</strong> – Debate is welcome; harassment is not.</li>
+  <li><strong>No Spam or Scams</strong> – Keep the feed clear of junk, ads, or malicious links.</li>
+  <li><strong>Legal Content Only</strong> – No illegal material, threats, or incitement.</li>
+  <li><strong>Mark Sensitive Content</strong> – If posting NSFW or graphic content, clearly label it.</li>
+  <li><strong>Local First</strong> – Since SureJan is about Brisbane, local topics are encouraged.</li>
+  <li><strong>Minimal Moderation</strong> – We prefer self-regulation. Mods will only step in if things go off the rails.</li>
+</ul>
+<p><small>Last updated: 24/08/2025</small></p>
 {% endblock %}

--- a/templates/legal/terms.html
+++ b/templates/legal/terms.html
@@ -1,5 +1,13 @@
 {% extends "base.html" %}
 {% block content %}
-<h1>Terms of Service</h1>
-<p>These are the terms for using SureJan.</p>
+<h1>📜 Terms of Use (SureJan)</h1>
+<p>Welcome to SureJan, a community forum for Brisbane. By using this site, you agree to these terms:</p>
+<ul>
+  <li><strong>Free Expression</strong> – You’re encouraged to share your opinions, ideas, and discussions freely.</li>
+  <li><strong>Respect Others</strong> – Healthy debate is fine, but harassment, hate speech, and targeted abuse are not.</li>
+  <li><strong>Your Content</strong> – What you post is yours. By posting, you give SureJan permission to display and distribute it within the site.</li>
+  <li><strong>No Liability</strong> – Posts are created by users, not the site. SureJan is not responsible for the accuracy or consequences of user content.</li>
+  <li><strong>Moderation</strong> – We’ll only step in when necessary: spam, illegal content, or threats of harm may be removed.</li>
+  <li><strong>Changes</strong> – These terms may be updated as the community grows.</li>
+</ul>
 {% endblock %}

--- a/templates/registration/login.html
+++ b/templates/registration/login.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% block content %}
 <h1>Log in</h1>
-<div class="notice">No email resets during beta—save your password and recovery codes.</div>
+<div class="notice">No email resets—use recovery codes.</div>
 <form method="post" action="{% url 'login' %}" hx-boost="false" hx-swap="none">
   {% csrf_token %}
   {{ form.as_p }}
@@ -12,4 +12,5 @@
   <button>Log in</button>
 </form>
 <p>No account? <a href="{% url 'signup' %}">Sign up</a></p>
+<p><a href="{% url 'terms' %}">Terms</a> &middot; <a href="{% url 'privacy' %}">Privacy</a> &middot; <a href="{% url 'rules' %}">Rules</a></p>
 {% endblock %}

--- a/templates/registration/signup.html
+++ b/templates/registration/signup.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% block content %}
 <h1>Sign up</h1>
-<div class="notice">No email resets during beta—save your password and recovery codes.</div>
+<div class="notice">No email resets—use recovery codes.</div>
 <form method="post" hx-boost="false" hx-swap="none">
   {% csrf_token %}
   {{ form.username.errors }}
@@ -16,4 +16,5 @@
   <button>Create account</button>
 </form>
 <p>Already have an account? <a href="{% url 'login' %}">Log in</a></p>
+<p>By creating an account, you agree to our <a href="{% url 'terms' %}">Terms</a>, <a href="{% url 'privacy' %}">Privacy Policy</a>, and <a href="{% url 'rules' %}">Community Rules</a>.</p>
 {% endblock %}


### PR DESCRIPTION
## Summary
- flesh out Terms, Privacy Policy, and Community Rules pages
- warn users about lack of email resets during login and signup
- link legal pages in authentication workflow

## Testing
- `python manage.py test` *(fails: django-csp < 4.0 settings error)*

------
https://chatgpt.com/codex/tasks/task_e_68aac5f43e48832c81f1508e25de2b66