### PR TITLE
Resize uploads and add thumbnails

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -12,7 +12,10 @@ class PostForm(forms.ModelForm):
     def clean_image(self):
         image = self.cleaned_data.get("image")
         if image:
-            validate_image_file(image)
+            try:
+                validate_image_file(image)
+            except forms.ValidationError as e:
+                raise e
         return image
 
     def clean(self):

--- a/core/models.py
+++ b/core/models.py
@@ -41,14 +41,11 @@ def _resize_img(file, max_px=1600):
     return ContentFile(buf.getvalue(), name=f"{name}.jpg")
 
 
-def _make_thumb(file, height=400):
+def _make_thumb(file, max_px=400):
     file.seek(0)
     img = Image.open(file)
     img = img.convert("RGB")
-    w, h = img.size
-    if h > height:
-        ratio = height / float(h)
-        img = img.resize((int(w * ratio), height), Image.LANCZOS)
+    img.thumbnail((max_px, max_px), Image.LANCZOS)
     buf = BytesIO()
     img.save(buf, format="JPEG", quality=80, optimize=True)
     name, _ = os.path.splitext(getattr(file, "name", "thumb"))


### PR DESCRIPTION
## Summary
- validate uploaded images and generate 400px thumbnails for posts
- run image validation during form cleaning
- ensure feed uses thumbnails when available

## Testing
- `python manage.py test` *(fails: FAILED (failures=40, errors=17))*

------
https://chatgpt.com/codex/tasks/task_e_68aacb99f7cc832c992daf5b11189e9b