### PR TITLE
Add HTMX swap stub for deleted posts

### DIFF
--- a/templates/core/partials/post_deleted_stub.html
+++ b/templates/core/partials/post_deleted_stub.html
@@ -1,0 +1,8 @@
+<li id="post-{{ post.pk }}" class="post-row">
+  <div class="vote"></div>
+  <div class="post-body">
+    <h2><em>[deleted]</em></h2>
+    <div class="meta">in r/{{ post.community.slug }}</div>
+  </div>
+</li>
+


### PR DESCRIPTION
## Summary
- create post_deleted_stub partial for use when posts are removed via HTMX

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68abf4326094832caf33c0edc748a070