### PR TITLE
Add within_minutes template filter

### DIFF
--- a/core/templatetags/timeutils.py
+++ b/core/templatetags/timeutils.py
@@ -1,0 +1,16 @@
+from datetime import timedelta
+from django import template
+from django.utils import timezone
+
+register = template.Library()
+
+
+@register.filter
+def within_minutes(dt, minutes):
+    if not dt:
+        return False
+    try:
+        m = int(minutes)
+    except (TypeError, ValueError):
+        return False
+    return (timezone.now() - dt) <= timedelta(minutes=m)

--- a/core/tests_timeutils.py
+++ b/core/tests_timeutils.py
@@ -1,0 +1,20 @@
+from datetime import timedelta
+from django.template import Context, Template
+from django.test import TestCase
+from django.utils import timezone
+
+
+class WithinMinutesFilterTests(TestCase):
+    def render(self, dt, minutes):
+        tmpl = Template("{% load timeutils %}{{ dt|within_minutes:minutes }}")
+        return tmpl.render(Context({"dt": dt, "minutes": minutes}))
+
+    def test_within_minutes_true(self):
+        dt = timezone.now() - timedelta(minutes=4)
+        rendered = self.render(dt, 5)
+        self.assertEqual(rendered, "True")
+
+    def test_within_minutes_false(self):
+        dt = timezone.now() - timedelta(minutes=6)
+        rendered = self.render(dt, 5)
+        self.assertEqual(rendered, "False")


### PR DESCRIPTION
## Summary
- add `within_minutes` template filter to evaluate datetimes relative to current time
- cover filter with unit tests for both matching and non-matching intervals

## Testing
- `pytest -q` *(no tests discovered)*
- `python manage.py test core.tests_timeutils -v 2`


------
https://chatgpt.com/codex/tasks/task_e_68abfd817d38832c94c728bd49045567