### PR TITLE
Enhance editor with draft persistence and link helpers

### DIFF
--- a/static/js/editor.js
+++ b/static/js/editor.js
@@ -1,14 +1,20 @@
 document.addEventListener('DOMContentLoaded', () => {
   document.querySelectorAll('textarea[data-editor]').forEach(setupEditor);
+  document.querySelectorAll('.post-form, .comment-form').forEach(setupDraft);
   const title = document.querySelector('#id_title');
   if (title) setupCounter(title);
+  const contentUrl = document.querySelector('#id_content_url');
+  if (contentUrl) setupDomainHint(contentUrl);
 });
 
 document.body.addEventListener('htmx:afterSwap', (e) => {
   if (!e.detail || !e.detail.elt) return;
   e.detail.elt.querySelectorAll?.('textarea[data-editor]').forEach(setupEditor);
+  e.detail.elt.querySelectorAll?.('.post-form, .comment-form').forEach(setupDraft);
   const title = e.detail.elt.querySelector?.('#id_title');
   if (title) setupCounter(title);
+  const contentUrl = e.detail.elt.querySelector?.('#id_content_url');
+  if (contentUrl) setupDomainHint(contentUrl);
 });
 
 function setupEditor(textarea) {
@@ -104,6 +110,118 @@ function setupCounter(field) {
   };
   field.addEventListener('input', update);
   update();
+}
+
+function setupDomainHint(field) {
+  if (field.dataset.domainReady) return;
+  field.dataset.domainReady = '1';
+
+  let hint = field.parentElement.querySelector('.domain-hint');
+  if (!hint) {
+    hint = document.createElement('div');
+    hint.className = 'domain-hint';
+    hint.style.display = 'none';
+    field.insertAdjacentElement('afterend', hint);
+  }
+  const update = () => {
+    try {
+      const url = new URL(field.value);
+      hint.textContent = url.hostname;
+      hint.style.display = '';
+    } catch {
+      hint.textContent = '';
+      hint.style.display = 'none';
+    }
+  };
+  field.addEventListener('input', update);
+  update();
+}
+
+function setupDraft(form) {
+  if (form.dataset.draftReady) return;
+  form.dataset.draftReady = '1';
+
+  const key = getDraftKey(form);
+  if (!key) return;
+
+  const pill = form.querySelector('.draft-pill');
+  const save = () => {
+    const data = {};
+    form.querySelectorAll('input, textarea').forEach((el) => {
+      if (el.name) data[el.name] = el.value;
+    });
+    try {
+      localStorage.setItem(key, JSON.stringify(data));
+    } catch {}
+  };
+  const restore = () => {
+    try {
+      const data = JSON.parse(localStorage.getItem(key) || '{}');
+      Object.entries(data).forEach(([name, value]) => {
+        const field = form.querySelector(`[name="${name}"]`);
+        if (field) field.value = value;
+      });
+      form.querySelectorAll('input, textarea').forEach((el) => {
+        el.dispatchEvent(new Event('input', { bubbles: true }));
+      });
+    } catch {}
+    pill.hidden = true;
+  };
+  const discard = () => {
+    localStorage.removeItem(key);
+    pill.hidden = true;
+  };
+
+  const existing = localStorage.getItem(key);
+  if (existing && pill) {
+    pill.hidden = false;
+    pill.innerHTML =
+      '<button type="button" class="restore-draft">Restore</button> / <button type="button" class="discard-draft">Discard</button>';
+    pill.querySelector('.restore-draft')?.addEventListener('click', restore);
+    pill.querySelector('.discard-draft')?.addEventListener('click', discard);
+  }
+
+  form.addEventListener('input', save);
+  const interval = setInterval(save, 5000);
+  const cleanup = () => {
+    clearInterval(interval);
+    localStorage.removeItem(key);
+  };
+
+  form.addEventListener('submit', (e) => {
+    if (form.classList.contains('post-form')) {
+      const body = form.querySelector('textarea[name="body"]');
+      const urlField = form.querySelector('input[name="content_url"]');
+      if (body && urlField && !urlField.value.trim()) {
+        const text = body.value.trim();
+        if (isOnlyUrl(text)) {
+          if (confirm('Move URL to URL field?')) {
+            urlField.value = text;
+            urlField.dispatchEvent(new Event('input', { bubbles: true }));
+          }
+        }
+      }
+    }
+    cleanup();
+  });
+  window.addEventListener('beforeunload', save);
+}
+
+function getDraftKey(form) {
+  if (form.classList.contains('post-form')) {
+    const match = form.action.match(/\/c\/([^/]+)/);
+    const slug = match ? match[1] : 'global';
+    return `postDraft:${slug}`;
+  }
+  if (form.classList.contains('comment-form')) {
+    const post = form.querySelector('input[name="post"]')?.value;
+    if (post) return `commentDraft:${post}`;
+  }
+  return null;
+}
+
+function isOnlyUrl(text) {
+  return /^https?:\/\/\S+$/.test(text);
 }
 
 function applyAction(textarea, action) {


### PR DESCRIPTION
## Summary
- Auto-save post and comment drafts with community/post-specific keys
- Prompt to move standalone URLs to the URL field and show link domain hints

## Testing
- `STATICFILES_STORAGE=django.contrib.staticfiles.storage.StaticFilesStorage pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b41ecdaa80832c9d7912965b3868ce