### PR TITLE
Implement auto-refreshing time-ago timestamps

### DIFF
--- a/static/js/comments.js
+++ b/static/js/comments.js
@@ -82,11 +82,50 @@ function handleSelection(){
   btn.hidden = false;
 }
 
+function formatTimeAgo(seconds){
+  if(seconds < 60) return seconds + 's';
+  const minutes = Math.floor(seconds / 60);
+  if(minutes < 60) return minutes + 'm';
+  const hours = Math.floor(minutes / 60);
+  if(hours < 24) return hours + 'h';
+  const days = Math.floor(hours / 24);
+  if(days < 30) return days + 'd';
+  const months = Math.floor(days / 30);
+  if(months < 12) return months + 'mo';
+  const years = Math.floor(months / 12);
+  return years + 'y';
+}
+
+function updateTimeAgo(root=document){
+  root.querySelectorAll('time[data-ts]').forEach(el=>{
+    const ts = parseInt(el.dataset.ts, 10);
+    if(isNaN(ts)) return;
+    const diff = Math.floor(Date.now()/1000 - ts);
+    el.textContent = formatTimeAgo(diff);
+    if(!el.getAttribute('title')){
+      const d = new Date(ts*1000);
+      const pad = n=>n.toString().padStart(2,'0');
+      el.setAttribute('title',
+        d.getFullYear()+'-'+pad(d.getMonth()+1)+'-'+pad(d.getDate())+' '+pad(d.getHours())+':'+pad(d.getMinutes())
+      );
+    }
+  });
+}
+
 document.addEventListener('mouseup',handleSelection);
 document.addEventListener('keyup',handleSelection);
 document.addEventListener('selectionchange',handleSelection);
 document.addEventListener('click',e=>{if(!e.target.classList.contains('quote-btn')) hideQuoteBubbles();});
 
-document.addEventListener('DOMContentLoaded',()=>{initCommentCollapse();initQuoteButtons();});
+document.addEventListener('DOMContentLoaded',()=>{
+  initCommentCollapse();
+  initQuoteButtons();
+  updateTimeAgo();
+  setInterval(updateTimeAgo,60000);
+});
 
-document.body.addEventListener('htmx:afterSwap',e=>{initCommentCollapse(e.detail.elt);initQuoteButtons(e.detail.elt);});
+document.body.addEventListener('htmx:afterSwap',e=>{
+  initCommentCollapse(e.detail.elt);
+  initQuoteButtons(e.detail.elt);
+  updateTimeAgo(e.detail.elt);
+});

--- a/templates/core/partials/comment_item.html
+++ b/templates/core/partials/comment_item.html
@@ -3,7 +3,7 @@
   <div class="meta">
     <button class="collapse-toggle" data-comment-id="{{ comment.pk }}" aria-label="Collapse thread">▾</button>
     by <a href="{% url 'user_overview' comment.author.username %}">{{ comment.author.username }}</a>
-    • {{ comment.created_at|timesince }} ago
+    • <time datetime="{{ comment.created_at|date:'c' }}" data-ts="{{ comment.created_at|date:'U' }}" title="{{ comment.created_at|date:'Y-m-d H:i' }}">{{ comment.created_at|timesince }} ago</time>
     {% if comment.edited_at %}
       <span class="edited" title="Edited {{ comment.edited_at|date:'Y-m-d H:i' }}">edited</span>
     {% endif %}

--- a/templates/core/partials/comment_row.html
+++ b/templates/core/partials/comment_row.html
@@ -4,7 +4,7 @@
   <small>
     in <a href="{% url 'community' comment.post.community.slug %}">/r/{{ comment.post.community.slug }}/</a>
     on <a href="{% url 'post_detail' comment.post.community.slug comment.post.pk comment.post.title|slugify %}">{{ comment.post.title }}</a>
-    · {{ comment.created_at|timesince }} ago
+    · <time datetime="{{ comment.created_at|date:'c' }}" data-ts="{{ comment.created_at|date:'U' }}" title="{{ comment.created_at|date:'Y-m-d H:i' }}">{{ comment.created_at|timesince }} ago</time>
   </small>
 </div>
 

--- a/templates/core/partials/post_row.html
+++ b/templates/core/partials/post_row.html
@@ -29,7 +29,7 @@
     <p class="meta">
       <a href="{% url 'community' post.community.slug %}">/r/{{ post.community.slug }}/</a>
       · {{ post.author.username }}
-      · {{ post.created_at|timesince }} ago
+      · <time datetime="{{ post.created_at|date:'c' }}" data-ts="{{ post.created_at|date:'U' }}" title="{{ post.created_at|date:'Y-m-d H:i' }}">{{ post.created_at|timesince }} ago</time>
       · <a href="{% url 'post_detail' post.community.slug post.pk post.title|slugify %}">{{ post.comment_count }} comments</a>
       {% if user.is_authenticated %}
       · <a href="{% url 'report' %}?target_type=post&object_id={{ post.pk }}">[report]</a>

--- a/templates/core/post_detail.html
+++ b/templates/core/post_detail.html
@@ -15,7 +15,7 @@
           {% if post.url %}<a href="{{ post.url }}" rel="noopener nofollow">{{ post.title }}</a>{% else %}{{ post.title }}{% endif %}
         </h1>
         <div class="post-meta">
-          submitted {{ post.created_at|timesince }} ago by
+          submitted <time datetime="{{ post.created_at|date:'c' }}" data-ts="{{ post.created_at|date:'U' }}" title="{{ post.created_at|date:'Y-m-d H:i' }}">{{ post.created_at|timesince }} ago</time> by
           <a href="{% url 'user_overview' post.author.username %}">{{ post.author.username }}</a>
           to <a href="{% url 'community' post.community.slug %}">r/{{ post.community.slug }}</a>
         </div>


### PR DESCRIPTION
## Summary
- Show post and comment timestamps with `<time>` tags carrying absolute dates
- Add JS helper to auto-update these timestamps every 60s

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3c1648360832cb4a04eaad562dc12