### PR TITLE
Add Markdown preview endpoint and HTMX hooks

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -8,7 +8,7 @@ urlpatterns = [
     path("mission/", core_views.mission, name="mission"),
     path("transparency/methods", core_views.transparency_methods, name="transparency_methods"),
     path("transparency/posts", core_views.transparency_posts, name="transparency_posts"),
-    path("preview", core_views.render_preview, name="preview"),
+    path("preview/", core_views.render_preview, name="preview"),
     path("oembed/preview/", core_views.oembed_preview, name="oembed_preview"),
 
     # Post signals

--- a/core/views.py
+++ b/core/views.py
@@ -434,7 +434,9 @@ def download_recovery_codes(request):
 def render_preview(request):
     text = request.POST.get("text", "")
     html = markdown_renderer(text)
-    clean = bleach.clean(html, tags=ALLOWED_TAGS, attributes=ALLOWED_ATTRIBUTES)
+    clean = bleach.clean(
+        html, tags=ALLOWED_TAGS, attributes=ALLOWED_ATTRIBUTES, strip=True
+    )
     return render(
         request, "core/partials/preview.html", {"html": mark_safe(clean)}
     )

--- a/templates/core/post_form.html
+++ b/templates/core/post_form.html
@@ -15,9 +15,19 @@
 
   <div class="form-row">
     {{ form.body.label_tag }}
-    <div class="prose">
+    <div class="editor-container prose">
+      <div class="editor-tabs">
+        <button type="button" class="tab tab-write active">Write</button>
+        <button type="button"
+                class="tab tab-preview"
+                hx-post="{% url 'preview' %}"
+                hx-vals="js:{text: this.closest('.editor-container').querySelector('textarea').value}"
+                hx-target="#post-preview"
+                hx-swap="innerHTML">Preview</button>
+      </div>
       {% include "core/partials/editor_toolbar.html" %}
       {{ form.body }}
+      <div id="post-preview" class="preview" style="display:none"></div>
     </div>
     {{ form.body.errors }}
   </div>

--- a/templates/core/submit_post.html
+++ b/templates/core/submit_post.html
@@ -27,8 +27,20 @@
     {% if form.body %}
     <div class="form-row type-block" id="type-text">
       {{ form.body.label_tag }}
-      {% include "core/partials/editor_toolbar.html" %}
-      {{ form.body }}
+      <div class="editor-container">
+        <div class="editor-tabs">
+          <button type="button" class="tab tab-write active">Write</button>
+          <button type="button"
+                  class="tab tab-preview"
+                  hx-post="{% url 'preview' %}"
+                  hx-vals="js:{text: this.closest('.editor-container').querySelector('textarea').value}"
+                  hx-target="#post-preview"
+                  hx-swap="innerHTML">Preview</button>
+        </div>
+        {% include "core/partials/editor_toolbar.html" %}
+        {{ form.body }}
+        <div id="post-preview" class="preview" style="display:none"></div>
+      </div>
       {{ form.body.errors }}
     </div>
     {% endif %}


### PR DESCRIPTION
## Summary
- render Markdown previews via `/preview`, sanitized with bleach
- add Write/Preview tabs to post and submission forms with HTMX preview requests

## Testing
- `python manage.py test core.tests_link_safety.LinkSafetyTests.test_safe_url_allowed -v 2` *(fails: The file 'css/base.css' could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3ecef0d44832cb3a5004c5ff39ad1