### PR TITLE
Add owner post deletion endpoint

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -43,6 +43,11 @@ urlpatterns = [
     path("vote/comment/<int:pk>/", core_views.vote_comment, name="vote_comment"),
     # Post moderation
     path("post/<int:pk>/delete/", core_views.post_delete, name="post_delete"),
+    path(
+        "post/<int:pk>/delete/owner/",
+        core_views.post_delete_owner,
+        name="post_delete_owner",
+    ),
     path("report/", core_views.report, name="report"),
     path("reports/", core_views.report_list, name="report_list"),
 

--- a/core/views.py
+++ b/core/views.py
@@ -458,6 +458,23 @@ def post_delete(request, pk):
 @login_required
 @require_POST
 @csrf_protect
+def post_delete_owner(request, pk):
+    """Delete a post if the requester is the author or staff."""
+    if _is_banned(request.user):
+        return HttpResponseForbidden("Account banned")
+
+    post = get_object_or_404(Post, pk=pk)
+    if request.user != post.author and not request.user.is_staff:
+        return HttpResponseForbidden("Forbidden")
+
+    slug = post.community.slug
+    post.delete()
+    return redirect("community", slug=slug)
+
+
+@login_required
+@require_POST
+@csrf_protect
 def comment_delete(request, pk):
     """Delete a comment if the requester is the author or staff."""
     if _is_banned(request.user):


### PR DESCRIPTION
## Summary
- add endpoint to allow authors or staff to delete posts
- expose route `post/<int:pk>/delete/owner/`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68abf3cfe9c0832c812c235b171996db