### PR TITLE
Add oEmbed preview for link posts

### DIFF
--- a/core/tests_oembed_preview.py
+++ b/core/tests_oembed_preview.py
@@ -1,0 +1,52 @@
+import os
+import requests
+from unittest.mock import Mock, patch
+from django.urls import reverse
+from django.test import Client
+
+import django
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+django.setup()
+
+from core.views import fetch_oembed
+
+
+def _mock_response(json=None, text="", status=200):
+    resp = Mock()
+    resp.json.return_value = json
+    resp.text = text
+    def raise_for_status():
+        if status >= 400:
+            raise requests.HTTPError()
+    resp.raise_for_status = raise_for_status
+    return resp
+
+
+def test_fetch_oembed_youtube_removes_scripts():
+    sample_html = '<iframe src="https://youtube.com/embed/abc"></iframe><script>alert(1)</script>'
+    with patch("requests.get", return_value=_mock_response(json={"html": sample_html})):
+        data = fetch_oembed("https://www.youtube.com/watch?v=abc")
+    assert data["type"] == "embed"
+    assert "script" not in data["html"].lower()
+
+
+def test_fetch_oembed_falls_back_to_link_card():
+    def side_effect(url, *args, **kwargs):
+        if "oembed" in url:
+            raise requests.RequestException()
+        return _mock_response(text="<title>Example Domain</title>")
+    with patch("requests.get", side_effect=side_effect):
+        data = fetch_oembed("https://example.com")
+    assert data["type"] == "link"
+    assert data["domain"] == "example.com"
+    assert data["title"] == "Example Domain"
+
+
+def test_oembed_preview_view_uses_helper():
+    client = Client()
+    with patch("core.views.fetch_oembed", return_value={"type": "link", "domain": "example.com", "favicon": "f", "url": "https://example.com", "title": "Example"}) as mock_fetch:
+        resp = client.post(reverse("oembed_preview"), {"url": "https://example.com"}, HTTP_HOST="localhost")
+    assert resp.status_code == 200
+    assert "example.com" in resp.content.decode()
+    mock_fetch.assert_called_once()

--- a/core/urls.py
+++ b/core/urls.py
@@ -7,6 +7,7 @@ urlpatterns = [
     path("", core_views.home, name="home"),
     path("mission/", core_views.mission, name="mission"),
     path("preview/", core_views.render_preview, name="preview"),
+    path("oembed/preview/", core_views.oembed_preview, name="oembed_preview"),
 
     # Recovery codes
     path("accounts/recovery-codes/", core_views.recovery_codes, name="recovery_codes"),

--- a/core/views.py
+++ b/core/views.py
@@ -5,6 +5,10 @@ import secrets
 import string
 from datetime import timedelta
 
+import re
+from urllib.parse import urlparse, quote
+
+import requests
 import bleach
 import mistune
 from django.utils.safestring import mark_safe
@@ -77,6 +81,98 @@ ALLOWED_TAGS = [
     "br",
 ]
 ALLOWED_ATTRIBUTES = {"a": ["href"]}
+
+
+def fetch_oembed(url: str):
+    """Fetch and sanitize oEmbed HTML for supported providers.
+
+    If unsupported or fetch fails, return a fallback link card.
+    """
+
+    providers = {
+        "youtube.com": "https://www.youtube.com/oembed?format=json&url=",
+        "youtu.be": "https://www.youtube.com/oembed?format=json&url=",
+        "rumble.com": "https://rumble.com/api/oembed.json?url=",
+        "twitter.com": "https://publish.twitter.com/oembed?omit_script=1&url=",
+        "x.com": "https://publish.twitter.com/oembed?omit_script=1&url=",
+    }
+
+    parsed = urlparse(url)
+    domain = parsed.netloc
+    endpoint = None
+    for key, base in providers.items():
+        if key in domain:
+            endpoint = f"{base}{quote(url, safe='')}"
+            break
+
+    if endpoint:
+        try:
+            resp = requests.get(endpoint, timeout=5)
+            resp.raise_for_status()
+            data = resp.json()
+            html = data.get("html", "")
+            clean = bleach.clean(
+                html,
+                tags=[
+                    "iframe",
+                    "blockquote",
+                    "a",
+                    "p",
+                    "span",
+                    "img",
+                    "br",
+                    "div",
+                ],
+                attributes={
+                    "iframe": [
+                        "src",
+                        "width",
+                        "height",
+                        "frameborder",
+                        "allow",
+                        "allowfullscreen",
+                    ],
+                    "blockquote": ["class", "data-theme"],
+                    "a": ["href", "class"],
+                    "img": ["src", "alt"],
+                    "div": ["class"],
+                },
+                strip=True,
+            )
+            return {"type": "embed", "html": clean}
+        except Exception:
+            pass
+
+    # Fallback link card
+    title = None
+    try:
+        resp = requests.get(url, timeout=5)
+        resp.raise_for_status()
+        match = re.search(r"<title>(.*?)</title>", resp.text, re.IGNORECASE | re.DOTALL)
+        if match:
+            title = match.group(1).strip()
+    except Exception:
+        pass
+    favicon = f"https://www.google.com/s2/favicons?domain={domain}&sz=64"
+    return {
+        "type": "link",
+        "url": url,
+        "domain": domain,
+        "title": title,
+        "favicon": favicon,
+    }
+
+
+@require_POST
+def oembed_preview(request):
+    url = request.POST.get("url", "").strip()
+    if not url:
+        return HttpResponse("")
+    data = fetch_oembed(url)
+    html = render_to_string("core/partials/link_preview.html", data)
+    return HttpResponse(html)
+
+
 def mission(request):
     return render(request, "core/mission.html")
 

--- a/templates/core/partials/link_preview.html
+++ b/templates/core/partials/link_preview.html
@@ -1,0 +1,13 @@
+{% if type == 'embed' %}
+<div class="link-embed">{{ html|safe }}</div>
+{% elif type == 'link' %}
+<div class="link-card">
+  <div class="link-card-inner">
+    <img src="{{ favicon }}" alt="" class="link-favicon">
+    <div class="link-meta">
+      <div class="link-domain">{{ domain }}</div>
+      {% if title %}<div class="link-title">{{ title }}</div>{% endif %}
+    </div>
+  </div>
+</div>
+{% endif %}

--- a/templates/core/post_form.html
+++ b/templates/core/post_form.html
@@ -40,9 +40,19 @@
 
   <div class="form-row">
     <label for="{{ form.url.id_for_label }}">Content URL</label>
-    {{ form.url }}
+    <input type="url"
+           name="url"
+           id="{{ form.url.id_for_label }}"
+           value="{{ form.url.value|default:'' }}"
+           hx-post="{% url 'oembed_preview' %}"
+           hx-trigger="change, keyup delay:500ms"
+           hx-target="#link-preview"
+           hx-swap="innerHTML"
+           hx-include="[name=url]"
+    >
     {{ form.url.errors }}
   </div>
+  <div id="link-preview"></div>
 
   <input type="hidden" name="post_type" id="id_post_type" value="text">
   {{ form.post_type.errors }}


### PR DESCRIPTION
## Summary
- fetch and sanitize oEmbed data for YouTube, Rumble, or X, with link-card fallback
- add `/oembed/preview/` endpoint and HTMX-powered preview in post form
- render embed or compact link card via new `link_preview` partial

## Testing
- `python manage.py test core` *(fails: The file 'css/base.css' could not be found with <whitenoise.storage.CompressedManifestStaticFilesStorage object>)*
- `pytest core/tests_oembed_preview.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b3ae8a40a8832c92e687c0e8381229