### PR TITLE
Guard image URLs in feed template

### DIFF
--- a/templates/core/partials/post_row.html
+++ b/templates/core/partials/post_row.html
@@ -14,8 +14,14 @@
       <a href="{% url 'post_detail' post.community.slug post.pk post.title|slugify %}">{{ post.title }}</a>
     {% endif %}
     </h2>
-    {% if post.image or post.image_thumb %}
-      <img src="{{ post.image_thumb.url|default:post.image.url }}" alt="" class="post-image" loading="lazy" decoding="async" referrerpolicy="no-referrer">
+    {% if post.image_thumb or post.image %}
+      {% if post.image_thumb %}
+        <img src="{{ post.image_thumb.url }}" alt="" class="post-image"
+             loading="lazy" decoding="async" referrerpolicy="no-referrer">
+      {% else %}
+        <img src="{{ post.image.url }}" alt="" class="post-image"
+             loading="lazy" decoding="async" referrerpolicy="no-referrer">
+      {% endif %}
     {% endif %}
     <p class="meta">
       <a href="{% url 'community' post.community.slug %}">/r/{{ post.community.slug }}/</a>


### PR DESCRIPTION
## Summary
- Avoid calling `.url` on missing images by branching on `image_thumb` and `image`

## Testing
- `make test` (failed: no tests ran)
- `python manage.py test` (failed: failures=45, errors=17)


------
https://chatgpt.com/codex/tasks/task_e_68abe26d98ec832cba2f6396eb84f08c