### PR TITLE
Add cached post signal endpoints

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -10,6 +10,10 @@ urlpatterns = [
     path("preview", core_views.render_preview, name="preview"),
     path("oembed/preview/", core_views.oembed_preview, name="oembed_preview"),
 
+    # Post signals
+    path("posts/<int:pk>/signals.json", core_views.post_signals_json, name="post_signals_json"),
+    path("posts/<int:pk>/signals/chips", core_views.post_signals_chips, name="post_signals_chips"),
+
     # Recovery codes
     path("accounts/recovery-codes/", core_views.recovery_codes, name="recovery_codes"),
     path(

--- a/core/views.py
+++ b/core/views.py
@@ -3,6 +3,8 @@
 import random
 import secrets
 import string
+import hashlib
+import json
 from datetime import timedelta
 
 import re
@@ -20,19 +22,21 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.hashers import make_password
 from django.contrib.auth.views import LoginView
 from django.utils.decorators import method_decorator
-from django.views.decorators.http import require_POST, require_http_methods
+from django.views.decorators.http import require_GET, require_POST, require_http_methods
 from django.views.decorators.csrf import csrf_protect
 from django.contrib.admin.views.decorators import staff_member_required
 from django_ratelimit.decorators import ratelimit
 from django.template.loader import render_to_string
 from django.conf import settings
 
-from django.http import HttpResponse, HttpResponseBadRequest, HttpResponseForbidden
+from django.http import Http404, HttpResponse, HttpResponseBadRequest, HttpResponseForbidden
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils import timezone
 from django.utils.text import slugify
 from django.db.models import F
 from django import forms
+from django.core.cache import cache
+from django.utils.cache import patch_cache_control
 
 from django.contrib.contenttypes.models import ContentType
 from django_ratelimit.core import is_ratelimited
@@ -42,6 +46,7 @@ from .forms import CommentForm, PostForm, CommunityCreateForm
 from .models import Comment, Community, Post, RecoveryCode, Report
 from .votes import apply_vote
 from .pagination import PAGE_SIZE
+from .services.astro import compute_post_signals
 
 
 def _is_banned(user):
@@ -190,6 +195,50 @@ def transparency_methods(request):
         "ASTRO_EARLY_SHARE_RED_PCT": int(settings.ASTRO_EARLY_SHARE_RED * 100),
     }
     return render(request, "core/transparency_methods.html", ctx)
+
+
+def _cached_post_signals(pk):
+    cache_key = f"post-signals:{pk}"
+    data = cache.get(cache_key)
+    if data is None:
+        data = compute_post_signals(pk)
+        cache.set(cache_key, data, 30)
+    return data
+
+
+@require_GET
+def post_signals_json(request, pk):
+    try:
+        data = _cached_post_signals(pk)
+    except Post.DoesNotExist:
+        raise Http404
+    body = json.dumps(data)
+    etag = hashlib.md5(body.encode()).hexdigest()
+    if request.headers.get("If-None-Match") == etag:
+        return HttpResponse(status=304)
+    response = HttpResponse(body, content_type="application/json")
+    response["ETag"] = etag
+    patch_cache_control(response, max_age=30)
+    return response
+
+
+@require_GET
+def post_signals_chips(request, pk):
+    try:
+        data = _cached_post_signals(pk)
+    except Post.DoesNotExist:
+        raise Http404
+    response = render(
+        request,
+        "core/partials/post_context_chips.html",
+        {"signals": data},
+    )
+    etag = hashlib.md5(response.content).hexdigest()
+    if request.headers.get("If-None-Match") == etag:
+        return HttpResponse(status=304)
+    response["ETag"] = etag
+    patch_cache_control(response, max_age=30)
+    return response
 
 
 class SignupForm(forms.Form):

--- a/templates/core/partials/post_context_chips.html
+++ b/templates/core/partials/post_context_chips.html
@@ -1,0 +1,7 @@
+{% comment %}Display engagement signal chips for a post{% endcomment %}
+<div class="post-context-chips">
+  {% for key, value in signals.items %}
+    <span class="chip">{{ key }}: {{ value }}</span>
+  {% endfor %}
+</div>
+


### PR DESCRIPTION
## Summary
- add JSON and chips views for post engagement signals with 30s caching and ETags
- expose post signal endpoints in core URLs
- include template for rendering post signal chips

## Testing
- `python manage.py test` *(fails: Conflicting migrations detected; multiple leaf nodes in the migration graph)*

------
https://chatgpt.com/codex/tasks/task_e_68b3d79e9f94832c833aacc443c29731