### PR TITLE
Use within_minutes filter for delete button visibility

### DIFF
--- a/templates/core/partials/post_row.html
+++ b/templates/core/partials/post_row.html
@@ -1,4 +1,5 @@
 {% load url_domain %}
+{% load timeutils %}
 <div class="post-row" id="post-{{ post.pk }}">
   <div class="vote-col">
     <button hx-post="{% url 'vote_post' post.pk %}?v=1" hx-target="#post-score-{{ post.pk }}" hx-swap="outerHTML" aria-label="Upvote">▲</button>
@@ -36,7 +37,7 @@
       · <a href="{% url 'report' %}?target_type=post&object_id={{ post.pk }}">[report]</a>
       {% endif %}
       {% if request.user.is_authenticated and not post.is_deleted %}
-        {% if request.user.is_staff or post.can_author_delete(request.user, 15) %}
+        {% if request.user.is_staff or (request.user.id == post.author_id and post.created_at|within_minutes:15) %}
         · <form method="post"
               action="{% url 'post_delete_owner' post.pk %}"
               style="display:inline"

--- a/templates/core/post_detail.html
+++ b/templates/core/post_detail.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load timeutils %}
 
 {% block content %}
 <div class="post-page">
@@ -39,7 +40,7 @@
         <a href="#" onclick="navigator.clipboard.writeText(window.location.href);return false;">share</a>
         <a href="{% url 'community' post.community.slug %}">back to r/{{ post.community.slug }}</a>
         {% if request.user.is_authenticated and not post.is_deleted %}
-          {% if request.user.is_staff or post.can_author_delete(request.user, 15) %}
+          {% if request.user.is_staff or (request.user.id == post.author_id and post.created_at|within_minutes:15) %}
             <form method="post"
                   action="{% url 'post_delete_owner' post.pk %}"
                   hx-post="{% url 'post_delete_owner' post.pk %}"


### PR DESCRIPTION
## Summary
- load timeutils in post templates
- show delete option only for staff or post authors within 15 minutes via within_minutes filter

## Testing
- `pytest -q`
- `python manage.py test` *(fails: KeyError 'signup_captcha_q', response code mismatches, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68abfe6a1928832c909a55bab23f6e0d