### PR TITLE
Persist post and comment drafts with restore option

### DIFF
--- a/static/js/editor.js
+++ b/static/js/editor.js
@@ -63,12 +63,14 @@ function setupDraft(form,key,fields){
   if(!form||form.dataset.draftReady)return;form.dataset.draftReady=1;
   let data={};try{data=JSON.parse(localStorage.getItem(key)||'{}');}catch(e){}
   if(Object.values(data).some(v=>v)){
-    const pill=document.createElement('div');pill.className='draft-pill';
-    const restore=document.createElement('button');restore.type='button';restore.textContent='Restore draft';
+    let pill=form.querySelector('.draft-pill');
+    if(!pill){pill=document.createElement('div');pill.className='draft-pill';form.prepend(pill);} 
+    pill.hidden=false;pill.textContent='';
+    const restore=document.createElement('button');restore.type='button';restore.textContent='Restore';
     const discard=document.createElement('button');discard.type='button';discard.textContent='Discard';
-    pill.append(restore,' / ',discard);form.prepend(pill);
-    restore.addEventListener('click',()=>{fields.forEach(f=>{if(form[f]&&data[f]!==undefined){form[f].value=data[f];form[f].dispatchEvent(new Event('input',{bubbles:true}));}});pill.remove();});
-    discard.addEventListener('click',()=>{localStorage.removeItem(key);pill.remove();});
+    pill.append(restore,' / ',discard);
+    restore.addEventListener('click',()=>{fields.forEach(f=>{if(form[f]&&data[f]!==undefined){form[f].value=data[f];form[f].dispatchEvent(new Event('input',{bubbles:true}));}});pill.hidden=true;});
+    discard.addEventListener('click',()=>{localStorage.removeItem(key);pill.hidden=true;});
   }
   const i=setInterval(()=>{
     const draft={};let empty=true;
@@ -80,7 +82,7 @@ function setupDraft(form,key,fields){
 
 function initDrafts(root=document){
   const pf=root.querySelector('.post-form');
-  if(pf){const path=pf.getAttribute('action')||location.pathname;const m=path.match(/\/r\/([^/]+)/);if(m)setupDraft(pf,`draft:${m[1]}:post`,['title','body','url']);}
+  if(pf){const path=pf.getAttribute('action')||location.pathname;const m=path.match(/\/r\/([^/]+)/);if(m)setupDraft(pf,`draft:post:${m[1]}`,['title','body','url']);}
   root.querySelectorAll('form.comment-form').forEach(f=>{
     const postField=f.querySelector('input[name="post"]');
     const postId=postField&&postField.value;

--- a/templates/core/partials/comment_form.html
+++ b/templates/core/partials/comment_form.html
@@ -19,6 +19,7 @@
       <input type="hidden" name="parent" value="{{ parent.pk }}">
     {% endif %}
   {% endif %}
+  <div class="draft-pill" hidden></div>
   <div class="form-error" role="alert" style="display:none"></div>
   <div class="editor-container">
     <div class="editor-tabs">

--- a/templates/core/post_form.html
+++ b/templates/core/post_form.html
@@ -5,6 +5,7 @@
 <h1>Create Post</h1>
 <form method="post" action="{% url 'submit_post' community.slug %}" class="post-form" hx-boost="false" hx-swap="none">
   {% csrf_token %}
+  <div class="draft-pill" hidden></div>
   {{ form.non_field_errors }}
 
   <div class="form-row">


### PR DESCRIPTION
## Summary
- Save post and comment form inputs to localStorage every 2s using stable draft keys
- Add Restore/Discard pill to forms so users can recover or clear saved drafts

## Testing
- `pytest -q` *(fails: Requested setting INSTALLED_APPS, but settings are not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68b3ee4ee950832cbdb2be66b0ee0ea5