### PR TITLE
feat: move pasted URLs to content field

### DIFF
--- a/static/js/editor.js
+++ b/static/js/editor.js
@@ -134,10 +134,43 @@ document.addEventListener('DOMContentLoaded',()=>{
   const urlField=document.getElementById('id_url');
   const postTypeField=document.getElementById('id_post_type');
   let domainHint;
-  function updateDomain(){if(!urlField||!domainHint)return;const v=urlField.value.trim();let h='';if(v){try{h=new URL(v).hostname;}catch(e){}}domainHint.textContent=h?`(${h})`:'';}
-  if(urlField){domainHint=document.createElement('div');domainHint.id='link-domain';urlField.insertAdjacentElement('afterend',domainHint);urlField.addEventListener('input',updateDomain);updateDomain();}
+  function updateDomain(){
+    if(!urlField||!domainHint)return;
+    const v=urlField.value.trim();
+    let h='';
+    if(v){
+      try{h=new URL(v).hostname;}catch(e){}
+    }
+    domainHint.value=h;
+    domainHint.hidden=!h;
+  }
+  if(urlField){
+    domainHint=document.createElement('input');
+    domainHint.id='link-domain';
+    domainHint.readOnly=true;
+    domainHint.tabIndex=-1;
+    domainHint.hidden=true;
+    urlField.insertAdjacentElement('afterend',domainHint);
+    urlField.addEventListener('input',updateDomain);
+    updateDomain();
+  }
 
-  if(bodyField&&urlField){bodyField.addEventListener('paste',e=>{const t=e.clipboardData.getData('text/plain').trim();if(/^https?:\/\/\S+$/.test(t)&&!urlField.value.trim()){setTimeout(()=>{if(confirm('Move this to Content URL?')){urlField.value=t;urlField.dispatchEvent(new Event('input',{bubbles:true}));}},0);}});}
+  if(bodyField&&urlField){
+    bodyField.addEventListener('paste',e=>{
+      const t=e.clipboardData.getData('text/plain').trim();
+      if(/^https?:\/\/\S+$/.test(t)&&!urlField.value.trim()){
+        e.preventDefault();
+        const start=bodyField.selectionStart,end=bodyField.selectionEnd;
+        if(confirm('Move this to Content URL?')){
+          urlField.value=t;
+          urlField.dispatchEvent(new Event('input',{bubbles:true}));
+        }else{
+          bodyField.setRangeText(t,start,end,'end');
+          bodyField.dispatchEvent(new Event('input',{bubbles:true}));
+        }
+      }
+    });
+  }
 
   const form=document.querySelector('.post-form');
   if(form){form.addEventListener('submit',()=>{if(postTypeField){const urlVal=urlField&&urlField.value.trim();postTypeField.value=urlVal?'link':'text';}});}


### PR DESCRIPTION
## Summary
- prompt to move single pasted URLs from Body to Content URL
- display read-only domain hint beside Content URL

## Testing
- `python manage.py test` *(fails: The file 'css/base.css' could not be found with <whitenoise.storage.CompressedManifestStaticFilesStorage object at 0x7fc7aff5c3b0>.)*

------
https://chatgpt.com/codex/tasks/task_e_68b3ef4a38b8832cb0c25ca50e1fa116