### PR TITLE
Enhance editor keyboard shortcuts and counters

### DIFF
--- a/static/js/editor.js
+++ b/static/js/editor.js
@@ -1,20 +1,82 @@
 document.addEventListener('DOMContentLoaded', () => {
-  document
-    .querySelectorAll('textarea[data-editor]')
-    .forEach(initEditor);
+  document.querySelectorAll('textarea[data-editor]').forEach(setupEditor);
+  const title = document.querySelector('#id_title');
+  if (title) setupCounter(title);
 });
 
-function initEditor(textarea) {
-  const toolbar = textarea.previousElementSibling;
-  if (!toolbar || !toolbar.classList.contains('editor-toolbar')) return;
+document.body.addEventListener('htmx:afterSwap', (e) => {
+  if (!e.detail || !e.detail.elt) return;
+  e.detail.elt.querySelectorAll?.('textarea[data-editor]').forEach(setupEditor);
+  const title = e.detail.elt.querySelector?.('#id_title');
+  if (title) setupCounter(title);
+});
 
-  toolbar.querySelectorAll('button[data-action]').forEach((button) => {
-    button.addEventListener('click', () => {
-      applyAction(textarea, button.dataset.action);
-      textarea.dispatchEvent(new Event('input', { bubbles: true }));
-      textarea.focus();
+function setupEditor(textarea) {
+  if (textarea.dataset.editorReady) return;
+  textarea.dataset.editorReady = '1';
+
+  const toolbar = textarea.previousElementSibling;
+  if (toolbar && toolbar.classList.contains('editor-toolbar')) {
+    toolbar.querySelectorAll('button[data-action]').forEach((button) => {
+      button.addEventListener('click', () => {
+        applyAction(textarea, button.dataset.action);
+        textarea.dispatchEvent(new Event('input', { bubbles: true }));
+        textarea.focus();
+      });
     });
+  }
+
+  textarea.addEventListener('keydown', (e) => {
+    if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
+      e.preventDefault();
+      textarea.form?.requestSubmit();
+    }
+    if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'b') {
+      e.preventDefault();
+      applyAction(textarea, 'bold');
+      textarea.dispatchEvent(new Event('input', { bubbles: true }));
+    }
+    if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'i') {
+      e.preventDefault();
+      applyAction(textarea, 'italic');
+      textarea.dispatchEvent(new Event('input', { bubbles: true }));
+    }
   });
+
+  const resize = () => {
+    const max = window.innerHeight * 0.6;
+    textarea.style.height = 'auto';
+    textarea.style.height = Math.min(textarea.scrollHeight, max) + 'px';
+  };
+  textarea.addEventListener('input', resize);
+  window.addEventListener('resize', resize);
+  resize();
+
+  setupCounter(textarea);
+}
+
+function setupCounter(field) {
+  if (field.dataset.counterReady) return;
+  field.dataset.counterReady = '1';
+
+  const max = parseInt(
+    field.getAttribute('maxlength') || field.dataset.max || (field.tagName === 'TEXTAREA' ? '10000' : '300'),
+    10,
+  );
+  let counter = field.parentElement.querySelector('.char-count');
+  if (!counter) {
+    counter = document.createElement('div');
+    counter.className = 'char-count';
+    field.insertAdjacentElement('afterend', counter);
+  }
+  const update = () => {
+    const len = field.value.length;
+    counter.textContent = `${len}/${max}`;
+    counter.classList.toggle('near-limit', len > max * 0.9 && len <= max);
+    counter.classList.toggle('over-limit', len > max);
+  };
+  field.addEventListener('input', update);
+  update();
 }
 
 function applyAction(textarea, action) {
@@ -57,4 +119,6 @@ function applyAction(textarea, action) {
 
   textarea.setRangeText(replacement, start, end, 'end');
 }
+
+window.setupEditor = setupEditor;
 


### PR DESCRIPTION
## Summary
- add form submission via Ctrl/Cmd+Enter and bold/italic shortcuts
- auto-expand textareas and provide live character counters

## Testing
- `python manage.py collectstatic --noinput`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b41b518510832cbe5bfde91713481e