### PR TITLE
Add progressive loading for comment replies

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -43,6 +43,7 @@ urlpatterns = [
     path("comment/<int:pk>/delete/", core_views.comment_delete, name="comment_delete"),
     path("comments/new", core_views.comment_new, name="comment_new"),
     path("comments/create", core_views.comment_create, name="comment_create"),
+    path("comments/children", core_views.comment_children, name="comment_children"),
     path("vote/post/<int:pk>/", core_views.vote_post, name="vote_post"),
     path("vote/comment/<int:pk>/", core_views.vote_comment, name="vote_comment"),
     # Post moderation

--- a/core/views.py
+++ b/core/views.py
@@ -534,6 +534,41 @@ def comment_reply(request, post_id):
     )
 
 
+def comment_children(request):
+    """Return a batch of child comments for progressive loading."""
+
+    if request.headers.get("HX-Request") != "true":
+        return HttpResponseBadRequest("Invalid request")
+
+    parent_id = request.GET.get("parent")
+    if not parent_id:
+        return HttpResponseBadRequest("Missing parent")
+
+    try:
+        offset = int(request.GET.get("offset", 0))
+    except (TypeError, ValueError):
+        return HttpResponseBadRequest("Invalid offset")
+
+    parent = get_object_or_404(Comment, pk=parent_id)
+    children_qs = parent.children.select_related("author").order_by("path")
+    total = children_qs.count()
+    children = list(children_qs[offset : offset + PAGE_SIZE])
+    next_offset = offset + len(children)
+    remaining = max(0, total - next_offset)
+
+    html = render_to_string(
+        "core/partials/comment_children.html",
+        {
+            "children": children,
+            "parent": parent,
+            "next_offset": next_offset,
+            "remaining": remaining,
+        },
+        request=request,
+    )
+    return HttpResponse(html)
+
+
 @login_required
 @require_http_methods(["GET"])
 def comment_new(request):

--- a/templates/core/partials/comment_children.html
+++ b/templates/core/partials/comment_children.html
@@ -1,0 +1,12 @@
+{% for comment in children %}
+  {% include "core/partials/comment_item.html" with comment=comment %}
+{% endfor %}
+{% if remaining > 0 %}
+  <button class="linklike load-more"
+          hx-get="/comments/children?parent={{ parent.pk }}&offset={{ next_offset }}"
+          hx-swap="afterend"
+          hx-on="htmx:afterSwap:this.remove()">
+    Show more replies ({{ remaining }})
+  </button>
+{% endif %}
+

--- a/templates/core/partials/comment_item.html
+++ b/templates/core/partials/comment_item.html
@@ -32,10 +32,10 @@
       {% if child_count %}
         <div class="children more-replies">
           <button class="linklike load-more"
-                  hx-get="/comments/children?parent={{ comment.pk }}"
-                  hx-target="closest .children"
-                  hx-swap="outerHTML">
-            Show {{ child_count }} more repl{{ child_count|pluralize:'y,ies' }}
+                  hx-get="/comments/children?parent={{ comment.pk }}&offset=0"
+                  hx-swap="afterend"
+                  hx-on="htmx:afterSwap:this.remove()">
+            Show more replies ({{ child_count }})
           </button>
         </div>
       {% endif %}


### PR DESCRIPTION
## Summary
- paginate comment reply chains via new `/comments/children` HTMX endpoint
- add `comment_children.html` partial and update comment templates for incremental loading
- expose URL route for loading additional comment children

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3b9bacb74832cbb9b5f876ae43636