### PR TITLE
Ensure Fly health check sends Host header

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -21,11 +21,12 @@ primary_region = "syd"
   processes = ["app"]
 
   [[http_service.checks]]
-    grace_period = "10s"
-    interval = "30s"
-    timeout = "5s"
-    method = "GET"
+    type = "http"
+    method = "get"
     path = "/healthz"
+    interval = "10s"
+    timeout = "2s"
+    headers = { Host = "surejan.fly.dev" }
 
 [[vm]]
   cpu_kind = "shared"


### PR DESCRIPTION
## Summary
- Configure Fly's HTTP health check to send the surejan.fly.dev Host header
- Use explicit http check type with shorter interval and timeout

## Testing
- `make test` *(fails: no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_68aba7e8fb0c832c9b33bfa8e8c71080