### PR TITLE
Add user post health summary and sparkline

### DIFF
--- a/core/services/astro.py
+++ b/core/services/astro.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
 
 from django.conf import settings
+from django.utils import timezone
 
 from ..models import CommunityBaseline, Post, Vote
 
@@ -102,4 +103,52 @@ def compute_post_signals(post_id):
             "discuss_low": discuss_low,
         },
         "severity": severity,
+    }
+
+
+def compute_user_post_summary(user_id, days: int = 90):
+    """Return aggregate post signal stats for a user.
+
+    Looks at posts authored by ``user_id`` within the last ``days`` days and
+    computes:
+
+    - percentage of posts that were flagged (severity > 0)
+    - average severity across all posts
+    - a simple rating bucket based on the average severity
+
+    The function also returns a list of severities in chronological order which
+    can be used to render a sparkline in templates.
+    """
+
+    since = timezone.now() - timedelta(days=days)
+    posts = Post.objects.filter(author_id=user_id, created_at__gte=since).order_by(
+        "created_at"
+    )
+    total = posts.count()
+    severities = []
+    flagged = 0
+
+    for post in posts:
+        signals = compute_post_signals(post.pk)
+        severity = signals.get("severity", 0.0)
+        severities.append(severity)
+        if severity > 0:
+            flagged += 1
+
+    pct_flagged = (flagged / total * 100.0) if total else 0.0
+    avg_severity = (sum(severities) / total) if total else 0.0
+
+    if avg_severity > 60:
+        rating = "red"
+    elif avg_severity >= 25:
+        rating = "amber"
+    else:
+        rating = "green"
+
+    return {
+        "total_posts": total,
+        "flagged_pct": round(pct_flagged, 2),
+        "avg_severity": round(avg_severity, 2),
+        "rating": rating,
+        "severities": severities,
     }

--- a/core/views.py
+++ b/core/views.py
@@ -42,6 +42,7 @@ from .forms import CommentForm, PostForm, CommunityCreateForm
 from .models import Comment, Community, Post, RecoveryCode, Report
 from .votes import apply_vote
 from .pagination import PAGE_SIZE
+from .services.astro import compute_user_post_summary
 
 
 def _is_banned(user):
@@ -996,10 +997,13 @@ def user_overview(request, username):
     activity.sort(key=lambda a: a["created_at"], reverse=True)
     activity = activity[:20]
 
+    summary = compute_user_post_summary(profile_user.id)
+
     context = {
         "profile_user": profile_user,
         "activity": activity,
         "tab": "overview",
+        "user_summary": summary,
     }
     return render(request, "core/user_overview.html", context)
 

--- a/templates/core/partials/user_karma_sparkline.html
+++ b/templates/core/partials/user_karma_sparkline.html
@@ -1,0 +1,9 @@
+{# Render a simple bar sparkline for a series of severities (0-100). #}
+<div class="user-karma-sparkline" role="img" aria-label="{{ alt }}">
+  {% for v in severities %}
+    <span
+      style="display:inline-block;width:4px;height:{{ v|floatformat:0 }}%;background-color:currentColor;margin-right:1px;"
+    ></span>
+  {% endfor %}
+</div>
+

--- a/templates/core/user_overview.html
+++ b/templates/core/user_overview.html
@@ -1,6 +1,16 @@
 {% extends "base.html" %}
 {% block content %}
-<h1>u/{{ profile_user.username }}</h1>
+<h1>
+  u/{{ profile_user.username }}
+  {% if user_summary %}
+  <span class="badge badge-{{ user_summary.rating }}" title="{{ user_summary.flagged_pct }}% flagged, avg severity {{ user_summary.avg_severity }}">
+    {{ user_summary.rating|title }}
+  </span>
+  {% endif %}
+</h1>
+{% if user_summary %}
+  {% include "core/partials/user_karma_sparkline.html" with severities=user_summary.severities alt="Post severity trend for {{ profile_user.username }} over last 90 days. {{ user_summary.flagged_pct }}% flagged, average severity {{ user_summary.avg_severity }}" %}
+{% endif %}
 {% include "core/partials/user_tab_bar.html" %}
 {% for item in activity %}
   {% if item.type == 'post' %}


### PR DESCRIPTION
## Summary
- compute per-user post health metrics from last 90 days with rating
- show rating badge and severity sparkline on user overview
- add reusable sparkline partial

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3d7a0d590832c81ea7d5d57967b7a