### PR TITLE
Limit session to 8 hours or browser close

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -55,6 +55,8 @@ if _extra_csrf:
 # Respect Fly proxy for secure detection
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 SESSION_COOKIE_SECURE = not DEBUG
+SESSION_COOKIE_AGE = 60 * 60 * 8  # 8 hours
+SESSION_EXPIRE_AT_BROWSER_CLOSE = True
 CSRF_COOKIE_SECURE = not DEBUG
 
 if not DEBUG:


### PR DESCRIPTION
## Summary
- Expire sessions on browser close or after 8 hours

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68abdebf4cc0832ca25c6ce13d35a8ab