### PR TITLE
Add author/staff HTMX delete controls to feed post row

### DIFF
--- a/templates/core/partials/post_row.html
+++ b/templates/core/partials/post_row.html
@@ -1,26 +1,30 @@
 {% load url_domain %}
-<div class="post-row">
+<div class="post-row" id="post-{{ post.pk }}">
   <div class="vote-col">
     <button hx-post="{% url 'vote_post' post.pk %}?v=1" hx-target="#post-score-{{ post.pk }}" hx-swap="outerHTML" aria-label="Upvote">▲</button>
     <span id="post-score-{{ post.pk }}">{{ post.score }}</span>
     <button hx-post="{% url 'vote_post' post.pk %}?v=-1" hx-target="#post-score-{{ post.pk }}" hx-swap="outerHTML" aria-label="Downvote">▼</button>
   </div>
   <div class="post-body">
-    <h2>
-    {% if post.url %}
-      <a href="{{ post.url }}">{{ post.title }}</a>
-      <span class="domain">({{ post.url|domain }})</span>
+    {% if post.is_deleted %}
+      <em>[deleted]</em>
     {% else %}
-      <a href="{% url 'post_detail' post.community.slug post.pk post.title|slugify %}">{{ post.title }}</a>
-    {% endif %}
-    </h2>
-    {% if post.image_thumb or post.image %}
-      {% if post.image_thumb %}
-        <img src="{{ post.image_thumb.url }}" alt="" class="post-image"
-             loading="lazy" decoding="async" referrerpolicy="no-referrer">
+      <h2>
+      {% if post.url %}
+        <a href="{{ post.url }}">{{ post.title }}</a>
+        <span class="domain">({{ post.url|domain }})</span>
       {% else %}
-        <img src="{{ post.image.url }}" alt="" class="post-image"
-             loading="lazy" decoding="async" referrerpolicy="no-referrer">
+        <a href="{% url 'post_detail' post.community.slug post.pk post.title|slugify %}">{{ post.title }}</a>
+      {% endif %}
+      </h2>
+      {% if post.image_thumb or post.image %}
+        {% if post.image_thumb %}
+          <img src="{{ post.image_thumb.url }}" alt="" class="post-image"
+               loading="lazy" decoding="async" referrerpolicy="no-referrer">
+        {% else %}
+          <img src="{{ post.image.url }}" alt="" class="post-image"
+               loading="lazy" decoding="async" referrerpolicy="no-referrer">
+        {% endif %}
       {% endif %}
     {% endif %}
     <p class="meta">
@@ -31,16 +35,20 @@
       {% if user.is_authenticated %}
       · <a href="{% url 'report' %}?target_type=post&object_id={{ post.pk }}">[report]</a>
       {% endif %}
-        {% if user == post.author %}
-        · <form action="{% url 'post_delete_owner' post.pk %}" method="post" style="display:inline">
-          {% csrf_token %}<button type="submit" style="background:none;border:none;padding:0;color:inherit">[delete]</button>
-        </form>
-        {% elif user.is_staff %}
-        <!-- staff moderation controls -->
-        · <form action="{% url 'post_delete' post.pk %}" method="post" style="display:inline">
-          {% csrf_token %}<button type="submit" style="background:none;border:none;padding:0;color:inherit">[remove]</button>
-        </form>
+      {% if request.user.is_authenticated and not post.is_deleted %}
+        {% if request.user.is_staff or post.can_author_delete(request.user, 15) %}
+        · <form method="post"
+              action="{% url 'post_delete_owner' post.pk %}"
+              style="display:inline"
+              hx-post="{% url 'post_delete_owner' post.pk %}"
+              hx-target="#post-{{ post.pk }}"
+              hx-swap="outerHTML"
+              hx-confirm="Delete this post? (If it has comments, only the content will be deleted)">
+            {% csrf_token %}
+            <button type="submit" class="linklike">delete</button>
+          </form>
         {% endif %}
+      {% endif %}
     </p>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- Allow HTMX to target post rows by adding an id attribute
- Show a delete button to staff or authors within 15 minutes; replace row after deletion
- Display a tombstone `[deleted]` when post content has been soft deleted

## Testing
- `pytest`
- `python manage.py check` *(fails: IndentationError: expected an indented block after function definition on line 156)*

------
https://chatgpt.com/codex/tasks/task_e_68abf8137470832cb7c8ea5944638380