### PR TITLE
Enable inline HTMX replies for comments

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -41,6 +41,8 @@ urlpatterns = [
     path("comment/<int:post_id>/reply/", core_views.comment_reply, name="comment_reply"),
     path("comment/<int:post_id>/reply-form/", core_views.comment_reply_form, name="comment_reply_form"),
     path("comment/<int:pk>/delete/", core_views.comment_delete, name="comment_delete"),
+    path("comments/new", core_views.comment_new, name="comment_new"),
+    path("comments/create", core_views.comment_create, name="comment_create"),
     path("vote/post/<int:pk>/", core_views.vote_post, name="vote_post"),
     path("vote/comment/<int:pk>/", core_views.vote_comment, name="vote_comment"),
     # Post moderation

--- a/core/views.py
+++ b/core/views.py
@@ -536,6 +536,96 @@ def comment_reply(request, post_id):
 
 @login_required
 @require_http_methods(["GET"])
+def comment_new(request):
+    """Return a comment form for replying via HTMX."""
+
+    if _is_banned(request.user):
+        return HttpResponseForbidden("Account banned")
+    if request.headers.get("HX-Request") != "true":
+        return HttpResponseBadRequest("Invalid request")
+
+    post_id = request.GET.get("post")
+    parent_id = request.GET.get("parent")
+    if not post_id:
+        return HttpResponseBadRequest("Missing post")
+    post = get_object_or_404(Post, pk=post_id)
+    parent = None
+    if parent_id:
+        parent = get_object_or_404(Comment, pk=parent_id, post=post)
+    form = CommentForm()
+    html = render_to_string(
+        "core/partials/comment_form.html",
+        {"form": form, "post": post, "parent": parent},
+        request=request,
+    )
+    return HttpResponse(html)
+
+
+@login_required
+@require_POST
+def comment_create(request):
+    """Create a new comment via HTMX."""
+
+    if _is_banned(request.user):
+        return HttpResponseForbidden("Account banned")
+
+    if is_new_user(request.user):
+        if limit_or_429(request, "comment_new_user", "3/m"):
+            return render(request, "429.html", status=429)
+    else:
+        if limit_or_429(request, "comment_established", "10/m"):
+            return render(request, "429.html", status=429)
+
+    post_id = request.POST.get("post")
+    if not post_id:
+        return HttpResponseBadRequest("Missing post")
+    post = get_object_or_404(Post, pk=post_id)
+
+    form = CommentForm(request.POST)
+    if not form.is_valid():
+        return HttpResponseBadRequest("Invalid comment")
+
+    parent_id = request.POST.get("parent")
+    parent = None
+    if parent_id:
+        parent = get_object_or_404(Comment, pk=parent_id, post=post)
+        child_seq = parent.children.count() + 1
+        path = f"{parent.path}/{child_seq:04d}"
+    else:
+        root_seq = post.comments.filter(parent__isnull=True).count() + 1
+        path = f"{root_seq:04d}"
+
+    comment = Comment.objects.create(
+        post=post,
+        author=request.user,
+        parent=parent,
+        body=form.cleaned_data["body"],
+        path=path,
+    )
+    Post.objects.filter(pk=post.pk).update(comment_count=F("comment_count") + 1)
+    post.refresh_from_db(fields=["comment_count"])
+
+    if request.headers.get("HX-Request") == "true":
+        item_html = render_to_string(
+            "core/partials/comment_item.html", {"comment": comment}, request=request
+        )
+        plural = "s" if post.comment_count != 1 else ""
+        count_html = (
+            f'<a href="#comments" id="comment-count" hx-swap-oob="outerHTML">'
+            f"{post.comment_count} comment{plural}</a>"
+        )
+        return HttpResponse(item_html + count_html)
+
+    return redirect(
+        "post_detail",
+        slug=post.community.slug,
+        post_id=post.pk,
+        post_slug=slugify(post.title),
+    )
+
+
+@login_required
+@require_http_methods(["GET"])
 def comment_reply_form(request, post_id):
     """Render the comment reply form via HTMX."""
 

--- a/templates/core/partials/comment_form.html
+++ b/templates/core/partials/comment_form.html
@@ -1,8 +1,16 @@
-<form hx-post="{% url 'comment_reply' post.pk %}"
+<form hx-post="{% url 'comment_create' %}"
+      {% if parent %}
+      hx-swap="afterend"
+      {% else %}
       hx-target="#comments"
       hx-swap="beforeend"
+      {% endif %}
       class="comment-form">
   {% csrf_token %}
+  <input type="hidden" name="post" value="{{ post.pk }}">
+  {% if parent %}
+  <input type="hidden" name="parent" value="{{ parent.pk }}">
+  {% endif %}
   <div class="form-error" role="alert" style="display:none"></div>
   <div class="editor-container" style="line-height:1.5">
     <div class="editor-tabs">
@@ -15,7 +23,11 @@
               hx-swap="innerHTML">Preview</button>
     </div>
     {% include "core/partials/editor_toolbar.html" %}
-    {{ form.body }}
+    {% if parent %}
+      {{ form.body.as_widget(attrs={"autofocus": "autofocus"}) }}
+    {% else %}
+      {{ form.body }}
+    {% endif %}
     <div id="comment-preview" class="preview" style="display:none"></div>
   </div>
   <button type="submit">Comment<span class="spinner" hidden aria-hidden="true"></span></button>

--- a/templates/core/partials/comment_item.html
+++ b/templates/core/partials/comment_item.html
@@ -9,8 +9,8 @@
     <button hx-post="{% url 'vote_comment' comment.pk %}?v=-1"
             hx-target="#comment-score-{{ comment.pk }}"
             hx-swap="outerHTML" aria-label="Downvote" class="down">▼</button>
-    <button hx-get="{% url 'comment_reply_form' comment.post.pk %}?parent_id={{ comment.pk }}"
-            hx-target="#comment-{{ comment.pk }}" hx-swap="afterend">reply</button>
+    <button hx-get="/comments/new?parent={{ comment.pk }}&post={{ comment.post.pk }}"
+            hx-target="#comment-{{ comment.pk }}" hx-swap="afterend">Reply</button>
     {% if request.user.id == comment.author_id or request.user.is_staff %}
       <form method="post" action="{% url 'comment_delete' comment.pk %}" style="display:inline"
             hx-post="{% url 'comment_delete' comment.pk %}" hx-target="#comment-{{ comment.pk }}" hx-swap="outerHTML">

--- a/templates/core/post_detail.html
+++ b/templates/core/post_detail.html
@@ -36,7 +36,7 @@
         {% endif %}
       </div>
       <nav class="post-actions">
-        <a href="#comments">
+        <a href="#comments" id="comment-count">
           {{ post.comment_count }} comment{{ post.comment_count|pluralize }}
         </a>
         <a href="#" onclick="navigator.clipboard.writeText(window.location.href);return false;">share</a>


### PR DESCRIPTION
## Summary
- Allow replying inline to comments via HTMX
- Post comment form dynamically and update comments without reload
- Update comment count out-of-band after new replies

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3b75f4acc832cbb1990fb4961d1cb