### PR TITLE
feat: extend S3 media cache to 3 years

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -211,6 +211,7 @@ if USE_S3_MEDIA:
     AWS_S3_ADDRESSING_STYLE = "virtual"
     AWS_S3_SIGNATURE_VERSION = "s3v4"
     AWS_DEFAULT_ACL = "public-read"
+    AWS_S3_OBJECT_PARAMETERS = {"CacheControl": "public, max-age=94608000"}
     STORAGES["default"] = {"BACKEND": "storages.backends.s3boto3.S3Boto3Storage"}
 else:
     STORAGES["default"] = {"BACKEND": "django.core.files.storage.FileSystemStorage"}


### PR DESCRIPTION
## Summary
- add CacheControl header to S3 media uploads when using S3
- set max-age to 3 years for public caching

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68abdecd0cb8832cb00ade2d2fa603ca