### PR TITLE
Add embed tests and CSP allowances for embeds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ recompute:
         python manage.py recompute_ranks
 
 test:
-        pytest -q
+	python manage.py test
 
 astro:
 	python manage.py compute_astro_baselines

--- a/config/settings.py
+++ b/config/settings.py
@@ -88,10 +88,20 @@ if not DEBUG:
     CONTENT_SECURITY_POLICY = {
         "DIRECTIVES": {
             "default-src": ("'self'",),
-            "script-src": ("'self'",),
+            "script-src": (
+                "'self'",
+                "https://platform.twitter.com",
+                "https://cdn.syndication.twimg.com",
+            ),
             "style-src": ("'self'", "'unsafe-inline'"),
             "img-src": ("'self'", "https:", "data:"),
             "connect-src": ("'self'",),
+            "frame-src": (
+                "'self'",
+                "https://www.youtube.com",
+                "https://www.youtube-nocookie.com",
+                "https://rumble.com",
+            ),
             "frame-ancestors": ("'self'",),
             "upgrade-insecure-requests": True,
             "base-uri": ("'self'",),

--- a/core/tests/test_compose.py
+++ b/core/tests/test_compose.py
@@ -57,6 +57,33 @@ class PostCreationTests(TestCase):
         self.assertEqual(post.content_url, "https://example.com")
 
 
+class CommentFormTests(TestCase):
+    def setUp(self) -> None:
+        cache.clear()
+        User = get_user_model()
+        self.user = User.objects.create_user("alice", password="pwd")
+        self.community = Community.objects.create(
+            slug="t", name="Test", title="Test", created_by=self.user
+        )
+        self.post = Post.objects.create(
+            community=self.community,
+            author=self.user,
+            post_type="text",
+            title="Post",
+            body="Body",
+        )
+        self.client.login(username="alice", password="pwd")
+
+    def test_submit_comment(self):
+        url = reverse("comment_reply", args=[self.post.pk])
+        resp = self.client.post(url, {"body": "Nice"})
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(self.post.comments.count(), 1)
+        comment = self.post.comments.get()
+        self.assertEqual(comment.body, "Nice")
+        self.assertEqual(comment.author, self.user)
+
+
 class PreviewTests(TestCase):
     def test_strips_disallowed_tags_but_keeps_links(self):
         text = "Hello <script>alert(1)</script> [link](http://example.com)"

--- a/core/tests/test_oembed.py
+++ b/core/tests/test_oembed.py
@@ -1,0 +1,27 @@
+from unittest.mock import Mock, patch
+
+import requests
+from django.test import TestCase
+
+from core.oembed import fetch_oembed
+
+
+def _mock_response(json=None, status=200):
+    resp = Mock()
+    resp.json.return_value = json
+
+    def raise_for_status():
+        if status >= 400:
+            raise requests.HTTPError()
+
+    resp.raise_for_status = raise_for_status
+    return resp
+
+
+class OEmbedTests(TestCase):
+    def test_fetch_oembed_removes_scripts(self):
+        sample_html = '<iframe src="https://youtube.com/embed/abc"></iframe><script>alert(1)</script>'
+        with patch("requests.get", return_value=_mock_response(json={"html": sample_html})):
+            data = fetch_oembed("https://www.youtube.com/watch?v=abc")
+        self.assertEqual(data["type"], "embed")
+        self.assertNotIn("script", data["html"].lower())


### PR DESCRIPTION
## Summary
- test post creation, comment submission, preview, and oEmbed sanitization
- allow YouTube, Rumble, and Twitter in CSP script-src and frame-src
- run Django tests via `python manage.py test`

## Testing
- `DJANGO_TESTS=1 python manage.py test` *(fails: ModuleNotFoundError: No module named 'freezegun'; FAIL: 5 failures, 2 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b424ca54f0832cb4f261c484e759da