### PR TITLE
Use HTMX micro updates for comment votes

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -46,7 +46,7 @@ urlpatterns = [
     path("comments/create", core_views.comment_create, name="comment_create"),
     path("comments/children", core_views.comment_children, name="comment_children"),
     path("vote/post/<int:pk>/", core_views.vote_post, name="vote_post"),
-    path("vote/comment/<int:pk>/", core_views.vote_comment, name="vote_comment"),
+    path("comments/vote/<int:pk>/", core_views.vote_comment, name="vote_comment"),
     # Post moderation
     path(
         "post/<int:pk>/delete-owner/",

--- a/core/views.py
+++ b/core/views.py
@@ -35,6 +35,7 @@ from django import forms
 
 from django.contrib.contenttypes.models import ContentType
 from django_ratelimit.core import is_ratelimited
+from django.urls import reverse
 
 from .forms import CommentForm, PostForm, CommunityCreateForm
 from .models import Comment, Community, Post, RecoveryCode, Report
@@ -871,12 +872,25 @@ def vote_comment(request, pk):
         return HttpResponseBadRequest("Invalid vote")
 
     try:
-        apply_vote(request.user, "comment", pk, value)
+        _, _, new_value = apply_vote(request.user, "comment", pk, value)
     except ValueError:
         return HttpResponseBadRequest("Invalid vote")
 
-    score = Comment.objects.get(pk=pk).score
-    return HttpResponse(f"<span id='comment-score-{pk}'>{score}</span>")
+    comment = Comment.objects.get(pk=pk)
+    score = comment.score
+    up_pressed = "true" if new_value == 1 else "false"
+    down_pressed = "true" if new_value == -1 else "false"
+    url = reverse("vote_comment", args=[pk])
+    html = (
+        f"<span id='comment-score-{pk}' class='score' hx-swap-oob='outerHTML'>{score}</span>"
+        f"<button id='comment-up-{pk}' hx-post='{url}?v=1' hx-swap='none' "
+        f"hx-disabled-elt='#comment-up-{pk}, #comment-down-{pk}' "
+        f"class='up' aria-label='Upvote' aria-pressed='{up_pressed}' hx-swap-oob='outerHTML'>▲</button>"
+        f"<button id='comment-down-{pk}' hx-post='{url}?v=-1' hx-swap='none' "
+        f"hx-disabled-elt='#comment-up-{pk}, #comment-down-{pk}' "
+        f"class='down' aria-label='Downvote' aria-pressed='{down_pressed}' hx-swap-oob='outerHTML'>▼</button>"
+    )
+    return HttpResponse(html)
 
 
 @login_required

--- a/templates/core/partials/comment_item.html
+++ b/templates/core/partials/comment_item.html
@@ -9,13 +9,19 @@
     {% if comment.edited_at %}
       <span class="edited" title="Edited {{ comment.edited_at|date:'Y-m-d H:i' }}">edited</span>
     {% endif %}
-    <button hx-post="{% url 'vote_comment' comment.pk %}?v=1"
-            hx-target="#comment-score-{{ comment.pk }}"
-            hx-swap="outerHTML" aria-label="Upvote" class="up">▲</button>
-    <span id="comment-score-{{ comment.pk }}">{{ comment.score }}</span>
-    <button hx-post="{% url 'vote_comment' comment.pk %}?v=-1"
-            hx-target="#comment-score-{{ comment.pk }}"
-            hx-swap="outerHTML" aria-label="Downvote" class="down">▼</button>
+    <span class="vote">
+      <button id="comment-up-{{ comment.pk }}"
+              hx-post="{% url 'vote_comment' comment.pk %}?v=1"
+              hx-swap="none"
+              hx-disabled-elt="#comment-up-{{ comment.pk }}, #comment-down-{{ comment.pk }}"
+              aria-label="Upvote" class="up" aria-pressed="false">▲</button>
+      <span id="comment-score-{{ comment.pk }}" class="score">{{ comment.score }}</span>
+      <button id="comment-down-{{ comment.pk }}"
+              hx-post="{% url 'vote_comment' comment.pk %}?v=-1"
+              hx-swap="none"
+              hx-disabled-elt="#comment-up-{{ comment.pk }}, #comment-down-{{ comment.pk }}"
+              aria-label="Downvote" class="down" aria-pressed="false">▼</button>
+    </span>
     <button hx-get="/comments/new?parent={{ comment.pk }}&post={{ comment.post.pk }}"
             hx-target="#comment-{{ comment.pk }}" hx-swap="afterend">Reply</button>
     {% if comment|can_edit_comment:request.user %}


### PR DESCRIPTION
## Summary
- Swap comment voting to out‑of‑band HTMX fragments for minimal repaint
- Disable vote controls while a request is pending and keep button state in sync
- Route comment voting through `/comments/vote/<id>/`

## Testing
- `python manage.py test core.tests.VoteCommentTests --verbosity=2`
- `python manage.py test core.tests.VotePostTests --verbosity=2`


------
https://chatgpt.com/codex/tasks/task_e_68b3c3bc2830832ca057a4c75ab36ace