### PR TITLE
Add markdown preview endpoint and editor tab support

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -8,7 +8,8 @@ urlpatterns = [
     path("mission/", core_views.mission, name="mission"),
     path("transparency/methods", core_views.transparency_methods, name="transparency_methods"),
     path("transparency/posts", core_views.transparency_posts, name="transparency_posts"),
-    path("preview/", core_views.render_preview, name="preview"),
+    # Markdown preview endpoint
+    path("preview", core_views.render_preview, name="preview"),
     path("oembed/preview/", core_views.oembed_preview, name="oembed_preview"),
 
     # Post signals

--- a/static/js/editor.js
+++ b/static/js/editor.js
@@ -53,6 +53,33 @@ function setupEditor(textarea) {
   resize();
 
   setupCounter(textarea);
+
+  // Handle Write/Preview tab switching
+  const container = textarea.closest('.editor-container');
+  const writeTab = container?.querySelector('.tab-write');
+  const previewTab = container?.querySelector('.tab-preview');
+  const preview = container?.querySelector('.preview');
+  const showWrite = () => {
+    writeTab?.classList.add('active');
+    previewTab?.classList.remove('active');
+    textarea.style.display = '';
+    if (toolbar) toolbar.style.display = '';
+    if (preview) preview.style.display = 'none';
+  };
+  const showPreview = () => {
+    previewTab?.classList.add('active');
+    writeTab?.classList.remove('active');
+    textarea.style.display = 'none';
+    if (toolbar) toolbar.style.display = 'none';
+    if (preview) preview.style.display = '';
+  };
+  writeTab?.addEventListener('click', (e) => {
+    e.preventDefault();
+    showWrite();
+  });
+  previewTab?.addEventListener('click', () => {
+    showPreview();
+  });
 }
 
 function setupCounter(field) {


### PR DESCRIPTION
## Summary
- add `/preview` URL for Markdown rendering
- toggle write/preview tabs in editor via JavaScript

## Testing
- `python manage.py test core.tests.test_compose.PreviewTests.test_strips_disallowed_tags_but_keeps_links`


------
https://chatgpt.com/codex/tasks/task_e_68b41cf6d344832c8eab14c9297a9d1f