### PR TITLE
Add astro Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: bootstrap migrate seed recompute test
+.PHONY: bootstrap migrate seed recompute test astro
 
 bootstrap:
 	pip install -r requirements.txt
@@ -10,7 +10,10 @@ seed:
 	python manage.py seed_demo
 
 recompute:
-	python manage.py recompute_ranks
+        python manage.py recompute_ranks
 
 test:
-	pytest -q
+        pytest -q
+
+astro:
+	python manage.py compute_astro_baselines


### PR DESCRIPTION
## Summary
- Add `astro` target to Makefile to run `python manage.py compute_astro_baselines`
- Include `astro` in `.PHONY` target list

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3d4de34b0832ca546e951c04468ef