### PR TITLE
Add can_author_delete template filter for delete permissions

### DIFF
--- a/core/templatetags/permissions.py
+++ b/core/templatetags/permissions.py
@@ -1,0 +1,21 @@
+from datetime import timedelta
+from django import template
+from django.utils import timezone
+
+register = template.Library()
+
+@register.filter
+def can_author_delete(post, user):
+    """Staff can always delete. Author can delete within 15 minutes. Not if already deleted."""
+    if not getattr(user, "is_authenticated", False):
+        return False
+    if getattr(user, "is_staff", False):
+        return True
+    if getattr(post, "is_deleted", False):
+        return False
+    if getattr(post, "author_id", None) != getattr(user, "id", None):
+        return False
+    created = getattr(post, "created_at", None)
+    if not created:
+        return False
+    return timezone.now() - created <= timedelta(minutes=15)

--- a/templates/core/partials/post_row.html
+++ b/templates/core/partials/post_row.html
@@ -1,5 +1,5 @@
 {% load url_domain %}
-{% load timeutils %}
+{% load permissions %}
 <div class="post-row" id="post-{{ post.pk }}">
   <div class="vote-col">
     <button hx-post="{% url 'vote_post' post.pk %}?v=1" hx-target="#post-score-{{ post.pk }}" hx-swap="outerHTML" aria-label="Upvote">▲</button>
@@ -35,7 +35,7 @@
       · <a href="{% url 'report' %}?target_type=post&object_id={{ post.pk }}">[report]</a>
       {% endif %}
       {% if request.user.is_authenticated and not post.is_deleted %}
-        {% if request.user.is_staff or (request.user.id == post.author_id and post.created_at|within_minutes:15) %}
+        {% if request.user.is_staff or post|can_author_delete:request.user %}
         · <form method="post"
               action="{% url 'post_delete_owner' post.pk %}"
               style="display:inline"

--- a/templates/core/post_detail.html
+++ b/templates/core/post_detail.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load timeutils %}
+{% load permissions %}
 
 {% block content %}
 <div class="post-page">
@@ -40,7 +40,7 @@
         <a href="#" onclick="navigator.clipboard.writeText(window.location.href);return false;">share</a>
         <a href="{% url 'community' post.community.slug %}">back to r/{{ post.community.slug }}</a>
         {% if request.user.is_authenticated and not post.is_deleted %}
-          {% if request.user.is_staff or (request.user.id == post.author_id and post.created_at|within_minutes:15) %}
+          {% if request.user.is_staff or post|can_author_delete:request.user %}
             <form method="post"
                   action="{% url 'post_delete_owner' post.pk %}"
                   hx-post="{% url 'post_delete_owner' post.pk %}"


### PR DESCRIPTION
## Summary
- add `can_author_delete` template filter to centralize delete permissions
- simplify post delete button logic and remove invalid `{% if (...) %}` parentheses
- load new filter in post row and detail templates

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac053c5100832c9ffbb5913c9eec8b