### PR TITLE
Add user banning controls for moderation

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -85,6 +85,8 @@ class VoteAdmin(admin.ModelAdmin):
 class UserProfileInline(admin.StackedInline):
     model = UserProfile
     can_delete = False
+    fields = ("points_cached", "is_banned")
+    readonly_fields = ("points_cached",)
 
 
 class UserAdmin(BaseUserAdmin):

--- a/core/tests_ban_user.py
+++ b/core/tests_ban_user.py
@@ -1,0 +1,43 @@
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+
+from .models import Community, Post
+
+
+class BanUserTests(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.staff = User.objects.create_user(
+            "mod", password="pwd", is_staff=True
+        )
+        self.user = User.objects.create_user("alice", password="pwd")
+        self.community = Community.objects.create(
+            slug="t", name="Test", title="Test", created_by=self.staff
+        )
+        self.post = Post.objects.create(
+            community=self.community,
+            author=self.staff,
+            post_type="text",
+            title="hello",
+        )
+
+    def test_ban_and_unban_user(self):
+        self.client.login(username="mod", password="pwd")
+        resp = self.client.post(reverse("ban_user", args=[self.user.username]))
+        self.assertRedirects(resp, reverse("user_overview", args=[self.user.username]))
+        self.user.refresh_from_db()
+        self.assertTrue(self.user.profile.is_banned)
+
+        self.client.logout()
+        self.client.login(username="alice", password="pwd")
+        resp = self.client.post(
+            reverse("comment_reply", args=[self.post.pk]), {"body": "hi"}
+        )
+        self.assertEqual(resp.status_code, 403)
+
+        self.client.logout()
+        self.client.login(username="mod", password="pwd")
+        self.client.post(reverse("unban_user", args=[self.user.username]))
+        self.user.refresh_from_db()
+        self.assertFalse(self.user.profile.is_banned)

--- a/core/urls.py
+++ b/core/urls.py
@@ -49,4 +49,6 @@ urlpatterns = [
     path("u/<str:username>/", core_views.user_overview, name="user_overview"),
     path("u/<str:username>/comments/", core_views.user_comments, name="user_comments"),
     path("u/<str:username>/submitted/", core_views.user_submitted, name="user_submitted"),
+    path("u/<str:username>/ban/", core_views.ban_user, name="ban_user"),
+    path("u/<str:username>/unban/", core_views.unban_user, name="unban_user"),
 ]

--- a/core/views.py
+++ b/core/views.py
@@ -391,6 +391,8 @@ def comment_reply(request, post_id):
 def comment_reply_form(request, post_id):
     """Render the comment reply form via HTMX."""
 
+    if _is_banned(request.user):
+        return HttpResponseForbidden("Account banned")
     if request.headers.get("HX-Request") != "true":
         return HttpResponseBadRequest("Invalid request")
 
@@ -608,6 +610,36 @@ def user_submitted(request, username):
         "tab": "submitted",
     }
     return render(request, "core/user_submitted.html", context)
+
+
+@login_required
+@require_POST
+@csrf_protect
+def ban_user(request, username):
+    if _is_banned(request.user):
+        return HttpResponseForbidden("Account banned")
+    if not request.user.is_staff:
+        return HttpResponseForbidden("Forbidden")
+    user = _get_profile_user(username)
+    if user == request.user:
+        return HttpResponseForbidden("Cannot modify yourself")
+    user.profile.is_banned = True
+    user.profile.save(update_fields=["is_banned"])
+    return redirect("user_overview", username=username)
+
+
+@login_required
+@require_POST
+@csrf_protect
+def unban_user(request, username):
+    if _is_banned(request.user):
+        return HttpResponseForbidden("Account banned")
+    if not request.user.is_staff:
+        return HttpResponseForbidden("Forbidden")
+    user = _get_profile_user(username)
+    user.profile.is_banned = False
+    user.profile.save(update_fields=["is_banned"])
+    return redirect("user_overview", username=username)
 
 
 @login_required

--- a/templates/core/partials/user_tab_bar.html
+++ b/templates/core/partials/user_tab_bar.html
@@ -5,5 +5,18 @@
   <a href="{% url 'user_comments' profile_user.username %}" class="{% if current == 'comments' %}active{% endif %}">Comments</a>
   <a href="{% url 'user_submitted' profile_user.username %}" class="{% if current == 'submitted' %}active{% endif %}">Submitted</a>
 </nav>
+{% if request.user.is_staff and request.user != profile_user %}
+  {% if profile_user.profile.is_banned %}
+    <form method="post" action="{% url 'unban_user' profile_user.username %}">
+      {% csrf_token %}
+      <button type="submit">Unban user</button>
+    </form>
+  {% else %}
+    <form method="post" action="{% url 'ban_user' profile_user.username %}">
+      {% csrf_token %}
+      <button type="submit">Ban user</button>
+    </form>
+  {% endif %}
+{% endif %}
 {% endwith %}
 


### PR DESCRIPTION
## Summary
- expose UserProfile.is_banned in admin
- allow staff to ban or unban users via new views and profile actions
- block banned users from using comment reply form and add regression test

## Testing
- `DEBUG=1 DJANGO_TESTS=1 python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68aace0ec5a4832c84ea03f5c5109a09