### PR TITLE
Make comment composer compact with preview

### DIFF
--- a/static/js/editor.js
+++ b/static/js/editor.js
@@ -2,6 +2,7 @@ function initToolbar(root=document){
   root.querySelectorAll('.editor-toolbar').forEach(tb=>{
     if(tb.dataset.ready)return;tb.dataset.ready=1;
     const ta=tb.nextElementSibling;if(!ta)return;
+    if(!ta.closest('.post-form')){ta.style.lineHeight='1.5';ta.style.maxWidth='65ch';if(ta.parentElement){ta.parentElement.style.maxWidth='65ch';ta.parentElement.style.lineHeight='1.5';}}
     tb.querySelectorAll('button').forEach(b=>b.addEventListener('click',()=>{
       const s=ta.selectionStart,e=ta.selectionEnd,v=ta.value,sel=v.slice(s,e);
       if(b.dataset.wrap){const w=b.dataset.wrap;ta.value=v.slice(0,s)+w+sel+w+v.slice(e);ta.setSelectionRange(s+w.length,s+w.length+sel.length);}

--- a/templates/core/partials/comment_form.html
+++ b/templates/core/partials/comment_form.html
@@ -1,0 +1,21 @@
+<form hx-post="{% url 'comment_reply' post.pk %}"
+      hx-target="#comments"
+      hx-swap="beforeend"
+      class="comment-form">
+  {% csrf_token %}
+  <div class="editor-container" style="line-height:1.5">
+    <div class="editor-tabs">
+      <button type="button" class="tab tab-write active">Write</button>
+      <button type="button"
+              class="tab tab-preview"
+              hx-post="{% url 'preview' %}"
+              hx-include="[name=body]"
+              hx-target="#comment-preview"
+              hx-swap="innerHTML">Preview</button>
+    </div>
+    {% include "core/partials/editor_toolbar.html" %}
+    {{ form.body }}
+    <div id="comment-preview" class="preview" style="display:none"></div>
+  </div>
+  <button type="submit">Comment</button>
+</form>

--- a/templates/core/partials/comment_item.html
+++ b/templates/core/partials/comment_item.html
@@ -19,10 +19,10 @@
       </form>
     {% endif %}
   </div>
-  <div class="body">{{ comment.body|linebreaksbr }}</div>
+  <div class="body" style="line-height:1.5;max-width:65ch">{{ comment.body|linebreaksbr }}</div>
   <div class="children">
     {% for child in comment.children.all %}
-      {% include "core/partials/comment.html" with comment=child %}
+      {% include "core/partials/comment_item.html" with comment=child %}
     {% endfor %}
   </div>
 </div>

--- a/templates/core/post_detail.html
+++ b/templates/core/post_detail.html
@@ -64,19 +64,14 @@
 <div id="comments">
   {% for comment in comments %}
     {% if not comment.parent_id %}
-      {% include "core/partials/comment.html" %}
+      {% include "core/partials/comment_item.html" %}
     {% endif %}
   {% empty %}
     <p>No comments yet.</p>
   {% endfor %}
 </div>
 <div>
-  <form hx-post="{% url 'comment_reply' post.pk %}" hx-target="#comments" hx-swap="beforeend">
-    {% csrf_token %}
-    {% include "core/partials/editor_toolbar.html" %}
-    {{ form.body }}
-    <button type="submit">Comment</button>
-  </form>
+  {% include "core/partials/comment_form.html" %}
 </div>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- Create reusable comment form partial with toolbar and preview tabs
- Style comment display and composer for 1.5 line-height and 65ch width
- Limit editor width in JS for non-post forms

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b3b0797318832c8f07359de97a8c99