### PR TITLE
Enable dev proxy via Fly and simplify health check

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -59,6 +59,17 @@ _extra_csrf = os.environ.get("DJANGO_CSRF_TRUSTED", "").strip()
 if _extra_csrf:
     CSRF_TRUSTED_ORIGINS += [o.strip() for o in _extra_csrf.split(",") if o.strip()]
 
+# --- Dev proxy defaults (only in DEBUG) ---
+if DEBUG:
+    _dev_allowed = {"localhost", "127.0.0.1", "surejan.internal", "surejan.fly.dev"}
+    ALLOWED_HOSTS = list(sorted(set(ALLOWED_HOSTS) | _dev_allowed))
+    # allow HTTP localhost origins for forms while using the proxy
+    _dev_csrf = {
+        "http://localhost:8080", "http://127.0.0.1:8080",
+        "http://localhost:8888", "http://127.0.0.1:8888",
+    }
+    CSRF_TRUSTED_ORIGINS = list(sorted(set(CSRF_TRUSTED_ORIGINS + list(_dev_csrf))))
+
 # Respect Fly proxy for secure detection
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 SESSION_COOKIE_SECURE = not DEBUG

--- a/config/urls.py
+++ b/config/urls.py
@@ -5,12 +5,13 @@ from django.contrib import admin
 from django.contrib.auth.views import LogoutView
 from django.urls import path, include
 from django.views.generic import TemplateView
+from django.http import HttpResponse
 
 from core import views as core
 
 urlpatterns = [
     path(settings.ADMIN_URL, admin.site.urls),
-    path("healthz", core.healthz, name="healthz"),
+    path("healthz", lambda request: HttpResponse("ok"), name="healthz"),
     path("accounts/login/", core.RateLimitedLoginView.as_view(), name="login"),
     path(
         "accounts/logout/",

--- a/core/tests_healthz.py
+++ b/core/tests_healthz.py
@@ -1,8 +1,5 @@
-from unittest.mock import patch
-
 from django.test import TestCase
 from django.urls import reverse
-from django.db.utils import OperationalError
 
 
 class HealthzTests(TestCase):
@@ -11,14 +8,3 @@ class HealthzTests(TestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.content, b"ok")
 
-    @patch("core.views.connections")
-    def test_healthz_db_failure(self, mock_connections):
-        mock_connections.__getitem__.return_value.cursor.side_effect = OperationalError
-        resp = self.client.get(reverse("healthz"))
-        self.assertEqual(resp.status_code, 500)
-
-    @patch("core.views.cache")
-    def test_healthz_cache_failure(self, mock_cache):
-        mock_cache.set.side_effect = Exception
-        resp = self.client.get(reverse("healthz"))
-        self.assertEqual(resp.status_code, 500)

--- a/core/views.py
+++ b/core/views.py
@@ -26,8 +26,6 @@ from django.db.models import F
 from django import forms
 
 from django.contrib.contenttypes.models import ContentType
-from django.core.cache import cache
-from django.db import connections
 from django_ratelimit.core import is_ratelimited
 
 from .forms import CommentForm, PostForm, CommunityCreateForm
@@ -55,19 +53,6 @@ def limit_or_429(request, group, rate):
         method=["POST"],
         increment=True,
     )
-
-
-def healthz(_request):
-    """Health check verifying database and cache connectivity."""
-    try:
-        connections["default"].cursor()
-        cache.set("healthz", "ok", 1)
-        cache.get("healthz")
-    except Exception:
-        return HttpResponse("unhealthy", status=500, content_type="text/plain")
-    return HttpResponse("ok", content_type="text/plain")
-
-
 def mission(request):
     return render(request, "core/mission.html")
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -5,8 +5,8 @@
 Set `SENTRY_DSN` via Fly secrets or environment variables before deploying.
 The Django admin lives at `/secret-admin/`; restrict it by setting an
 `ADMIN_IP_ALLOWLIST` environment variable with a comma-separated list of
-allowed IPs. The app exposes `/healthz` which checks database and cache
-connectivity; point your uptime monitor at this path.
+allowed IPs. The app exposes `/healthz` for uptime checks; point your
+monitor at this path.
 
 ```bash
 git add -A

--- a/docs/uptime.md
+++ b/docs/uptime.md
@@ -1,6 +1,6 @@
 # Uptime monitoring
 
-The `/healthz` endpoint performs basic checks for the database and cache.
+The `/healthz` endpoint returns a lightweight `ok` response.
 Configure an external service such as UptimeRobot to poll it and alert if
 it fails.
 

--- a/fly.toml
+++ b/fly.toml
@@ -21,12 +21,11 @@ primary_region = "syd"
   processes = ["app"]
 
   [[http_service.checks]]
-    type = "http"
-    method = "get"
-    path = "/healthz"
-    interval = "10s"
-    timeout = "2s"
-    headers = { Host = "surejan.fly.dev" }
+    interval = "30s"
+    timeout  = "5s"
+    method   = "GET"
+    path     = "/healthz"
+    headers  = ["Host=localhost"]
 
 [[vm]]
   cpu_kind = "shared"


### PR DESCRIPTION
## Summary
- Ensure dev mode allows local hosts and CSRF origins when DEBUG is true
- Use lightweight `/healthz` route and document simplified health checks
- Update Fly config health check headers and defaults

## Testing
- ⚠️ `pytest -q core/tests_healthz.py -vv` (fails: Requested setting DATABASES, but settings are not configured)
- ✅ `python manage.py test core.tests_healthz`


------
https://chatgpt.com/codex/tasks/task_e_68b3988d4500832c9a598380acfcb20a