### PR TITLE
Check and block unsafe link submissions

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -2,6 +2,7 @@ from django import forms
 from django.utils.text import slugify
 
 from .models import Comment, Post, Community, validate_image_file
+from .utils.link_safety import check_url_safety
 
 
 class PostForm(forms.ModelForm):
@@ -37,6 +38,9 @@ class PostForm(forms.ModelForm):
         if post_type == "link":
             if not url:
                 self.add_error("url", "URL is required for link posts.")
+            else:
+                if not check_url_safety(url):
+                    self.add_error("url", "URL flagged as unsafe.")
             if body:
                 self.add_error("body", "Body must be empty for link posts.")
             if image:

--- a/core/tests_link_safety.py
+++ b/core/tests_link_safety.py
@@ -1,0 +1,56 @@
+from django.contrib.auth import get_user_model
+from django.core.cache import cache
+from django.test import TestCase, override_settings
+from django.urls import reverse
+from unittest.mock import patch
+
+from .models import Community, Post
+
+
+class LinkSafetyTests(TestCase):
+    def setUp(self):
+        cache.clear()
+        user_model = get_user_model()
+        self.user = user_model.objects.create_user("alice", password="pwd")
+        self.community = Community.objects.create(
+            slug="t", name="Test", title="Test", created_by=self.user
+        )
+        self.client.login(username="alice", password="pwd")
+        self.url = reverse("submit_post", args=[self.community.slug])
+
+    @override_settings(URL_REPUTATION_API_KEY="k")
+    @patch("core.utils.link_safety.requests.post")
+    def test_safe_url_allowed(self, mock_post):
+        mock_post.return_value.json.return_value = {}
+        mock_post.return_value.status_code = 200
+        resp = self.client.post(
+            self.url,
+            {
+                "post_type": "link",
+                "title": "Link",
+                "body": "",
+                "url": "https://example.com",
+            },
+        )
+        self.assertRedirects(resp, reverse("community", args=[self.community.slug]))
+        self.assertEqual(Post.objects.count(), 1)
+
+    @override_settings(URL_REPUTATION_API_KEY="k")
+    @patch("core.utils.link_safety.requests.post")
+    def test_unsafe_url_rejected(self, mock_post):
+        mock_post.return_value.json.return_value = {
+            "matches": [{"threatType": "MALWARE"}]
+        }
+        mock_post.return_value.status_code = 200
+        resp = self.client.post(
+            self.url,
+            {
+                "post_type": "link",
+                "title": "Bad",
+                "body": "",
+                "url": "http://malware.test",
+            },
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertFormError(resp.context["form"], "url", "URL flagged as unsafe.")
+        self.assertEqual(Post.objects.count(), 0)

--- a/core/utils/link_safety.py
+++ b/core/utils/link_safety.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import requests
+from django.conf import settings
+
+SAFE_BROWSING_URL = "https://safebrowsing.googleapis.com/v4/threatMatches:find"
+
+
+def check_url_safety(url: str) -> bool:
+    """Return True if the URL is considered safe.
+
+    Uses Google Safe Browsing Lookup API. If the API key is missing or the
+    request fails for any reason, the URL is treated as safe.
+    """
+    api_key = getattr(settings, "URL_REPUTATION_API_KEY", "")
+    if not api_key:
+        return True
+
+    payload = {
+        "client": {"clientId": "surejan", "clientVersion": "1.0"},
+        "threatInfo": {
+            "threatTypes": [
+                "MALWARE",
+                "SOCIAL_ENGINEERING",
+                "UNWANTED_SOFTWARE",
+                "POTENTIALLY_HARMFUL_APPLICATION",
+            ],
+            "platformTypes": ["ANY_PLATFORM"],
+            "threatEntryTypes": ["URL"],
+            "threatEntries": [{"url": url}],
+        },
+    }
+
+    try:
+        resp = requests.post(
+            SAFE_BROWSING_URL, params={"key": api_key}, json=payload, timeout=5
+        )
+        data = resp.json()
+        return not data.get("matches")
+    except Exception:
+        # Fail open: if the reputation service is unavailable, don't block the URL
+        return True

--- a/core/views.py
+++ b/core/views.py
@@ -323,6 +323,8 @@ def submit_post(request, slug):
             post.save()
             messages.success(request, "Post submitted")
             return redirect("community", slug=community.slug)
+        else:
+            messages.error(request, "Please correct the errors below.")
     else:
         form = PostForm()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ argon2-cffi==23.1.0
 gunicorn==23.0.0
 packaging==25.0
 pillow==11.3.0
+requests==2.32.3
 psycopg[binary]==3.2.9
 sentry-sdk==2.35.0
 sqlparse==0.5.3


### PR DESCRIPTION
## Summary
- add helper to consult Google Safe Browsing and determine if a link is safe
- validate link posts against reputation service and display form errors
- test that safe links post successfully and unsafe links are rejected

## Testing
- `DEBUG=1 DJANGO_TESTS=1 python manage.py test core.tests_link_safety -v 2`


------
https://chatgpt.com/codex/tasks/task_e_68aad1522588832c942a8efff9ec20be