### PR TITLE
Improve editor accessibility and form UX

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -154,6 +154,26 @@ li + li {
     transform: rotate(360deg);
   }
 }
+/* Accessible button styles */
+form button,
+.button {
+  background: #e5e7eb;
+  color: #111111;
+  border: 1px solid #9ca3af;
+  cursor: pointer;
+}
+
+form button:hover,
+.button:hover {
+  background: #d1d5db;
+}
+
+form button:focus,
+.button:focus {
+  outline: 2px solid #1d4ed8;
+  outline-offset: 2px;
+}
+
 
 .form-error {
   color: #b91c1c;

--- a/static/js/editor.js
+++ b/static/js/editor.js
@@ -16,6 +16,11 @@ document.body.addEventListener('htmx:afterSwap', (e) => {
   const contentUrl = e.detail.elt.querySelector?.('#id_content_url');
   if (contentUrl) setupDomainHint(contentUrl);
 });
+document.body.addEventListener('submit', handleSubmit);
+document.body.addEventListener('htmx:afterRequest', handleAfterRequest);
+document.body.addEventListener('htmx:responseError', handleError);
+document.body.addEventListener('htmx:sendError', handleError);
+
 
 function setupEditor(textarea) {
   if (textarea.dataset.editorReady) return;
@@ -222,6 +227,46 @@ function getDraftKey(form) {
 
 function isOnlyUrl(text) {
   return /^https?:\/\/\S+$/.test(text);
+}
+
+function handleSubmit(e) {
+  const form = e.target;
+  const button = form.querySelector('button[type="submit"]');
+  const spinner = button?.querySelector('.spinner');
+  if (button) {
+    button.disabled = true;
+  }
+  if (spinner) {
+    spinner.hidden = false;
+  }
+  const err = form.querySelector('.form-error');
+  if (err) {
+    err.style.display = 'none';
+    err.textContent = '';
+  }
+}
+
+function handleAfterRequest(e) {
+  const form = e.target.closest('form');
+  if (!form || !form.isConnected) return;
+  const button = form.querySelector('button[type="submit"]');
+  const spinner = button?.querySelector('.spinner');
+  if (button) button.disabled = false;
+  if (spinner) spinner.hidden = true;
+}
+
+function handleError(e) {
+  const form = e.target.closest('form');
+  if (!form) return;
+  const button = form.querySelector('button[type="submit"]');
+  const spinner = button?.querySelector('.spinner');
+  if (button) button.disabled = false;
+  if (spinner) spinner.hidden = true;
+  const err = form.querySelector('.form-error');
+  if (err) {
+    err.textContent = e.detail.xhr?.response || 'An error occurred';
+    err.style.display = '';
+  }
 }
 
 function applyAction(textarea, action) {

--- a/templates/core/partials/editor_toolbar.html
+++ b/templates/core/partials/editor_toolbar.html
@@ -1,8 +1,8 @@
 <div class="editor-toolbar" role="toolbar">
-  <button type="button" data-action="bold">Bold</button>
-  <button type="button" data-action="italic">Italic</button>
-  <button type="button" data-action="link">Link</button>
-  <button type="button" data-action="code">Code</button>
-  <button type="button" data-action="bullets">Bullets</button>
-  <button type="button" data-action="numbers">Numbers</button>
+  <button type="button" data-action="bold" aria-label="Bold">Bold</button>
+  <button type="button" data-action="italic" aria-label="Italic">Italic</button>
+  <button type="button" data-action="link" aria-label="Link">Link</button>
+  <button type="button" data-action="code" aria-label="Code">Code</button>
+  <button type="button" data-action="bullets" aria-label="Bullets">Bullets</button>
+  <button type="button" data-action="numbers" aria-label="Numbers">Numbers</button>
 </div>


### PR DESCRIPTION
## Summary
- Add aria labels to markdown toolbar buttons
- Improve button styles for contrast and visible focus
- Disable submit buttons on submit, show spinner, and surface HTMX errors inline

## Testing
- `python manage.py test` *(fails: ValueError: The file 'css/base.css' could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_68b422856df0832ca7fd9e07db2122e8