### PR TITLE
Add simple report view and admin reporting tools

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -100,3 +100,4 @@ admin.site.register(get_user_model(), UserAdmin)
 @admin.register(Report)
 class ReportAdmin(admin.ModelAdmin):
     list_display = ("id", "reporter", "content_type", "object_id", "created_at")
+    list_filter = ("content_type", "reporter")

--- a/core/urls.py
+++ b/core/urls.py
@@ -43,7 +43,8 @@ urlpatterns = [
     path("vote/comment/<int:pk>/", core_views.vote_comment, name="vote_comment"),
     # Post moderation
     path("post/<int:pk>/delete/", core_views.post_delete, name="post_delete"),
-    path("report/<str:target_type>/<int:pk>/", core_views.report, name="report"),
+    path("report/", core_views.report, name="report"),
+    path("reports/", core_views.report_list, name="report_list"),
 
     # User pages
     path("u/<str:username>/", core_views.user_overview, name="user_overview"),

--- a/core/views.py
+++ b/core/views.py
@@ -13,6 +13,7 @@ from django.contrib.auth.views import LoginView
 from django.utils.decorators import method_decorator
 from django.views.decorators.http import require_POST, require_http_methods
 from django.views.decorators.csrf import csrf_protect
+from django.contrib.admin.views.decorators import staff_member_required
 from django_ratelimit.decorators import ratelimit, is_ratelimited
 from django.template.loader import render_to_string
 
@@ -510,15 +511,29 @@ def vote_comment(request, pk):
 @login_required
 @require_http_methods(["GET", "POST"])
 @csrf_protect
-def report(request, target_type, pk):
+def report(request):
+    """Allow users to report posts or comments."""
     if _is_banned(request.user):
         return HttpResponseForbidden("Account banned")
-    if target_type == "post":
-        target = get_object_or_404(Post, pk=pk)
-    elif target_type == "comment":
-        target = get_object_or_404(Comment, pk=pk)
+
+    if request.method == "POST":
+        target_type = request.POST.get("target_type")
+        object_id = request.POST.get("object_id")
     else:
+        target_type = request.GET.get("target_type")
+        object_id = request.GET.get("object_id")
+
+    if target_type not in {"post", "comment"}:
         return HttpResponseBadRequest("Invalid target")
+
+    try:
+        object_id = int(object_id)
+    except (TypeError, ValueError):
+        return HttpResponseBadRequest("Invalid object id")
+
+    model = Post if target_type == "post" else Comment
+    target = get_object_or_404(model, pk=object_id)
+
     if request.method == "POST":
         reason = request.POST.get("reason", "")
         Report.objects.create(
@@ -528,7 +543,19 @@ def report(request, target_type, pk):
             reason=reason,
         )
         return render(request, "core/report_form.html", {"thanks": True})
-    return render(request, "core/report_form.html", {"target": target})
+
+    return render(
+        request,
+        "core/report_form.html",
+        {"target": target, "target_type": target_type, "object_id": object_id},
+    )
+
+
+@staff_member_required
+def report_list(request):
+    """Simple listing view for recent reports."""
+    reports = Report.objects.select_related("reporter", "content_type").order_by("-created_at")
+    return render(request, "core/report_list.html", {"reports": reports})
 
 
 def community_wiki(request, slug):

--- a/templates/core/partials/post_row.html
+++ b/templates/core/partials/post_row.html
@@ -23,7 +23,7 @@
       · {{ post.created_at|timesince }} ago
       · <a href="{% url 'post_detail' post.community.slug post.pk post.title|slugify %}">{{ post.comment_count }} comments</a>
       {% if user.is_authenticated %}
-      · <a href="{% url 'report' 'post' post.pk %}">[report]</a>
+      · <a href="{% url 'report' %}?target_type=post&object_id={{ post.pk }}">[report]</a>
       {% endif %}
       {% if user.is_staff %}
       <!-- staff moderation controls -->

--- a/templates/core/post_detail.html
+++ b/templates/core/post_detail.html
@@ -35,7 +35,7 @@
         <a href="#" onclick="navigator.clipboard.writeText(window.location.href);return false;">share</a>
         <a href="{% url 'community' post.community.slug %}">back to r/{{ post.community.slug }}</a>
         {% if user.is_authenticated %}
-        <a href="{% url 'report' 'post' post.pk %}">[report]</a>
+        <a href="{% url 'report' %}?target_type=post&object_id={{ post.pk }}">[report]</a>
         {% endif %}
         {% if user.is_staff %}
         <form action="{% url 'post_delete' post.pk %}" method="post" style="display:inline">

--- a/templates/core/report_form.html
+++ b/templates/core/report_form.html
@@ -7,6 +7,9 @@
 {% else %}
 <form method="post">
   {% csrf_token %}
+  <input type="hidden" name="target_type" value="{{ target_type }}">
+  <input type="hidden" name="object_id" value="{{ object_id }}">
+  {% if target %}<p>Reporting {{ target }}</p>{% endif %}
   <label for="id_reason">Reason:</label>
   <textarea id="id_reason" name="reason" required></textarea>
   <button type="submit">Submit</button>

--- a/templates/core/report_list.html
+++ b/templates/core/report_list.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+
+{% block content %}
+<h1>Reports</h1>
+<ul>
+  {% for r in reports %}
+  <li>{{ r.created_at }} - {{ r.reporter }} reported {{ r.content_type }} {{ r.object_id }}: {{ r.reason }}</li>
+  {% empty %}
+  <li>No reports.</li>
+  {% endfor %}
+</ul>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Add POST-driven report view with hidden fields and staff listing page
- Expose report endpoints in URL config and templates
- Register reports with filter in admin for easy review

## Testing
- `pytest` *(no tests collected)*
- `python manage.py test` *(fail: FAILURES=41, ERRORS=17)*

------
https://chatgpt.com/codex/tasks/task_e_68aacfae000c832ca70dde919fc4f601