### PR TITLE
Add transparency methods page

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -6,6 +6,7 @@ urlpatterns = [
     # Home / front page
     path("", core_views.home, name="home"),
     path("mission/", core_views.mission, name="mission"),
+    path("transparency/methods", core_views.transparency_methods, name="transparency_methods"),
     path("preview", core_views.render_preview, name="preview"),
     path("oembed/preview/", core_views.oembed_preview, name="oembed_preview"),
 

--- a/core/views.py
+++ b/core/views.py
@@ -25,6 +25,7 @@ from django.views.decorators.csrf import csrf_protect
 from django.contrib.admin.views.decorators import staff_member_required
 from django_ratelimit.decorators import ratelimit
 from django.template.loader import render_to_string
+from django.conf import settings
 
 from django.http import HttpResponse, HttpResponseBadRequest, HttpResponseForbidden
 from django.shortcuts import get_object_or_404, redirect, render
@@ -176,6 +177,19 @@ def oembed_preview(request):
 
 def mission(request):
     return render(request, "core/mission.html")
+
+
+def transparency_methods(request):
+    ctx = {
+        "ASTRO_WINDOW_S": settings.ASTRO_WINDOW_S,
+        "ASTRO_BUCKET_S": settings.ASTRO_BUCKET_S,
+        "ASTRO_BASELINE_LOOKBACK_D": settings.ASTRO_BASELINE_LOOKBACK_D,
+        "ASTRO_NEW_ACCOUNT_DAYS": settings.ASTRO_NEW_ACCOUNT_DAYS,
+        "ASTRO_EARLY_VOTES_N": settings.ASTRO_EARLY_VOTES_N,
+        "ASTRO_MIN_EARLY_VOTES": settings.ASTRO_MIN_EARLY_VOTES,
+        "ASTRO_EARLY_SHARE_RED_PCT": int(settings.ASTRO_EARLY_SHARE_RED * 100),
+    }
+    return render(request, "core/transparency_methods.html", ctx)
 
 
 class SignupForm(forms.Form):

--- a/templates/core/transparency_methods.html
+++ b/templates/core/transparency_methods.html
@@ -1,0 +1,25 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="page container">
+  <h1>Astroturf detection methods</h1>
+  <p>We monitor voting patterns to spot coordinated campaigns while protecting individual privacy.</p>
+
+  <h2>Time windows</h2>
+  <p>Votes are analysed in {{ ASTRO_WINDOW_S }}‑second windows and grouped into {{ ASTRO_BUCKET_S }}‑second buckets. Baseline activity comes from the last {{ ASTRO_BASELINE_LOOKBACK_D }} days.</p>
+
+  <h2>Definitions</h2>
+  <ul>
+    <li><strong>New accounts:</strong> accounts less than {{ ASTRO_NEW_ACCOUNT_DAYS }} days old.</li>
+    <li><strong>Early votes:</strong> the first {{ ASTRO_EARLY_VOTES_N }} votes on a post.</li>
+  </ul>
+
+  <h2>Thresholds</h2>
+  <p>A post is flagged when at least {{ ASTRO_MIN_EARLY_VOTES }} early votes are cast and {{ ASTRO_EARLY_SHARE_RED_PCT }}% or more come from new accounts.</p>
+
+  <h2>Privacy assurances</h2>
+  <p>Only aggregate patterns are reviewed. Individual identities and private data are never sold or shared.</p>
+
+  <h2>Example</h2>
+  <p>If a post receives {{ ASTRO_EARLY_VOTES_N }} early votes and {{ ASTRO_EARLY_SHARE_RED_PCT }}% are from accounts younger than {{ ASTRO_NEW_ACCOUNT_DAYS }} days, moderators take a closer look.</p>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add view to display astroturf detection constants
- provide template outlining windows, definitions, thresholds and privacy assurances
- expose page at `/transparency/methods`

## Testing
- `python manage.py check`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3cfa6ded0832c8cdc1090ad341c92