### PR TITLE
Improve accessibility for editor toolbar and focus styling

### DIFF
--- a/static/css/theme.css
+++ b/static/css/theme.css
@@ -45,8 +45,14 @@ a:visited {
   color: var(--link-visited);
 }
 
-a:hover {
+a:hover,
+a:focus {
   text-decoration: underline;
+}
+
+a:focus {
+  outline: 2px solid var(--link);
+  outline-offset: 2px;
 }
 
 /* Header ------------------------------------------------------------- */
@@ -379,7 +385,8 @@ input[type="text"]:focus,
 input[type="password"]:focus,
 textarea:focus {
   border-color: var(--link);
-  outline: none;
+  outline: 2px solid var(--link);
+  outline-offset: 2px;
 }
 
 /* Misc --------------------------------------------------------------- */
@@ -394,6 +401,14 @@ textarea:focus {
 
 .button:hover {
   background: var(--border);
+}
+
+button:focus,
+.button:focus,
+input[type="button"]:focus,
+input[type="submit"]:focus {
+  outline: 2px solid var(--link);
+  outline-offset: 2px;
 }
 
 hr {

--- a/templates/core/partials/editor_toolbar.html
+++ b/templates/core/partials/editor_toolbar.html
@@ -1,8 +1,8 @@
-<div class="editor-toolbar">
-  <button type="button" data-wrap="**" title="Bold"><strong>B</strong></button>
-  <button type="button" data-wrap="_" title="Italic"><em>I</em></button>
-  <button type="button" data-link title="Link">🔗</button>
-  <button type="button" data-wrap="`" title="Code"><code>&lt;/&gt;</code></button>
-  <button type="button" data-prefix="- " title="Bulleted list">•</button>
-  <button type="button" data-prefix="1. " title="Numbered list">1.</button>
+<div class="editor-toolbar" role="toolbar">
+  <button type="button" data-wrap="**" title="Bold" aria-label="Bold" tabindex="0"><strong>B</strong></button>
+  <button type="button" data-wrap="_" title="Italic" aria-label="Italic" tabindex="0"><em>I</em></button>
+  <button type="button" data-link title="Link" aria-label="Link" tabindex="0">🔗</button>
+  <button type="button" data-wrap="`" title="Code" aria-label="Code" tabindex="0"><code>&lt;/&gt;</code></button>
+  <button type="button" data-prefix="- " title="Bulleted list" aria-label="Bulleted list" tabindex="0">•</button>
+  <button type="button" data-prefix="1. " title="Numbered list" aria-label="Numbered list" tabindex="0">1.</button>
 </div>


### PR DESCRIPTION
## Summary
- add aria labels and tabindex to editor toolbar buttons for screen-reader and keyboard support
- underline links on hover/focus and provide visible focus rings for links, form fields and buttons

## Testing
- `python manage.py test` *(fails: FAIL=5, ERRORS=38)*

------
https://chatgpt.com/codex/tasks/task_e_68b3f41c416c832cb6a02c035991912d