### PR TITLE
Add heading field and embed fetching for link posts

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -8,7 +8,7 @@ from .utils.link_safety import check_url_safety
 class PostForm(forms.ModelForm):
     class Meta:
         model = Post
-        fields = ["title", "body", "content_url", "image"]
+        fields = ["title", "heading", "body", "content_url", "image"]
         widgets = {"body": forms.Textarea(attrs={"data-editor": "1"})}
 
     def clean_image(self):
@@ -24,10 +24,12 @@ class PostForm(forms.ModelForm):
         cleaned_data = super().clean()
 
         title = (cleaned_data.get("title") or "").strip()
+        heading = (cleaned_data.get("heading") or "").strip()
         body = (cleaned_data.get("body") or "").strip()
         content_url = (cleaned_data.get("content_url") or "").strip()
 
         cleaned_data["title"] = title
+        cleaned_data["heading"] = heading
         cleaned_data["body"] = body
         cleaned_data["content_url"] = content_url
 

--- a/core/urls.py
+++ b/core/urls.py
@@ -54,6 +54,7 @@ urlpatterns = [
     path("vote/post/<int:pk>/", core_views.vote_post, name="vote_post"),
     path("comments/vote/<int:pk>/", core_views.vote_comment, name="vote_comment"),
     # Post moderation
+    path("post/<int:pk>/edit/", core_views.post_edit, name="post_edit"),
     path(
         "post/<int:pk>/delete-owner/",
         core_views.post_delete_owner,

--- a/core/views.py
+++ b/core/views.py
@@ -41,6 +41,7 @@ from django.utils.cache import patch_cache_control
 from django.contrib.contenttypes.models import ContentType
 from django_ratelimit.core import is_ratelimited
 from django.urls import reverse
+from urllib.parse import urlparse
 
 from .forms import CommentForm, PostForm, CommunityCreateForm
 from .models import Comment, Community, Post, RecoveryCode, Report
@@ -491,6 +492,12 @@ def submit_post(request, slug):
             post = form.save(commit=False)
             post.community = community
             post.author = request.user
+            if post.content_url:
+                post.link_domain = urlparse(post.content_url).netloc
+                data = fetch_oembed(post.content_url)
+                post.embed_html = render_to_string(
+                    "core/partials/link_preview.html", data
+                )
             post.save()
             messages.success(request, "Post submitted")
             return redirect("community", slug=community.slug)
@@ -511,6 +518,45 @@ def post_detail(request, slug, post_id, post_slug):
     form = CommentForm()
     context = {"post": post, "comments": comments, "form": form}
     return render(request, "core/post_detail.html", context)
+
+
+@login_required
+@require_http_methods(["GET", "POST"])
+def post_edit(request, pk):
+    post = get_object_or_404(Post, pk=pk)
+    if _is_banned(request.user):
+        return HttpResponseForbidden("Account banned")
+    if request.user != post.author and not request.user.is_staff:
+        return HttpResponseForbidden("Forbidden")
+
+    if request.method == "POST":
+        form = PostForm(request.POST, instance=post)
+        if form.is_valid():
+            post = form.save(commit=False)
+            if post.content_url:
+                post.link_domain = urlparse(post.content_url).netloc
+                data = fetch_oembed(post.content_url)
+                post.embed_html = render_to_string(
+                    "core/partials/link_preview.html", data
+                )
+            else:
+                post.link_domain = ""
+                post.embed_html = ""
+            post.save()
+            messages.success(request, "Post updated")
+            return redirect(
+                "post_detail",
+                slug=post.community.slug,
+                post_id=post.pk,
+                post_slug=slugify(post.title),
+            )
+        else:
+            messages.error(request, "Please correct the errors below.")
+    else:
+        form = PostForm(instance=post)
+
+    context = {"form": form, "community": post.community, "post": post}
+    return render(request, "core/post_form.html", context)
 
 
 @login_required


### PR DESCRIPTION
## Summary
- include heading field on `PostForm` and require either body or URL
- fetch oEmbed HTML and store link domain when submitting or editing posts
- add post edit view and route to update posts

## Testing
- `DJANGO_TESTS=1 python manage.py test` *(fails: PostDeleteOwnerTests expect different status codes)*

------
https://chatgpt.com/codex/tasks/task_e_68b4168b36e4832caf0b9a70f3b27951