### PR TITLE
Add Sentry DSN init and database/cache health checks

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -16,7 +16,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 SECRET_KEY = os.environ.get("SECRET_KEY", "dev-secret-key")
 DEBUG = os.environ.get("DEBUG", "0") in ("1", "true", "True")
 
-if not DEBUG and (dsn := os.getenv("SENTRY_DSN")):
+if dsn := os.getenv("SENTRY_DSN"):
     sentry_sdk.init(
         dsn=dsn,
         integrations=[DjangoIntegration()],

--- a/config/urls.py
+++ b/config/urls.py
@@ -3,7 +3,6 @@ from django.conf import settings
 from django.conf.urls.static import static as serve_static
 from django.contrib import admin
 from django.contrib.auth.views import LogoutView
-from django.http import HttpResponse
 from django.urls import path, include
 from django.views.generic import TemplateView
 
@@ -11,7 +10,7 @@ from core import views as core
 
 urlpatterns = [
     path(settings.ADMIN_URL, admin.site.urls),
-    path("healthz", lambda request: HttpResponse("ok"), name="healthz"),
+    path("healthz", core.healthz, name="healthz"),
     path("accounts/login/", core.RateLimitedLoginView.as_view(), name="login"),
     path(
         "accounts/logout/",

--- a/core/tests_healthz.py
+++ b/core/tests_healthz.py
@@ -1,5 +1,8 @@
+from unittest.mock import patch
+
 from django.test import TestCase
 from django.urls import reverse
+from django.db.utils import OperationalError
 
 
 class HealthzTests(TestCase):
@@ -7,3 +10,15 @@ class HealthzTests(TestCase):
         resp = self.client.get(reverse("healthz"))
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.content, b"ok")
+
+    @patch("core.views.connections")
+    def test_healthz_db_failure(self, mock_connections):
+        mock_connections.__getitem__.return_value.cursor.side_effect = OperationalError
+        resp = self.client.get(reverse("healthz"))
+        self.assertEqual(resp.status_code, 500)
+
+    @patch("core.views.cache")
+    def test_healthz_cache_failure(self, mock_cache):
+        mock_cache.set.side_effect = Exception
+        resp = self.client.get(reverse("healthz"))
+        self.assertEqual(resp.status_code, 500)

--- a/core/views.py
+++ b/core/views.py
@@ -23,6 +23,8 @@ from django.db.models import F
 from django import forms
 
 from django.contrib.contenttypes.models import ContentType
+from django.core.cache import cache
+from django.db import connections
 
 from .forms import CommentForm, PostForm, CommunityCreateForm
 from .models import Comment, Community, Post, RecoveryCode, Report
@@ -36,7 +38,13 @@ def _is_banned(user):
 
 
 def healthz(_request):
-    """Simple health check endpoint."""
+    """Health check verifying database and cache connectivity."""
+    try:
+        connections["default"].cursor()
+        cache.set("healthz", "ok", 1)
+        cache.get("healthz")
+    except Exception:
+        return HttpResponse("unhealthy", status=500, content_type="text/plain")
     return HttpResponse("ok", content_type="text/plain")
 
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -93,7 +93,7 @@ primary_region = "syd"
     interval = "30s"
     timeout = "5s"
     method = "GET"
-    path = "/"
+    path = "/healthz"
 
 [[vm]]
   cpu_kind = "shared"
@@ -111,7 +111,8 @@ else
       if(!have_build){print "\n[build]"; print "  dockerfile = \"Dockerfile\""}
       else if(!have_df){print "  dockerfile = \"Dockerfile\""}
     }' fly.toml | \
-  awk '{sub(/internal_port *= *[0-9]+/,"internal_port = 8000")}1' > .fly.toml.tmp
+  awk '{sub(/internal_port *= *[0-9]+/,"internal_port = 8000")}1' | \
+  awk '{sub(/path *= *"[^"]*"/,"path = \"/healthz\"")}1' > .fly.toml.tmp
   mv .fly.toml.tmp fly.toml
 fi
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -2,10 +2,11 @@
 
 ## Environment
 
-Set `SENTRY_DSN` via Fly secrets or environment variables before deploying. The
-Django admin lives at `/secret-admin/`; restrict it by setting an
+Set `SENTRY_DSN` via Fly secrets or environment variables before deploying.
+The Django admin lives at `/secret-admin/`; restrict it by setting an
 `ADMIN_IP_ALLOWLIST` environment variable with a comma-separated list of
-allowed IPs.
+allowed IPs. The app exposes `/healthz` which checks database and cache
+connectivity; point your uptime monitor at this path.
 
 ```bash
 git add -A

--- a/docs/uptime.md
+++ b/docs/uptime.md
@@ -1,0 +1,15 @@
+# Uptime monitoring
+
+The `/healthz` endpoint performs basic checks for the database and cache.
+Configure an external service such as UptimeRobot to poll it and alert if
+it fails.
+
+## Example (UptimeRobot)
+
+1. Create a new **HTTPS** monitor with the URL
+   `https://<APP>.fly.dev/healthz` (replace `<APP>` with the Fly app name).
+2. Choose an interval (e.g. 5 minutes).
+3. Select the notification channels (email, Slack, etc.).
+
+Fly's internal health checks are defined in `fly.toml`, but an external
+monitor provides visibility if the app becomes unreachable.


### PR DESCRIPTION
## Summary
- initialize Sentry when a SENTRY_DSN is provided
- expose `/healthz` endpoint checking database and cache connections
- document uptime monitoring and point Fly deploy script's health check to `/healthz`

## Testing
- `DEBUG=1 python manage.py test core.tests_healthz`
- `DEBUG=1 DJANGO_TESTS=1 python manage.py test` *(fails: ValueError: The file 'css/base.css' could not be found)*


------
https://chatgpt.com/codex/tasks/task_e_68aac6bf0820832c960820c287969212