### PR TITLE
fix(ui): pluralize comment label; add backfill command to sync Post.comment_count

### DIFF
--- a/core/management/commands/backfill_comment_counts.py
+++ b/core/management/commands/backfill_comment_counts.py
@@ -1,0 +1,18 @@
+from django.core.management.base import BaseCommand
+from django.db.models import Count
+
+from core.models import Post, Comment
+
+
+class Command(BaseCommand):
+    help = "Recompute and store Post.comment_count from Comment table"
+
+    def handle(self, *args, **options):
+        qs = Post.objects.all().annotate(real_count=Count("comments"))
+        updated = 0
+        for p in qs:
+            if p.comment_count != p.real_count:
+                Post.objects.filter(pk=p.pk).update(comment_count=p.real_count)
+                updated += 1
+        self.stdout.write(self.style.SUCCESS(f"Updated {updated} posts"))
+

--- a/templates/core/post_detail.html
+++ b/templates/core/post_detail.html
@@ -36,7 +36,9 @@
         {% endif %}
       </div>
       <nav class="post-actions">
-        <a href="#comments">{{ post.comment_count }} comments</a>
+        <a href="#comments">
+          {{ post.comment_count }} comment{{ post.comment_count|pluralize }}
+        </a>
         <a href="#" onclick="navigator.clipboard.writeText(window.location.href);return false;">share</a>
         <a href="{% url 'community' post.community.slug %}">back to r/{{ post.community.slug }}</a>
         {% if request.user.is_authenticated and not post.is_deleted %}


### PR DESCRIPTION
## Summary
- pluralize comment label on post detail
- add management command to backfill Post.comment_count

## Testing
- `python manage.py backfill_comment_counts --help`
- `python manage.py test` *(fails: failures=51, errors=17)*

------
https://chatgpt.com/codex/tasks/task_e_68ac0ab5a218832cb8ec2d3d00ea7111