### PR TITLE
Add post context chip rendering with HTMX

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -180,3 +180,30 @@ li + li {
   margin-left: 1rem;
   padding-left: 1rem;
 }
+
+/* --- Post context chips -------------------------------------------------- */
+[id^="chips-"] {
+  min-height: 24px;
+}
+
+.post-context-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  align-items: center;
+}
+
+.post-context-chips .chip {
+  background: #e5e7eb;
+  color: #374151;
+  border-radius: 9999px;
+  padding: 2px 8px;
+  font-size: 12px;
+  line-height: 1.5;
+  text-decoration: none;
+}
+
+.post-context-chips .chip:hover {
+  background: #d1d5db;
+  text-decoration: underline;
+}

--- a/templates/core/partials/post_context_chips.html
+++ b/templates/core/partials/post_context_chips.html
@@ -1,7 +1,21 @@
 {% comment %}Display engagement signal chips for a post{% endcomment %}
 <div class="post-context-chips">
-  {% for key, value in signals.items %}
-    <span class="chip">{{ key }}: {{ value }}</span>
-  {% endfor %}
+  {# Render a chip for each active signal flag #}
+  {% if signals.flags %}
+    {% for key, value in signals.flags.items %}
+      {% if value %}
+        <a class="chip" href="{% url 'transparency_methods' %}" title="Learn about {{ key|replace:'_',' ' }} detection">
+          {{ key|replace:'_',' '|title }}
+        </a>
+      {% endif %}
+    {% endfor %}
+  {% endif %}
+
+  {# Always show severity chip #}
+  {% if signals.severity is not None %}
+    <a class="chip" href="{% url 'transparency_methods' %}" title="Aggregated anomaly score">
+      Severity: {{ signals.severity }}
+    </a>
+  {% endif %}
 </div>
 

--- a/templates/core/partials/post_row.html
+++ b/templates/core/partials/post_row.html
@@ -49,5 +49,8 @@
         {% endif %}
       {% endif %}
     </p>
+    <div id="chips-{{ post.id }}"
+         hx-get="{% url 'post_signals_chips' post.id %}"
+         hx-trigger="load" hx-swap="innerHTML"></div>
   </div>
 </div>

--- a/templates/core/post_detail.html
+++ b/templates/core/post_detail.html
@@ -20,6 +20,9 @@
           to <a href="{% url 'community' post.community.slug %}">r/{{ post.community.slug }}</a>
         </div>
       </header>
+      <div id="chips-{{ post.id }}"
+           hx-get="{% url 'post_signals_chips' post.id %}"
+           hx-trigger="load" hx-swap="innerHTML"></div>
       <div class="post-content">
         {% if post.is_deleted %}
           <p><em>[deleted by author]</em></p>


### PR DESCRIPTION
## Summary
- Render post context chips via new partial that links to transparency methods
- Load chips asynchronously in post listings and detail views via HTMX
- Style chips with neutral gray palette and placeholder height to prevent layout shift

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3db6da210832cbf22063728c8c000