### PR TITLE
Register engagement-related admin models

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -2,7 +2,17 @@ from django.contrib import admin, messages
 from django.contrib.auth import get_user_model
 from django.contrib.auth.admin import UserAdmin as BaseUserAdmin
 
-from .models import Community, Post, Comment, Vote, UserProfile, Report
+from .models import (
+    Community,
+    Post,
+    Comment,
+    Vote,
+    UserProfile,
+    Report,
+    EngagementEvent,
+    PostBurstState,
+    CommunityBaseline,
+)
 
 
 @admin.register(Community)
@@ -101,3 +111,18 @@ admin.site.register(get_user_model(), UserAdmin)
 class ReportAdmin(admin.ModelAdmin):
     list_display = ("id", "reporter", "content_type", "object_id", "created_at")
     list_filter = ("content_type", "reporter")
+
+
+@admin.register(EngagementEvent)
+class EngagementEventAdmin(admin.ModelAdmin):
+    list_filter = ("post", "post__community")
+
+
+@admin.register(PostBurstState)
+class PostBurstStateAdmin(admin.ModelAdmin):
+    list_filter = ("post__community",)
+
+
+@admin.register(CommunityBaseline)
+class CommunityBaselineAdmin(admin.ModelAdmin):
+    list_filter = ("community",)


### PR DESCRIPTION
## Summary
- import engagement-related models in admin
- add admin registrations for EngagementEvent, PostBurstState, and CommunityBaseline

## Testing
- `pytest`
- `python manage.py test` *(fails: Conflicting migrations detected; multiple leaf nodes in the migration graph)*

------
https://chatgpt.com/codex/tasks/task_e_68b3d44479c4832c902f73700dab66c7