### PR TITLE
Add lightweight markdown toolbar

### DIFF
--- a/static/js/editor.js
+++ b/static/js/editor.js
@@ -1,47 +1,38 @@
-document.addEventListener('DOMContentLoaded', () => {
-  const titleField = document.getElementById('id_title');
-  const bodyField = document.getElementById('id_body');
-  const urlField = document.getElementById('id_url');
-  const postTypeField = document.getElementById('id_post_type');
-  const titleCount = document.getElementById('title-count');
-  const bodyCount = document.getElementById('body-count');
-  const TITLE_MAX = 300;
-  const BODY_MAX = 40000;
+function initToolbar(root=document){
+  root.querySelectorAll('.editor-toolbar').forEach(tb=>{
+    if(tb.dataset.ready)return;tb.dataset.ready=1;
+    const ta=tb.nextElementSibling;if(!ta)return;
+    tb.querySelectorAll('button').forEach(b=>b.addEventListener('click',()=>{
+      const s=ta.selectionStart,e=ta.selectionEnd,v=ta.value,sel=v.slice(s,e);
+      if(b.dataset.wrap){const w=b.dataset.wrap;ta.value=v.slice(0,s)+w+sel+w+v.slice(e);ta.setSelectionRange(s+w.length,s+w.length+sel.length);} 
+      else if(b.dataset.link){const u=prompt('URL','https://');if(!u)return;const t=sel||'text',m=`[${t}](${u})`;ta.value=v.slice(0,s)+m+v.slice(e);ta.setSelectionRange(s+m.length,s+m.length);} 
+      else if(b.dataset.prefix){const p=b.dataset.prefix,l=sel.split('\n').map(x=>p+x).join('\n');ta.value=v.slice(0,s)+l+v.slice(e);ta.setSelectionRange(s,s+l.length);} 
+      ta.focus();ta.dispatchEvent(new Event('input',{bubbles:true}));
+    }));
+  });
+}
 
-  function updateCount(field, counter, max) {
-    if (!field || !counter) return;
-    counter.textContent = `${field.value.length} / ${max}`;
-  }
+document.addEventListener('DOMContentLoaded',()=>{
+  const titleField=document.getElementById('id_title');
+  const bodyField=document.getElementById('id_body');
+  const urlField=document.getElementById('id_url');
+  const postTypeField=document.getElementById('id_post_type');
+  const titleCount=document.getElementById('title-count');
+  const bodyCount=document.getElementById('body-count');
+  const TITLE_MAX=300,BODY_MAX=40000;
 
-  if (titleField && titleCount) {
-    updateCount(titleField, titleCount, TITLE_MAX);
-    titleField.addEventListener('input', () => updateCount(titleField, titleCount, TITLE_MAX));
-  }
+  function updateCount(f,c,m){if(!f||!c)return;c.textContent=`${f.value.length} / ${m}`;}
 
-  function autoResize(el) {
-    if (!el) return;
-    el.style.height = 'auto';
-    const max = window.innerHeight * 0.6;
-    const newHeight = Math.min(el.scrollHeight, max);
-    el.style.height = newHeight + 'px';
-  }
+  if(titleField&&titleCount){updateCount(titleField,titleCount,TITLE_MAX);titleField.addEventListener('input',()=>updateCount(titleField,titleCount,TITLE_MAX));}
 
-  if (bodyField && bodyCount) {
-    updateCount(bodyField, bodyCount, BODY_MAX);
-    autoResize(bodyField);
-    bodyField.addEventListener('input', () => {
-      updateCount(bodyField, bodyCount, BODY_MAX);
-      autoResize(bodyField);
-    });
-  }
+  function autoResize(el){if(!el)return;el.style.height='auto';const max=window.innerHeight*0.6;el.style.height=Math.min(el.scrollHeight,max)+'px';}
 
-  const form = document.querySelector('.post-form');
-  if (form) {
-    form.addEventListener('submit', () => {
-      if (postTypeField) {
-        const urlVal = urlField && urlField.value.trim();
-        postTypeField.value = urlVal ? 'link' : 'text';
-      }
-    });
-  }
+  if(bodyField&&bodyCount){updateCount(bodyField,bodyCount,BODY_MAX);autoResize(bodyField);bodyField.addEventListener('input',()=>{updateCount(bodyField,bodyCount,BODY_MAX);autoResize(bodyField);});}
+
+  const form=document.querySelector('.post-form');
+  if(form){form.addEventListener('submit',()=>{if(postTypeField){const urlVal=urlField&&urlField.value.trim();postTypeField.value=urlVal?'link':'text';}});}
+
+  initToolbar();
 });
+
+document.addEventListener('htmx:load',e=>initToolbar(e.detail.elt));

--- a/templates/core/partials/editor_toolbar.html
+++ b/templates/core/partials/editor_toolbar.html
@@ -1,0 +1,8 @@
+<div class="editor-toolbar">
+  <button type="button" data-wrap="**" title="Bold">B</button>
+  <button type="button" data-wrap="_" title="Italic">I</button>
+  <button type="button" data-link title="Link">link</button>
+  <button type="button" data-wrap="`" title="Code">`code`</button>
+  <button type="button" data-prefix="- " title="Bulleted list">•</button>
+  <button type="button" data-prefix="1. " title="Numbered list">1.</button>
+</div>

--- a/templates/core/partials/reply_form.html
+++ b/templates/core/partials/reply_form.html
@@ -3,6 +3,7 @@
           hx-target="#comment-{{ parent.pk }}"
           hx-swap="afterend">
         {% csrf_token %}
+        {% include "core/partials/editor_toolbar.html" %}
         {{ form.body }}
         <input type="hidden" name="parent_id" value="{{ parent.pk }}">
         <button type="submit">Reply</button>

--- a/templates/core/post_detail.html
+++ b/templates/core/post_detail.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load permissions %}
+{% load permissions static %}
 
 {% block content %}
 <div class="post-page">
@@ -73,9 +73,15 @@
 <div>
   <form hx-post="{% url 'comment_reply' post.pk %}" hx-target="#comments" hx-swap="beforeend">
     {% csrf_token %}
+    {% include "core/partials/editor_toolbar.html" %}
     {{ form.body }}
     <button type="submit">Comment</button>
   </form>
 </div>
+{% endblock %}
+
+{% block scripts %}
+{{ block.super }}
+<script src="{% static 'js/editor.js' %}" defer></script>
 {% endblock %}
 

--- a/templates/core/post_form.html
+++ b/templates/core/post_form.html
@@ -16,6 +16,7 @@
 
   <div class="form-row">
     <label for="{{ form.body.id_for_label }}">Body</label>
+    {% include "core/partials/editor_toolbar.html" %}
     {{ form.body }}
     <div id="body-count" class="char-count">0 / 40000</div>
     {{ form.body.errors }}

--- a/templates/core/submit_post.html
+++ b/templates/core/submit_post.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load static %}
 
 {% block content %}
 <h1>Submit to {{ community.title|default:community.slug }}</h1>
@@ -25,6 +26,7 @@
     {% if form.body %}
     <div class="form-row type-block" id="type-text">
       {{ form.body.label_tag }}
+      {% include "core/partials/editor_toolbar.html" %}
       {{ form.body }}
       {{ form.body.errors }}
     </div>
@@ -61,4 +63,9 @@
     if (sel){ show(sel.value || "text"); sel.addEventListener("change", e => show(e.target.value)); }
   })();
 </script>
+{% endblock %}
+
+{% block scripts %}
+{{ block.super }}
+<script src="{% static 'js/editor.js' %}" defer></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add reusable editor toolbar partial for markdown formatting
- extend editor.js with selection wrapping for toolbar buttons
- include toolbar and script in post and comment forms

## Testing
- `make test` *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3a747d8e8832c94805aca9f7ae194