### PR TITLE
Expose astroturf settings in templates

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -151,6 +151,7 @@ TEMPLATES = [
                 "django.template.context_processors.request",
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
+                "core.context.astro_constants",
             ],
         },
     },
@@ -261,6 +262,18 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 LOGIN_URL = "/accounts/login/"
 LOGIN_REDIRECT_URL = "/"
 LOGOUT_REDIRECT_URL = "/"
+
+# -----------------------------------------------------------------------------
+# Astroturf detection constants
+# -----------------------------------------------------------------------------
+ASTROTURF_WATCH = True
+ASTRO_WINDOW_S = 300
+ASTRO_BUCKET_S = 30
+ASTRO_BASELINE_LOOKBACK_D = 30
+ASTRO_NEW_ACCOUNT_DAYS = 7
+ASTRO_EARLY_VOTES_N = 50
+ASTRO_MIN_EARLY_VOTES = 20
+ASTRO_EARLY_SHARE_RED = 0.60
 
 # Logging (simple console)
 LOGGING = {

--- a/core/context.py
+++ b/core/context.py
@@ -1,0 +1,12 @@
+from django.conf import settings
+
+
+def astro_constants(request):
+    """Expose selected ASTRO* settings to templates."""
+    return {
+        "ASTROTURF_WATCH": settings.ASTROTURF_WATCH,
+        "ASTRO_NEW_ACCOUNT_DAYS": settings.ASTRO_NEW_ACCOUNT_DAYS,
+        "ASTRO_EARLY_VOTES_N": settings.ASTRO_EARLY_VOTES_N,
+        "ASTRO_MIN_EARLY_VOTES": settings.ASTRO_MIN_EARLY_VOTES,
+        "ASTRO_EARLY_SHARE_RED": settings.ASTRO_EARLY_SHARE_RED,
+    }


### PR DESCRIPTION
## Summary
- add ASTRO* configuration constants
- expose ASTRO constants via context processor for templates

## Testing
- `python manage.py check`
- `DJANGO_TESTS=1 python manage.py test` *(fails: TemplateDoesNotExist: core/partials/comment.html, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b3cb911948832ca1fbaa0bbced69f7