### PR TITLE
feat: add modern post form with auto-expanding body

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -1,0 +1,39 @@
+/* Global application styles */
+
+body {
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, Ubuntu, Cantarell, "Noto Sans", "Helvetica Neue", Arial, "Apple Color Emoji", "Segoe UI Emoji";
+}
+
+.post-form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  max-width: 600px;
+}
+
+.post-form .form-row {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.post-form input[type="text"],
+.post-form input[type="url"],
+.post-form textarea {
+  font: inherit;
+  padding: 6px;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.post-form .char-count {
+  align-self: flex-end;
+  font-size: 11px;
+  color: var(--muted, #777);
+}
+
+.post-form textarea {
+  resize: none;
+  overflow-y: auto;
+  max-height: 60vh;
+}

--- a/static/js/editor.js
+++ b/static/js/editor.js
@@ -1,0 +1,47 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const titleField = document.getElementById('id_title');
+  const bodyField = document.getElementById('id_body');
+  const urlField = document.getElementById('id_url');
+  const postTypeField = document.getElementById('id_post_type');
+  const titleCount = document.getElementById('title-count');
+  const bodyCount = document.getElementById('body-count');
+  const TITLE_MAX = 300;
+  const BODY_MAX = 40000;
+
+  function updateCount(field, counter, max) {
+    if (!field || !counter) return;
+    counter.textContent = `${field.value.length} / ${max}`;
+  }
+
+  if (titleField && titleCount) {
+    updateCount(titleField, titleCount, TITLE_MAX);
+    titleField.addEventListener('input', () => updateCount(titleField, titleCount, TITLE_MAX));
+  }
+
+  function autoResize(el) {
+    if (!el) return;
+    el.style.height = 'auto';
+    const max = window.innerHeight * 0.6;
+    const newHeight = Math.min(el.scrollHeight, max);
+    el.style.height = newHeight + 'px';
+  }
+
+  if (bodyField && bodyCount) {
+    updateCount(bodyField, bodyCount, BODY_MAX);
+    autoResize(bodyField);
+    bodyField.addEventListener('input', () => {
+      updateCount(bodyField, bodyCount, BODY_MAX);
+      autoResize(bodyField);
+    });
+  }
+
+  const form = document.querySelector('.post-form');
+  if (form) {
+    form.addEventListener('submit', () => {
+      if (postTypeField) {
+        const urlVal = urlField && urlField.value.trim();
+        postTypeField.value = urlVal ? 'link' : 'text';
+      }
+    });
+  }
+});

--- a/templates/base.html
+++ b/templates/base.html
@@ -9,6 +9,7 @@
     <!-- Styles -->
     <link rel="stylesheet" href="{% static 'css/base.css' %}">
     <link rel="stylesheet" href="{% static 'css/theme.css' %}">
+    <link rel="stylesheet" href="{% static 'css/app.css' %}">
     {% block head_extra %}{% endblock %}
 
   </head>

--- a/templates/core/post_form.html
+++ b/templates/core/post_form.html
@@ -1,0 +1,43 @@
+{% extends "base.html" %}
+{% load static %}
+
+{% block content %}
+<h1>Create Post</h1>
+<form method="post" action="{% url 'submit_post' community.slug %}" class="post-form" hx-boost="false" hx-swap="none">
+  {% csrf_token %}
+  {{ form.non_field_errors }}
+
+  <div class="form-row">
+    <label for="{{ form.title.id_for_label }}">Title</label>
+    {{ form.title }}
+    <div id="title-count" class="char-count">0 / 300</div>
+    {{ form.title.errors }}
+  </div>
+
+  <div class="form-row">
+    <label for="{{ form.body.id_for_label }}">Body</label>
+    {{ form.body }}
+    <div id="body-count" class="char-count">0 / 40000</div>
+    {{ form.body.errors }}
+  </div>
+
+  <div class="form-row">
+    <label for="{{ form.url.id_for_label }}">Content URL</label>
+    {{ form.url }}
+    {{ form.url.errors }}
+  </div>
+
+  <input type="hidden" name="post_type" id="id_post_type" value="text">
+  {{ form.post_type.errors }}
+
+  <div class="form-actions">
+    <button class="button">Submit</button>
+    <a href="{% url 'community' community.slug %}">cancel</a>
+  </div>
+</form>
+{% endblock %}
+
+{% block scripts %}
+{{ block.super }}
+<script src="{% static 'js/editor.js' %}" defer></script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add new post form template with title, body, and URL fields
- apply system-ui font stack and form styles
- add auto-expanding textarea and character counters

## Testing
- `python manage.py test` *(fails: ValueError: The file 'css/base.css' could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3a5ad1a0c832cb14b490f96d2f311