### PR TITLE
Prefer CF-Connecting-IP for client IP

### DIFF
--- a/core/middleware.py
+++ b/core/middleware.py
@@ -2,6 +2,23 @@ from django.conf import settings
 from django.http import HttpResponseForbidden
 
 
+def _client_ip(request):
+    """Return the best-guess client IP address.
+
+    Cloudflare exposes the original client IP in the CF-Connecting-IP header.
+    Fall back to the standard X-Forwarded-For header and REMOTE_ADDR for
+    environments without Cloudflare.
+    """
+
+    ip = request.META.get("HTTP_CF_CONNECTING_IP")
+    if ip:
+        return ip.strip()
+    xff = request.META.get("HTTP_X_FORWARDED_FOR")
+    if xff:
+        return xff.split(",")[0].strip()
+    return (request.META.get("REMOTE_ADDR") or "").strip()
+
+
 class AdminIPAllowlistMiddleware:
     """Restrict admin access to IPs in settings.ADMIN_IP_ALLOWLIST."""
 
@@ -12,10 +29,7 @@ class AdminIPAllowlistMiddleware:
     def __call__(self, request):
         allowlist = getattr(settings, "ADMIN_IP_ALLOWLIST", set())
         if allowlist and request.path.startswith(self.prefix):
-            # Prefer X-Forwarded-For header if present (take first IP)
-            ip = request.META.get("HTTP_X_FORWARDED_FOR", "").split(",")[0].strip()
-            if not ip:
-                ip = request.META.get("REMOTE_ADDR", "")
+            ip = _client_ip(request)
             if ip not in allowlist:
                 return HttpResponseForbidden("Forbidden")
         return self.get_response(request)

--- a/core/tests_admin_url.py
+++ b/core/tests_admin_url.py
@@ -22,3 +22,24 @@ class AdminURLTests(TestCase):
     def test_admin_allowed_for_allowlisted_ip(self):
         resp = self.client.get("/secret-admin/", REMOTE_ADDR="1.1.1.1", secure=True)
         self.assertEqual(resp.status_code, 302)
+
+    @override_settings(ADMIN_IP_ALLOWLIST={"1.1.1.1"})
+    def test_admin_uses_cf_connecting_ip(self):
+        resp = self.client.get(
+            "/secret-admin/",
+            REMOTE_ADDR="2.2.2.2",
+            HTTP_X_FORWARDED_FOR="3.3.3.3",
+            HTTP_CF_CONNECTING_IP="1.1.1.1",
+            secure=True,
+        )
+        self.assertEqual(resp.status_code, 302)
+
+    @override_settings(ADMIN_IP_ALLOWLIST={"1.1.1.1"})
+    def test_admin_blocks_when_cf_connecting_ip_not_allowlisted(self):
+        resp = self.client.get(
+            "/secret-admin/",
+            REMOTE_ADDR="1.1.1.1",
+            HTTP_CF_CONNECTING_IP="2.2.2.2",
+            secure=True,
+        )
+        self.assertEqual(resp.status_code, 403)


### PR DESCRIPTION
## Summary
- Use `CF-Connecting-IP` header to detect client IP, falling back to `X-Forwarded-For` and `REMOTE_ADDR`
- Add tests ensuring admin allowlist honors Cloudflare `CF-Connecting-IP` header

## Testing
- `python manage.py test` *(fails: FAILURES=45, ERRORS=17)*

------
https://chatgpt.com/codex/tasks/task_e_68abe8a6f61c832c9d2d875c1ee09799