### PR TITLE
Improve form submission UX with spinners and error handling

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -87,3 +87,26 @@ li + li {
   overflow-y: auto;
   max-height: 60vh;
 }
+
+.spinner {
+  display: inline-block;
+  width: 1em;
+  height: 1em;
+  border: 2px solid currentColor;
+  border-right-color: transparent;
+  border-radius: 50%;
+  animation: spin 0.6s linear infinite;
+  margin-left: 4px;
+  vertical-align: middle;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.form-error {
+  color: #b91c1c;
+  margin-top: 4px;
+}

--- a/static/js/editor.js
+++ b/static/js/editor.js
@@ -102,3 +102,45 @@ document.addEventListener('DOMContentLoaded',()=>{
 });
 
 document.addEventListener('htmx:load',e=>{initToolbar(e.detail.elt);initPreview(e.detail.elt);initDrafts(e.detail.elt);});
+
+function toggleSubmit(form,on){
+  if(!form)return;
+  const btn=form.querySelector('button[type="submit"],input[type="submit"]');
+  if(!btn)return;
+  btn.disabled=on;
+  const sp=btn.querySelector('.spinner');
+  if(sp)sp.hidden=!on;
+  if(on)showFormError(form,'');
+}
+
+function showFormError(form,msg){
+  const box=form.querySelector('.form-error');
+  if(box){box.textContent=msg;box.style.display=msg?'block':'none';}
+}
+
+document.addEventListener('submit',e=>{toggleSubmit(e.target,true);},true);
+document.body.addEventListener('htmx:beforeRequest',e=>{const f=e.detail.elt.closest('form');toggleSubmit(f,true);});
+document.body.addEventListener('htmx:responseError',e=>{e.preventDefault();const f=e.detail.elt.closest('form');const msg=e.detail.xhr&&e.detail.xhr.responseText?e.detail.xhr.responseText:'Error submitting form';toggleSubmit(f,false);showFormError(f,msg);});
+document.body.addEventListener('htmx:sendError',e=>{e.preventDefault();const f=e.detail.elt.closest('form');toggleSubmit(f,false);showFormError(f,'Network error');});
+document.body.addEventListener('htmx:afterRequest',e=>{const f=e.detail.elt.closest('form');if(f&&e.detail.xhr&&e.detail.xhr.status<400)toggleSubmit(f,false);});
+
+let lastFocus=null,lastScroll=null;
+document.body.addEventListener('htmx:beforeSwap',()=>{
+  const ae=document.activeElement;
+  lastFocus=null;
+  if(ae&&(ae.id||ae.name)){
+    lastFocus={id:ae.id,name:ae.name,start:ae.selectionStart,end:ae.selectionEnd};
+  }
+  lastScroll={x:window.scrollX,y:window.scrollY};
+});
+document.body.addEventListener('htmx:afterSwap',()=>{
+  if(lastScroll)window.scrollTo(lastScroll.x,lastScroll.y);
+  if(lastFocus){
+    const el=lastFocus.id?document.getElementById(lastFocus.id):document.querySelector(`[name="${lastFocus.name}"]`);
+    if(el){
+      el.focus();
+      if(lastFocus.start!=null)try{el.setSelectionRange(lastFocus.start,lastFocus.end);}catch{}
+    }
+  }
+  lastFocus=null;lastScroll=null;
+});

--- a/templates/core/partials/comment_form.html
+++ b/templates/core/partials/comment_form.html
@@ -3,6 +3,7 @@
       hx-swap="beforeend"
       class="comment-form">
   {% csrf_token %}
+  <div class="form-error" role="alert" style="display:none"></div>
   <div class="editor-container" style="line-height:1.5">
     <div class="editor-tabs">
       <button type="button" class="tab tab-write active">Write</button>
@@ -17,5 +18,5 @@
     {{ form.body }}
     <div id="comment-preview" class="preview" style="display:none"></div>
   </div>
-  <button type="submit">Comment</button>
+  <button type="submit">Comment<span class="spinner" hidden aria-hidden="true"></span></button>
 </form>

--- a/templates/core/partials/reply_form.html
+++ b/templates/core/partials/reply_form.html
@@ -1,8 +1,9 @@
 <div style="margin-left: {% widthratio parent.depth|add:'1' 1 20 %}px" hx-on="htmx:afterRequest:this.remove()">
-    <form hx-post="{% url 'comment_reply' post.pk %}"
+        <form hx-post="{% url 'comment_reply' post.pk %}"
           hx-target="#comment-{{ parent.pk }}"
           hx-swap="afterend">
         {% csrf_token %}
+        <div class="form-error" role="alert" style="display:none"></div>
         <div class="editor-container">
             <div class="editor-tabs">
                 <button type="button" class="tab tab-write active">Write</button>
@@ -18,6 +19,6 @@
             <div id="preview-{{ parent.pk }}" class="preview" style="display:none"></div>
         </div>
         <input type="hidden" name="parent_id" value="{{ parent.pk }}">
-        <button type="submit">Reply</button>
-    </form>
-</div>
+        <button type="submit">Reply<span class="spinner" hidden aria-hidden="true"></span></button>
+        </form>
+    </div>

--- a/templates/core/post_form.html
+++ b/templates/core/post_form.html
@@ -6,6 +6,7 @@
 <form method="post" action="{% url 'submit_post' community.slug %}" class="post-form" hx-boost="false" hx-swap="none">
   {% csrf_token %}
   {{ form.non_field_errors }}
+  <div class="form-error" role="alert" style="display:none"></div>
 
   <div class="form-row">
     <label for="{{ form.title.id_for_label }}">Title</label>
@@ -58,7 +59,7 @@
   {{ form.post_type.errors }}
 
   <div class="form-actions">
-    <button class="button">Submit</button>
+    <button class="button" type="submit">Submit<span class="spinner" hidden aria-hidden="true"></span></button>
     <a href="{% url 'community' community.slug %}">cancel</a>
   </div>
 </form>

--- a/templates/core/submit_post.html
+++ b/templates/core/submit_post.html
@@ -8,6 +8,7 @@
   <form method="post" action="{% url 'submit_post' community.slug %}" enctype="multipart/form-data" class="submit-form" hx-boost="false" hx-swap="none">
     {% csrf_token %}
     {{ form.non_field_errors }}
+    <div class="form-error" role="alert" style="display:none"></div>
 
     {% if form.title %}
     <div class="form-row">
@@ -49,7 +50,7 @@
     {% endif %}
 
     <div class="form-actions">
-      <button class="button">Submit</button>
+      <button class="button" type="submit">Submit<span class="spinner" hidden aria-hidden="true"></span></button>
       <a href="{% url 'community' community.slug %}">cancel</a>
     </div>
   </form>


### PR DESCRIPTION
## Summary
- Add CSS spinner and inline error styles
- Disable submit buttons during requests and show spinner; re-enable on error
- Preserve focus and scroll positions across HTMX swaps

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3b2d51e7c832cbe744218e8033992