### PR TITLE
Fix legal templates

### DIFF
--- a/templates/legal/privacy.html
+++ b/templates/legal/privacy.html
@@ -1,23 +1,13 @@
 {% extends "base.html" %}
 {% block content %}
-codex/create-templates-for-terms,-privacy,-rules-shfpl0
 <h1>🔒 Privacy Policy</h1>
 <p>Your privacy matters. Here’s how SureJan handles your information:</p>
 <ol>
-
-<h1>🔒 Privacy Policy (SureJan)</h1>
-<p>Your privacy matters. Here’s how SureJan handles your information:</p>
-<ul>
-main
   <li><strong>Data We Collect</strong> – Username, email (if provided), and posts/comments you create.</li>
   <li><strong>How We Use It</strong> – To run the site, maintain accounts, and improve community experience.</li>
   <li><strong>What We Don’t Do</strong> – We don’t sell your data.</li>
   <li><strong>Cookies</strong> – Basic cookies may be used to keep you logged in and improve browsing.</li>
   <li><strong>Third Parties</strong> – If we use outside services (like hosting or analytics), they’ll only receive what’s needed to keep the site running.</li>
   <li><strong>Your Control</strong> – You can delete your account or request removal of content by contacting the admin.</li>
-codex/create-templates-for-terms,-privacy,-rules-shfpl0
 </ol>
-
-</ul>
-main
 {% endblock %}

--- a/templates/legal/rules.html
+++ b/templates/legal/rules.html
@@ -1,6 +1,5 @@
 {% extends "base.html" %}
 {% block content %}
-codex/create-templates-for-terms,-privacy,-rules-shfpl0
 <h1>📖 Community Rules</h1>
 <p>SureJan is about open, respectful discussion. These are the ground rules:</p>
 <ol>
@@ -12,17 +11,4 @@ codex/create-templates-for-terms,-privacy,-rules-shfpl0
   <li><strong>Minimal Moderation</strong> – We prefer self-regulation. Mods will only step in if things go off the rails.</li>
 </ol>
 <p><small>Last updated: 25/08/2025</small></p>
-
-<h1>📖 Community Rules (SureJan)</h1>
-<p>SureJan is about open, respectful discussion. These are the ground rules:</p>
-<ul>
-  <li><strong>Be Free, But Respectful</strong> – Debate is welcome; harassment is not.</li>
-  <li><strong>No Spam or Scams</strong> – Keep the feed clear of junk, ads, or malicious links.</li>
-  <li><strong>Legal Content Only</strong> – No illegal material, threats, or incitement.</li>
-  <li><strong>Mark Sensitive Content</strong> – If posting NSFW or graphic content, clearly label it.</li>
-  <li><strong>Local First</strong> – Since SureJan is about Brisbane, local topics are encouraged.</li>
-  <li><strong>Minimal Moderation</strong> – We prefer self-regulation. Mods will only step in if things go off the rails.</li>
-</ul>
-<p><small>Last updated: 24/08/2025</small></p>
-main
 {% endblock %}

--- a/templates/legal/terms.html
+++ b/templates/legal/terms.html
@@ -1,23 +1,13 @@
 {% extends "base.html" %}
 {% block content %}
-codex/create-templates-for-terms,-privacy,-rules-shfpl0
 <h1>📜 Terms of Use</h1>
 <p>Welcome to SureJan, a community forum for Brisbane. By using this site, you agree to these terms:</p>
 <ol>
-
-<h1>📜 Terms of Use (SureJan)</h1>
-<p>Welcome to SureJan, a community forum for Brisbane. By using this site, you agree to these terms:</p>
-<ul>
-main
   <li><strong>Free Expression</strong> – You’re encouraged to share your opinions, ideas, and discussions freely.</li>
   <li><strong>Respect Others</strong> – Healthy debate is fine, but harassment, hate speech, and targeted abuse are not.</li>
   <li><strong>Your Content</strong> – What you post is yours. By posting, you give SureJan permission to display and distribute it within the site.</li>
   <li><strong>No Liability</strong> – Posts are created by users, not the site. SureJan is not responsible for the accuracy or consequences of user content.</li>
   <li><strong>Moderation</strong> – We’ll only step in when necessary: spam, illegal content, or threats of harm may be removed.</li>
   <li><strong>Changes</strong> – These terms may be updated as the community grows.</li>
-codex/create-templates-for-terms,-privacy,-rules-shfpl0
 </ol>
-
-</ul>
-main
 {% endblock %}


### PR DESCRIPTION
## Summary
- Clean up Terms of Use template with an ordered list of site guidelines
- Rewrite Privacy Policy template to clearly state data practices
- Replace Community Rules template with final rules and update timestamp

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aad88089c0832cb302a86b8eac165c