### PR TITLE
Add Markdown preview with HTMX and bleach sanitization

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -6,6 +6,7 @@ urlpatterns = [
     # Home / front page
     path("", core_views.home, name="home"),
     path("mission/", core_views.mission, name="mission"),
+    path("preview/", core_views.render_preview, name="preview"),
 
     # Recovery codes
     path("accounts/recovery-codes/", core_views.recovery_codes, name="recovery_codes"),

--- a/core/views.py
+++ b/core/views.py
@@ -5,6 +5,10 @@ import secrets
 import string
 from datetime import timedelta
 
+import bleach
+import mistune
+from django.utils.safestring import mark_safe
+
 from django.contrib import messages
 from django.contrib.auth import login
 from django.contrib.auth.decorators import login_required
@@ -53,6 +57,26 @@ def limit_or_429(request, group, rate):
         method=["POST"],
         increment=True,
     )
+
+
+markdown_renderer = mistune.create_markdown()
+ALLOWED_TAGS = [
+    "p",
+    "h1",
+    "h2",
+    "h3",
+    "a",
+    "strong",
+    "em",
+    "code",
+    "pre",
+    "ul",
+    "ol",
+    "li",
+    "blockquote",
+    "br",
+]
+ALLOWED_ATTRIBUTES = {"a": ["href"]}
 def mission(request):
     return render(request, "core/mission.html")
 
@@ -197,6 +221,16 @@ def download_recovery_codes(request):
     resp = HttpResponse("\n".join(codes), content_type="text/plain")
     resp["Content-Disposition"] = "attachment; filename=recovery-codes.txt"
     return resp
+
+
+@require_POST
+def render_preview(request):
+    text = request.POST.get("text") or request.POST.get("body", "")
+    html = markdown_renderer(text)
+    clean = bleach.clean(html, tags=ALLOWED_TAGS, attributes=ALLOWED_ATTRIBUTES)
+    return render(
+        request, "core/partials/preview.html", {"html": mark_safe(clean)}
+    )
 
 
 @login_required

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,5 @@ sqlparse==0.5.3
 typing_extensions==4.14.1
 tzdata==2025.2
 whitenoise==6.6.0
+mistune>=3
+bleach>=6

--- a/static/js/editor.js
+++ b/static/js/editor.js
@@ -22,6 +22,30 @@ function initToolbar(root=document){
   });
 }
 
+function initPreview(root=document){
+  root.querySelectorAll('.editor-container').forEach(ed=>{
+    if(ed.dataset.previewReady)return;ed.dataset.previewReady=1;
+    const write=ed.querySelector('.tab-write');
+    const preview=ed.querySelector('.tab-preview');
+    const ta=ed.querySelector('textarea');
+    const pv=ed.querySelector('.preview');
+    if(write&&preview&&ta&&pv){
+      write.addEventListener('click',()=>{
+        write.classList.add('active');
+        preview.classList.remove('active');
+        ta.style.display='';
+        pv.style.display='none';
+      });
+      preview.addEventListener('click',()=>{
+        preview.classList.add('active');
+        write.classList.remove('active');
+        ta.style.display='none';
+        pv.style.display='';
+      });
+    }
+  });
+}
+
 document.addEventListener('DOMContentLoaded',()=>{
   const titleField=document.getElementById('id_title');
   const bodyField=document.getElementById('id_body');
@@ -43,6 +67,7 @@ document.addEventListener('DOMContentLoaded',()=>{
   if(form){form.addEventListener('submit',()=>{if(postTypeField){const urlVal=urlField&&urlField.value.trim();postTypeField.value=urlVal?'link':'text';}});}
 
   initToolbar();
+  initPreview();
 });
 
-document.addEventListener('htmx:load',e=>initToolbar(e.detail.elt));
+document.addEventListener('htmx:load',e=>{initToolbar(e.detail.elt);initPreview(e.detail.elt);});

--- a/templates/core/partials/preview.html
+++ b/templates/core/partials/preview.html
@@ -1,0 +1,6 @@
+{% if html %}
+{{ html|safe }}
+{% else %}
+<p><em>Nothing to preview.</em></p>
+{% endif %}
+

--- a/templates/core/partials/reply_form.html
+++ b/templates/core/partials/reply_form.html
@@ -3,8 +3,20 @@
           hx-target="#comment-{{ parent.pk }}"
           hx-swap="afterend">
         {% csrf_token %}
-        {% include "core/partials/editor_toolbar.html" %}
-        {{ form.body }}
+        <div class="editor-container">
+            <div class="editor-tabs">
+                <button type="button" class="tab tab-write active">Write</button>
+                <button type="button"
+                        class="tab tab-preview"
+                        hx-post="{% url 'preview' %}"
+                        hx-include="[name=body]"
+                        hx-target="#preview-{{ parent.pk }}"
+                        hx-swap="innerHTML">Preview</button>
+            </div>
+            {% include "core/partials/editor_toolbar.html" %}
+            {{ form.body }}
+            <div id="preview-{{ parent.pk }}" class="preview" style="display:none"></div>
+        </div>
         <input type="hidden" name="parent_id" value="{{ parent.pk }}">
         <button type="submit">Reply</button>
     </form>

--- a/templates/core/post_form.html
+++ b/templates/core/post_form.html
@@ -16,8 +16,24 @@
 
   <div class="form-row">
     <label for="{{ form.body.id_for_label }}">Body</label>
-    {% include "core/partials/editor_toolbar.html" %}
-    {{ form.body }}
+    <div class="editor-container">
+      <div class="editor-tabs">
+        <button type="button" class="tab tab-write active">Write</button>
+        <button
+          type="button"
+          class="tab tab-preview"
+          hx-post="{% url 'preview' %}"
+          hx-include="[name=body]"
+          hx-target="#post-preview"
+          hx-swap="innerHTML"
+        >
+          Preview
+        </button>
+      </div>
+      {% include "core/partials/editor_toolbar.html" %}
+      {{ form.body }}
+      <div id="post-preview" class="preview" style="display:none"></div>
+    </div>
     <div id="body-count" class="char-count">0 / 40000</div>
     {{ form.body.errors }}
   </div>


### PR DESCRIPTION
## Summary
- Render Markdown previews via new `/preview` endpoint
- Add Write/Preview tabs with HTMX swapping for posts and comments
- Sanitize previewed HTML and extend editor JavaScript

## Testing
- `python manage.py collectstatic --noinput`
- `python manage.py test` *(fails: PostDeleteOwnerTests expected status codes differ)*

------
https://chatgpt.com/codex/tasks/task_e_68b3a96a59cc832c9d5bcaad5277bb61