### PR TITLE
Add heading field and responsive embed rendering

### DIFF
--- a/templates/core/partials/post_row.html
+++ b/templates/core/partials/post_row.html
@@ -13,17 +13,32 @@
       <h2>
       {% if post.content_url %}
         <a href="{{ post.content_url }}">{{ post.title }}</a>
-        <span class="domain">({{ post.content_url|domain }})</span>
       {% else %}
         <a href="{% url 'post_detail' post.community.slug post.pk post.title|slugify %}">{{ post.title }}</a>
       {% endif %}
       </h2>
-      {% if post.image_thumb or post.image %}
+      {% if post.heading %}
+        <h3 class="post-heading">{{ post.heading }}</h3>
+      {% endif %}
+      {% if post.embed_html %}
+        <div class="post-embed" style="position:relative;padding-top:56.25%;overflow:hidden;">
+          <div style="position:absolute;top:0;left:0;width:100%;height:100%;">
+            {{ post.embed_html|safe }}
+          </div>
+        </div>
+      {% elif post.image_thumb or post.image %}
         {% if post.image_thumb %}
           <img src="{{ post.image_thumb.url }}" class="post-image" loading="lazy" decoding="async" referrerpolicy="no-referrer">
         {% else %}
           <img src="{{ post.image.url }}" class="post-image" loading="lazy" decoding="async" referrerpolicy="no-referrer">
         {% endif %}
+      {% elif post.content_url %}
+        <div class="link-card">
+          <a href="{{ post.content_url }}" rel="noopener nofollow">{{ post.link_domain }}</a>
+        </div>
+      {% endif %}
+      {% if post.body %}
+        <div class="post-caption prose">{{ post.body|safe }}</div>
       {% endif %}
     {% endif %}
     <p class="meta">

--- a/templates/core/post_detail.html
+++ b/templates/core/post_detail.html
@@ -29,16 +29,26 @@
         {% if post.is_deleted %}
           <p><em>[deleted by author]</em></p>
         {% else %}
-          {% if post.image %}
-            <img src="{{ post.image.url }}" alt="" class="post-image" loading="lazy" decoding="async" referrerpolicy="no-referrer">
+          {% if post.heading %}
+            <h2 class="post-heading">{{ post.heading }}</h2>
           {% endif %}
-          {% if post.body %}
-            <div class="post-body prose">
-              {{ post.body|safe }}
+          {% if post.embed_html %}
+            <div class="post-embed" style="position:relative;padding-top:56.25%;overflow:hidden;">
+              <div style="position:absolute;top:0;left:0;width:100%;height:100%;">
+                {{ post.embed_html|safe }}
+              </div>
+            </div>
+          {% elif post.image %}
+            <img src="{{ post.image.url }}" alt="" class="post-image" loading="lazy" decoding="async" referrerpolicy="no-referrer">
+          {% elif post.content_url %}
+            <div class="link-card">
+              <a href="{{ post.content_url }}" rel="noopener nofollow">{{ post.link_domain }}</a>
             </div>
           {% endif %}
-          {% if post.content_url %}
-            <p><a href="{{ post.content_url }}">{{ post.content_url }}</a></p>
+          {% if post.body %}
+            <div class="post-caption prose">
+              {{ post.body|safe }}
+            </div>
           {% endif %}
         {% endif %}
       </div>

--- a/templates/core/post_form.html
+++ b/templates/core/post_form.html
@@ -15,6 +15,12 @@
   </div>
 
   <div class="form-row">
+    {{ form.heading.label_tag }}
+    {{ form.heading }}
+    {{ form.heading.errors }}
+  </div>
+
+  <div class="form-row">
     {{ form.body.label_tag }}
     <div class="editor-container prose">
       <div class="editor-tabs">
@@ -34,9 +40,9 @@
   </div>
 
   <div class="form-row">
-    {{ form.url.label_tag }}
-    {{ form.url }}
-    {{ form.url.errors }}
+    {{ form.content_url.label_tag }}
+    {{ form.content_url }}
+    {{ form.content_url.errors }}
   </div>
 
   <div class="form-actions">


### PR DESCRIPTION
## Summary
- add `heading` field to post form and show it in post detail and listings
- wrap `embed_html` in a responsive 16:9 container and fall back to a compact `link_domain` card
- render post body as a caption beneath embeds inside `.prose`

## Testing
- `python manage.py test --failfast` *(fails: ModuleNotFoundError: freezegun)*

------
https://chatgpt.com/codex/tasks/task_e_68b41879f6d0832c9a3d7ec743271d8b