### PR TITLE
Add shared editor toolbar and selection helpers

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -9,6 +9,7 @@ class PostForm(forms.ModelForm):
     class Meta:
         model = Post
         fields = ["title", "body", "url", "image"]
+        widgets = {"body": forms.Textarea(attrs={"data-editor": "1"})}
 
     def clean_image(self):
         image = self.cleaned_data.get("image")
@@ -58,7 +59,7 @@ class CommentForm(forms.ModelForm):
     class Meta:
         model = Comment
         fields = ["body"]
-        widgets = {"body": forms.Textarea(attrs={"rows": 3})}
+        widgets = {"body": forms.Textarea(attrs={"rows": 3, "data-editor": "1"})}
 
     def clean_body(self):
         body = (self.cleaned_data.get("body") or "").strip()

--- a/static/js/editor.js
+++ b/static/js/editor.js
@@ -1,7 +1,21 @@
+function setupEditor(ta){
+  if(!ta||ta.dataset.editorReady)return;ta.dataset.editorReady=1;
+  ta.addEventListener('keydown',e=>{
+    const ctrl=e.ctrlKey||e.metaKey,key=e.key.toLowerCase();
+    if(ctrl&&key==='enter'){e.preventDefault();const f=ta.closest('form');if(f){if(f.requestSubmit)f.requestSubmit();else f.submit();}}
+    else if(key==='enter'&&e.shiftKey){e.stopPropagation();}
+    else if(ctrl&&key==='b'){e.preventDefault();toggleWrap('**');}
+    else if(ctrl&&key==='i'){e.preventDefault();toggleWrap('_');}
+
+    function toggleWrap(w){const s=ta.selectionStart,e=ta.selectionEnd,v=ta.value,b=v.slice(0,s),sel=v.slice(s,e),a=v.slice(e),l=w.length;if(sel.startsWith(w)&&sel.endsWith(w)){ta.setRangeText(sel.slice(l,sel.length-l),s,e,'end');ta.setSelectionRange(s,e-2*l);}else if(b.endsWith(w)&&a.startsWith(w)){ta.setRangeText(sel,s-l,e+l,'end');ta.setSelectionRange(s-l,e-l);}else{ta.setRangeText(w+sel+w,s,e,'end');ta.setSelectionRange(s+l,e+l);}ta.dispatchEvent(new Event('input',{bubbles:true}));}
+  });
+}
+
 function initToolbar(root=document){
   root.querySelectorAll('.editor-toolbar').forEach(tb=>{
     if(tb.dataset.ready)return;tb.dataset.ready=1;
     const ta=tb.nextElementSibling;if(!ta)return;
+    if(!ta.dataset.editor)ta.dataset.editor=1;
     if(!ta.closest('.post-form')){ta.style.lineHeight='1.5';ta.style.maxWidth='var(--prose-max)';if(ta.parentElement){ta.parentElement.style.maxWidth='var(--prose-max)';ta.parentElement.style.lineHeight='1.5';}}
     tb.querySelectorAll('button').forEach(b=>b.addEventListener('click',()=>{
       const s=ta.selectionStart,e=ta.selectionEnd,v=ta.value,sel=v.slice(s,e);
@@ -11,16 +25,9 @@ function initToolbar(root=document){
       ta.focus();ta.dispatchEvent(new Event('input',{bubbles:true}));
     }));
 
-    ta.addEventListener('keydown',e=>{
-      const ctrl=e.ctrlKey||e.metaKey,key=e.key.toLowerCase();
-      if(ctrl&&key==='enter'){e.preventDefault();const f=ta.closest('form');if(f){if(f.requestSubmit)f.requestSubmit();else f.submit();}}
-      else if(key==='enter'&&e.shiftKey){e.stopPropagation();}
-      else if(ctrl&&key==='b'){e.preventDefault();toggleWrap('**');}
-      else if(ctrl&&key==='i'){e.preventDefault();toggleWrap('_');}
-
-      function toggleWrap(w){const s=ta.selectionStart,e=ta.selectionEnd,v=ta.value,b=v.slice(0,s),sel=v.slice(s,e),a=v.slice(e),l=w.length;if(sel.startsWith(w)&&sel.endsWith(w)){ta.setRangeText(sel.slice(l,sel.length-l),s,e,'end');ta.setSelectionRange(s,e-2*l);}else if(b.endsWith(w)&&a.startsWith(w)){ta.setRangeText(sel,s-l,e+l,'end');ta.setSelectionRange(s-l,e-l);}else{ta.setRangeText(w+sel+w,s,e,'end');ta.setSelectionRange(s+l,e+l);}ta.dispatchEvent(new Event('input',{bubbles:true}));}
-    });
+    setupEditor(ta);
   });
+  root.querySelectorAll('textarea[data-editor]').forEach(setupEditor);
 }
 
 function initPreview(root=document){

--- a/templates/core/partials/comment_form.html
+++ b/templates/core/partials/comment_form.html
@@ -30,7 +30,7 @@
               hx-target="#comment-preview"
               hx-swap="innerHTML">Preview</button>
     </div>
-    {% include "core/partials/editor_toolbar.html" %}
+    {% include "core/partials/editor_toolbar.html" %} {# formatting toolbar #}
     {{ form.body }}
     <div id="comment-preview" class="preview" style="display:none"></div>
   </div>

--- a/templates/core/partials/editor_toolbar.html
+++ b/templates/core/partials/editor_toolbar.html
@@ -1,8 +1,8 @@
 <div class="editor-toolbar">
-  <button type="button" data-wrap="**" title="Bold">B</button>
-  <button type="button" data-wrap="_" title="Italic">I</button>
-  <button type="button" data-link title="Link">link</button>
-  <button type="button" data-wrap="`" title="Code">`code`</button>
+  <button type="button" data-wrap="**" title="Bold"><strong>B</strong></button>
+  <button type="button" data-wrap="_" title="Italic"><em>I</em></button>
+  <button type="button" data-link title="Link">🔗</button>
+  <button type="button" data-wrap="`" title="Code"><code>&lt;/&gt;</code></button>
   <button type="button" data-prefix="- " title="Bulleted list">•</button>
   <button type="button" data-prefix="1. " title="Numbered list">1.</button>
 </div>

--- a/templates/core/post_form.html
+++ b/templates/core/post_form.html
@@ -16,6 +16,7 @@
   <div class="form-row">
     {{ form.body.label_tag }}
     <div class="prose">
+      {% include "core/partials/editor_toolbar.html" %}
       {{ form.body }}
     </div>
     {{ form.body.errors }}


### PR DESCRIPTION
## Summary
- add markdown formatting toolbar partial
- wire toolbar buttons to textarea selection transformations
- include toolbar in post and comment forms with data-editor widgets

## Testing
- `python manage.py test` *(fails: ValueError: The file 'css/base.css' could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3e778ddbc832cad089d12f8987000