### PR TITLE
Add HTMX preview tab

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -6,7 +6,7 @@ urlpatterns = [
     # Home / front page
     path("", core_views.home, name="home"),
     path("mission/", core_views.mission, name="mission"),
-    path("preview/", core_views.render_preview, name="preview"),
+    path("preview", core_views.render_preview, name="preview"),
     path("oembed/preview/", core_views.oembed_preview, name="oembed_preview"),
 
     # Recovery codes

--- a/core/views.py
+++ b/core/views.py
@@ -321,7 +321,7 @@ def download_recovery_codes(request):
 
 @require_POST
 def render_preview(request):
-    text = request.POST.get("text") or request.POST.get("body", "")
+    text = request.POST.get("text", "")
     html = markdown_renderer(text)
     clean = bleach.clean(html, tags=ALLOWED_TAGS, attributes=ALLOWED_ATTRIBUTES)
     return render(

--- a/templates/core/partials/comment_form.html
+++ b/templates/core/partials/comment_form.html
@@ -18,7 +18,7 @@
       <button type="button"
               class="tab tab-preview"
               hx-post="{% url 'preview' %}"
-              hx-include="[name=body]"
+              hx-vals="js:{text: this.closest('.editor-container').querySelector('textarea').value}"
               hx-target="#comment-preview"
               hx-swap="innerHTML">Preview</button>
     </div>

--- a/templates/core/partials/preview.html
+++ b/templates/core/partials/preview.html
@@ -1,5 +1,5 @@
 {% if html %}
-{{ html|safe }}
+{{ html }}
 {% else %}
 <p><em>Nothing to preview.</em></p>
 {% endif %}

--- a/templates/core/partials/reply_form.html
+++ b/templates/core/partials/reply_form.html
@@ -10,7 +10,7 @@
                 <button type="button"
                         class="tab tab-preview"
                         hx-post="{% url 'preview' %}"
-                        hx-include="[name=body]"
+                        hx-vals="js:{text: this.closest('.editor-container').querySelector('textarea').value}"
                         hx-target="#preview-{{ parent.pk }}"
                         hx-swap="innerHTML">Preview</button>
             </div>

--- a/templates/core/post_form.html
+++ b/templates/core/post_form.html
@@ -24,7 +24,7 @@
           type="button"
           class="tab tab-preview"
           hx-post="{% url 'preview' %}"
-          hx-include="[name=body]"
+          hx-vals="js:{text: this.closest('.editor-container').querySelector('textarea').value}"
           hx-target="#post-preview"
           hx-swap="innerHTML"
         >


### PR DESCRIPTION
## Summary
- Support markdown preview at `/preview`
- Post, comment, and reply forms send textarea content to preview endpoint
- Render sanitized markdown previews

## Testing
- `python manage.py test` (fails: `FAILED (failures=5, errors=36)`)

------
https://chatgpt.com/codex/tasks/task_e_68b3bb95773c832cbc768e014cc89553