### PR TITLE
Add comment thread collapse and depth compaction

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -131,3 +131,25 @@ li + li {
   color: #b91c1c;
   margin-top: 4px;
 }
+
+/* Comment collapse and load-more controls */
+.comment .collapse-toggle {
+  background: none;
+  border: 0;
+  cursor: pointer;
+  margin-right: 4px;
+}
+
+.comment.collapsed > .children { display: none; }
+
+.comment.collapsed .collapse-toggle { transform: rotate(-90deg); }
+
+.more-replies { margin-top: 4px; }
+
+.more-replies .load-more {
+  background: none;
+  border: 0;
+  color: var(--link, #1d4ed8);
+  cursor: pointer;
+  padding: 0;
+}

--- a/static/js/comments.js
+++ b/static/js/comments.js
@@ -1,0 +1,16 @@
+function initCommentCollapse(root=document){
+  root.querySelectorAll('.collapse-toggle').forEach(btn=>{
+    if(btn.dataset.ready) return;
+    btn.dataset.ready = '1';
+    btn.addEventListener('click',()=>{
+      const comment = btn.closest('.comment');
+      if(!comment) return;
+      const isCollapsed = comment.classList.toggle('collapsed');
+      btn.setAttribute('aria-expanded', (!isCollapsed).toString());
+    });
+  });
+}
+
+document.addEventListener('DOMContentLoaded',()=>{initCommentCollapse();});
+
+document.body.addEventListener('htmx:afterSwap',e=>{initCommentCollapse(e.detail.elt);});

--- a/templates/core/partials/comment_item.html
+++ b/templates/core/partials/comment_item.html
@@ -1,5 +1,6 @@
-<div id="comment-{{ comment.pk }}" class="comment">
+<div id="comment-{{ comment.pk }}" class="comment" data-comment-id="{{ comment.pk }}" data-depth="{{ comment.depth }}">
   <div class="meta">
+    <button class="collapse-toggle" data-comment-id="{{ comment.pk }}" aria-label="Collapse thread">▾</button>
     by <a href="{% url 'user_overview' comment.author.username %}">{{ comment.author.username }}</a>
     • {{ comment.created_at|timesince }} ago
     <button hx-post="{% url 'vote_comment' comment.pk %}?v=1"
@@ -20,10 +21,25 @@
     {% endif %}
   </div>
   <div class="comment-body prose">{{ comment.body|safe }}</div>
+  {% if comment.depth < 5 %}
   <div class="children">
     {% for child in comment.children.all %}
       {% include "core/partials/comment_item.html" with comment=child %}
     {% endfor %}
   </div>
+  {% else %}
+    {% with child_count=comment.children.count %}
+      {% if child_count %}
+        <div class="children more-replies">
+          <button class="linklike load-more"
+                  hx-get="/comments/children?parent={{ comment.pk }}"
+                  hx-target="closest .children"
+                  hx-swap="outerHTML">
+            Show {{ child_count }} more repl{{ child_count|pluralize:'y,ies' }}
+          </button>
+        </div>
+      {% endif %}
+    {% endwith %}
+  {% endif %}
 </div>
 

--- a/templates/core/post_detail.html
+++ b/templates/core/post_detail.html
@@ -80,5 +80,6 @@
 {% block scripts %}
 {{ block.super }}
 <script src="{% static 'js/editor.js' %}" defer></script>
+<script src="{% static 'js/comments.js' %}" defer></script>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- Add collapse toggle and depth-aware child loading to comment tree
- Style comment collapse controls and load-more stubs
- Include JS to handle comment collapsing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3b89d7184832c9aaa79b96b3d6a76