### PR TITLE
Use reusable comment editor and inline reply form

### DIFF
--- a/templates/core/partials/comment_form.html
+++ b/templates/core/partials/comment_form.html
@@ -1,3 +1,5 @@
+{% with base_id=comment.pk|default:parent.pk|default:'new' %}
+{% with preview_id='preview-'|add:base_id %}
 <form {% if comment %}
         hx-post="{% url 'comment_edit' comment.pk %}"
         hx-target="#comment-{{ comment.pk }}"
@@ -6,6 +8,7 @@
         hx-post="{% url 'comment_create' %}"
         {% if parent %}
         hx-swap="afterend"
+        hx-on="htmx:afterSwap:this.remove()"
         {% else %}
         hx-target="#comments"
         hx-swap="beforeend"
@@ -21,20 +24,22 @@
   {% endif %}
   <div class="draft-pill" hidden></div>
   <div class="form-error" role="alert" style="display:none"></div>
-  <div class="editor-container">
-    <div class="editor-tabs">
-      <button type="button" class="tab tab-write active">Write</button>
-      <button type="button"
-              class="tab tab-preview"
-              hx-post="{% url 'preview' %}"
-              hx-vals="js:{text: this.closest('.editor-container').querySelector('textarea').value}"
-              hx-target="#comment-preview"
-              hx-swap="innerHTML">Preview</button>
+    <div class="editor-container">
+      <div class="editor-tabs">
+        <button type="button" class="tab tab-write active">Write</button>
+        <button type="button"
+                class="tab tab-preview"
+                hx-post="{% url 'preview' %}"
+                hx-vals="js:{text: this.closest('.editor-container').querySelector('textarea').value}"
+                hx-target="#{{ preview_id }}"
+                hx-swap="innerHTML">Preview</button>
+      </div>
+      {% include "core/partials/editor_toolbar.html" %} {# formatting toolbar #}
+      {{ form.body }}
+      <div class="char-count"></div>
+      <div id="{{ preview_id }}" class="preview" style="display:none"></div>
     </div>
-    {% include "core/partials/editor_toolbar.html" %} {# formatting toolbar #}
-    {{ form.body }}
-    <div id="body-count" class="char-count"></div>
-    <div id="comment-preview" class="preview" style="display:none"></div>
-  </div>
   <button type="submit">{% if comment %}Save{% else %}Comment{% endif %}<span class="spinner" hidden aria-hidden="true"></span></button>
-</form>
+  </form>
+{% endwith %}
+{% endwith %}

--- a/templates/core/partials/comment_item.html
+++ b/templates/core/partials/comment_item.html
@@ -23,7 +23,7 @@
               aria-label="Downvote" class="down" aria-pressed="false">▼</button>
     </span>
     <button hx-get="/comments/new?parent={{ comment.pk }}&post={{ comment.post.pk }}"
-            hx-target="#comment-{{ comment.pk }}" hx-swap="afterend">Reply</button>
+            hx-target="#comment-{{ comment.pk }} > .children" hx-swap="beforeend">Reply</button>
     {% if comment|can_edit_comment:request.user %}
       <button hx-get="{% url 'comment_edit' comment.pk %}"
               hx-target="#comment-body-{{ comment.pk }}"
@@ -47,16 +47,16 @@
   </div>
   {% else %}
     {% with child_count=comment.children.count %}
-      {% if child_count %}
-        <div class="children more-replies">
+      <div class="children {% if child_count %}more-replies{% endif %}">
+        {% if child_count %}
           <button class="linklike load-more"
                   hx-get="/comments/children?parent={{ comment.pk }}&offset=0"
                   hx-swap="afterend"
                   hx-on="htmx:afterSwap:this.remove()">
             Show more replies ({{ child_count }})
           </button>
-        </div>
-      {% endif %}
+        {% endif %}
+      </div>
     {% endwith %}
   {% endif %}
 </div>


### PR DESCRIPTION
## Summary
- Simplify comment form with reusable editor, live char counter and unique preview areas
- Inject reply forms into nested comment threads for tidy spacing and collapsible control

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*
- `DJANGO_SETTINGS_MODULE=config.settings pytest -q` *(fails: django.core.exceptions.AppRegistryNotReady: Apps aren't loaded yet)*
- `python3 manage.py test --verbosity 0` *(fails: ValueError: The file 'css/base.css' could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_68b42043c374832c8bc78daf1cf33e3f