### PR TITLE
Cache astro signals and add invalidation

### DIFF
--- a/core/apps.py
+++ b/core/apps.py
@@ -2,5 +2,8 @@ from django.apps import AppConfig
 
 
 class CoreConfig(AppConfig):
-    default_auto_field = 'django.db.models.BigAutoField'
-    name = 'core'
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "core"
+
+    def ready(self):  # pragma: no cover - import for side effects
+        from . import signals  # noqa: F401

--- a/core/services/astro.py
+++ b/core/services/astro.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
 
 from django.conf import settings
+from django.core.cache import cache
 
 from ..models import CommunityBaseline, Post, Vote
 
@@ -17,6 +18,11 @@ def compute_post_signals(post_id):
     The function returns a dictionary with raw metrics, baseline thresholds,
     boolean flags for anomalies and an aggregated severity score (0-100).
     """
+
+    cache_key = f"post_signals:{post_id}"
+    cached = cache.get(cache_key)
+    if cached is not None:
+        return cached
 
     # Retrieve post, burst state and engagement events in a single query
     post = (
@@ -81,8 +87,7 @@ def compute_post_signals(post_id):
     if base_discuss > 0:
         severity += max(0.0, min(10.0, (base_discuss - discuss_ratio) / base_discuss * 10.0))
     severity = round(min(severity, 100.0), 2)
-
-    return {
+    data = {
         "rate5": rate5,
         "rate15": rate15,
         "early_votes": early_votes,
@@ -103,3 +108,5 @@ def compute_post_signals(post_id):
         },
         "severity": severity,
     }
+    cache.set(cache_key, data, 30)
+    return data

--- a/core/signals.py
+++ b/core/signals.py
@@ -1,0 +1,31 @@
+"""Signal handlers for cache invalidation of post engagement signals."""
+
+from django.core.cache import cache
+from django.db.models.signals import post_delete, post_save
+from django.dispatch import receiver
+
+from .models import Comment, EngagementEvent
+
+
+def _cache_key(post_id):
+    return f"post_signals:{post_id}"
+
+
+@receiver(post_save, sender=EngagementEvent)
+def engagement_event_saved(sender, instance, **kwargs):
+    """Invalidate cached post signals when an engagement event is recorded."""
+    cache.delete(_cache_key(instance.post_id))
+
+
+@receiver(post_save, sender=Comment)
+def comment_created(sender, instance, created, **kwargs):
+    """Invalidate cached post signals when a comment is created."""
+    if created:
+        cache.delete(_cache_key(instance.post_id))
+
+
+@receiver(post_delete, sender=Comment)
+def comment_deleted(sender, instance, **kwargs):
+    """Invalidate cached post signals when a comment is deleted."""
+    cache.delete(_cache_key(instance.post_id))
+


### PR DESCRIPTION
## Summary
- Cache computed post engagement signals for 30s to minimize recalculation.
- Add signal handlers to invalidate cached signals when engagement events or comments are created/deleted.
- Load signal handlers through Core app configuration.

## Testing
- `python manage.py test` *(fails: Conflicting migrations detected; multiple leaf nodes in the migration graph)*

------
https://chatgpt.com/codex/tasks/task_e_68b3d7a42588832cb3226c870e19efd3