### PR TITLE
Refactor post detail routing and links

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -11,6 +11,7 @@ from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
 from datetime import timedelta
 from django.utils import timezone
+from django.utils.text import slugify
 from urllib.parse import urlparse
 
 from PIL import Image
@@ -124,6 +125,10 @@ class Post(models.Model):
         related_name="+",
     )
     created_at = models.DateTimeField(auto_now_add=True)
+
+    @property
+    def slug(self):
+        return slugify(self.title)
 
     class Meta:
         indexes = [

--- a/core/tests/test_astro.py
+++ b/core/tests/test_astro.py
@@ -5,7 +5,6 @@ from django.core.management import call_command
 from django.test import TestCase, override_settings
 from django.urls import reverse
 from django.utils import timezone
-from django.utils.text import slugify
 from freezegun import freeze_time
 
 from ..models import Community, EngagementEvent, Post, CommunityBaseline
@@ -186,7 +185,7 @@ class AstroFeatureFlagViewTests(TestCase):
         chips_url = reverse("post_signals_chips", args=[self.post.pk])
         detail_url = reverse(
             "post_detail",
-            args=[self.community.slug, self.post.pk, slugify(self.post.title)],
+            args=[self.community.slug, self.post.pk, self.post.slug],
         )
         self.assertContains(self.client.get(detail_url), chips_url)
         self.assertContains(self.client.get(reverse("home")), chips_url)

--- a/core/urls.py
+++ b/core/urls.py
@@ -39,7 +39,7 @@ urlpatterns = [
 
     # Post detail (nested under community, with id + slug)
     path(
-        "r/<slug:slug>/comments/<int:post_id>/<slug:post_slug>/",
+        "r/<slug:community>/comments/<int:pk>/<slug:slug>/",
         core_views.post_detail,
         name="post_detail",
     ),

--- a/core/views.py
+++ b/core/views.py
@@ -30,7 +30,6 @@ from django.conf import settings
 from django.http import Http404, HttpResponse, HttpResponseBadRequest, HttpResponseForbidden
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils import timezone
-from django.utils.text import slugify
 from django.db.models import F
 from django import forms
 from django.core.paginator import Paginator
@@ -510,10 +509,10 @@ def submit_post(request, slug):
     return render(request, "core/post_form.html", context)
 
 
-def post_detail(request, slug, post_id, post_slug):
+def post_detail(request, community, pk, slug):
     """Display a single post and its comments."""
 
-    post = get_object_or_404(Post, pk=post_id, community__slug=slug)
+    post = get_object_or_404(Post, pk=pk, community__slug=community)
     comments = post.comments.select_related("author").order_by("path")
     form = CommentForm()
     context = {"post": post, "comments": comments, "form": form}
@@ -546,9 +545,9 @@ def post_edit(request, pk):
             messages.success(request, "Post updated")
             return redirect(
                 "post_detail",
-                slug=post.community.slug,
-                post_id=post.pk,
-                post_slug=slugify(post.title),
+                community=post.community.slug,
+                pk=post.pk,
+                slug=post.slug,
             )
         else:
             messages.error(request, "Please correct the errors below.")
@@ -606,9 +605,9 @@ def comment_reply(request, post_id):
 
     return redirect(
         "post_detail",
-        slug=post.community.slug,
-        post_id=post.pk,
-        post_slug=slugify(post.title),
+        community=post.community.slug,
+        pk=post.pk,
+        slug=post.slug,
     )
 
 
@@ -731,9 +730,9 @@ def comment_create(request):
 
     return redirect(
         "post_detail",
-        slug=post.community.slug,
-        post_id=post.pk,
-        post_slug=slugify(post.title),
+        community=post.community.slug,
+        pk=post.pk,
+        slug=post.slug,
     )
 
 
@@ -780,7 +779,12 @@ def comment_edit(request, pk):
         form = CommentForm(instance=comment)
         html = render_to_string(
             "core/partials/comment_form.html",
-            {"form": form, "comment": comment, "post": comment.post},
+            {
+                "form": form,
+                "comment": comment,
+                "post": comment.post,
+                "parent": comment,
+            },
             request=request,
         )
         return HttpResponse(html)
@@ -801,9 +805,9 @@ def comment_edit(request, pk):
 
     return redirect(
         "post_detail",
-        slug=comment.post.community.slug,
-        post_id=comment.post.pk,
-        post_slug=slugify(comment.post.title),
+        community=comment.post.community.slug,
+        pk=comment.post.pk,
+        slug=comment.post.slug,
     )
 
 
@@ -823,7 +827,7 @@ def post_delete_owner(request, pk):
 
     has_comments = Comment.objects.filter(post=post).exists()
     if has_comments:
-        post_slug = slugify(post.title)
+        post_slug = post.slug
         post.soft_delete(request.user)
         # HTMX: swap the row to a deleted stub in feeds
         if request.headers.get("HX-Request") == "true":
@@ -831,9 +835,9 @@ def post_delete_owner(request, pk):
             return HttpResponse(html)
         return redirect(
             "post_detail",
-            slug=post.community.slug,
-            post_id=post.id,
-            post_slug=post_slug,
+            community=post.community.slug,
+            pk=post.id,
+            slug=post_slug,
         )
     else:
         community_slug = post.community.slug
@@ -895,9 +899,9 @@ def comment_delete(request, pk):
 
     return redirect(
         "post_detail",
-        slug=post.community.slug,
-        post_id=post.pk,
-        post_slug=slugify(post.title),
+        community=post.community.slug,
+        pk=post.pk,
+        slug=post.slug,
     )
 
 

--- a/templates/core/partials/comment.html
+++ b/templates/core/partials/comment.html
@@ -1,1 +1,2 @@
+{% url 'post_detail' comment.post.community.slug comment.post.pk comment.post.slug as post_url %}
 {% include "core/partials/comment_item.html" %}

--- a/templates/core/partials/comment_children.html
+++ b/templates/core/partials/comment_children.html
@@ -1,3 +1,4 @@
+{% url 'post_detail' parent.post.community.slug parent.post.pk parent.post.slug as post_url %}
 {% for comment in children %}
   {% include "core/partials/comment_item.html" with comment=comment %}
 {% endfor %}

--- a/templates/core/partials/comment_item.html
+++ b/templates/core/partials/comment_item.html
@@ -5,7 +5,7 @@
     <button class="collapse-toggle" data-comment-id="{{ comment.pk }}" aria-label="Collapse thread">▾</button>
     by <a href="{% url 'user_overview' comment.author.username %}">{{ comment.author.username }}</a>
     • <time datetime="{{ comment.created_at|date:'c' }}" data-ts="{{ comment.created_at|date:'U' }}" title="{{ comment.created_at|date:'Y-m-d H:i' }}">{{ comment.created_at|timesince }} ago</time>
-    <button type="button" class="copy-link" data-link="{{ request.META.HTTP_HX_CURRENT_URL|default:request.build_absolute_uri }}#c{{ comment.pk }}" aria-label="Copy link to comment">🔗</button>
+    <a href="{{ post_url }}#c{{ comment.pk }}" class="copy-link" data-link="{{ post_url }}#c{{ comment.pk }}" aria-label="Copy link to comment">🔗</a>
     {% if comment.edited_at %}
       <span class="edited" title="Edited {{ comment.edited_at|date:'Y-m-d H:i' }}">edited</span>
     {% endif %}

--- a/templates/core/partials/comment_row.html
+++ b/templates/core/partials/comment_row.html
@@ -3,7 +3,7 @@
   <p>{{ comment.body }}</p>
   <small>
     in <a href="{% url 'community' comment.post.community.slug %}">/r/{{ comment.post.community.slug }}/</a>
-    on <a href="{% url 'post_detail' comment.post.community.slug comment.post.pk comment.post.title|slugify %}">{{ comment.post.title }}</a>
+    on <a href="{% url 'post_detail' comment.post.community.slug comment.post.pk comment.post.slug %}">{{ comment.post.title }}</a>
     · <time datetime="{{ comment.created_at|date:'c' }}" data-ts="{{ comment.created_at|date:'U' }}" title="{{ comment.created_at|date:'Y-m-d H:i' }}">{{ comment.created_at|timesince }} ago</time>
   </small>
 </div>

--- a/templates/core/partials/post_row.html
+++ b/templates/core/partials/post_row.html
@@ -11,11 +11,7 @@
       <em>[deleted]</em>
     {% else %}
       <h2>
-      {% if post.content_url %}
-        <a href="{{ post.content_url }}">{{ post.title }}</a>
-      {% else %}
-        <a href="{% url 'post_detail' post.community.slug post.pk post.title|slugify %}">{{ post.title }}</a>
-      {% endif %}
+        <a href="{% url 'post_detail' post.community.slug post.pk post.slug %}">{{ post.title }}</a>
       </h2>
       {% if post.heading %}
         <h3 class="post-heading">{{ post.heading }}</h3>
@@ -45,7 +41,7 @@
       <a href="{% url 'community' post.community.slug %}">/r/{{ post.community.slug }}/</a>
       · {{ post.author.username }}
       · <time datetime="{{ post.created_at|date:'c' }}" data-ts="{{ post.created_at|date:'U' }}" title="{{ post.created_at|date:'Y-m-d H:i' }}">{{ post.created_at|timesince }} ago</time>
-      · <a href="{% url 'post_detail' post.community.slug post.pk post.title|slugify %}">{{ post.comment_count }} comments</a>
+      · <a href="{% url 'post_detail' post.community.slug post.pk post.slug %}#comments">{{ post.comment_count }} comments</a>
       {% if user.is_authenticated %}
       · <a href="{% url 'report' %}?target_type=post&object_id={{ post.pk }}">[report]</a>
       {% endif %}

--- a/templates/core/post_detail.html
+++ b/templates/core/post_detail.html
@@ -1,5 +1,10 @@
 {% extends "base.html" %}
 {% load permissions static %}
+{% url 'post_detail' post.community.slug post.pk post.slug as post_url %}
+
+{% block head_extra %}
+<link rel="canonical" href="{{ post_url }}">
+{% endblock %}
 
 {% block content %}
 <div class="post-page">
@@ -88,7 +93,7 @@
   {% endfor %}
 </div>
 <div>
-  {% include "core/partials/comment_form.html" %}
+  {% include "core/partials/comment_form.html" with post=post parent=post comment=None %}
 </div>
 {% endblock %}
 

--- a/templates/core/transparency_posts.html
+++ b/templates/core/transparency_posts.html
@@ -17,7 +17,7 @@
     <tbody>
       {% for row in page_obj %}
       <tr>
-        <td><a href="{% url 'post_detail' row.post.community.slug row.post.pk row.post.title|slugify %}">{{ row.post.title }}</a></td>
+        <td><a href="{% url 'post_detail' row.post.community.slug row.post.pk row.post.slug %}">{{ row.post.title }}</a></td>
         <td>{{ row.author_age }}</td>
         <td>{{ row.rate5 }} / {{ row.base5 }}</td>
         <td>{{ row.rate15 }} / {{ row.base15 }}</td>


### PR DESCRIPTION
## Summary
- switch post detail route to `r/<community>/comments/<pk>/<slug>/`
- link posts and comments with the new route and canonical URL
- provide per-comment permalinks anchored to the post detail page

## Testing
- `python manage.py test` *(fails: 5 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b42990e8d0832ca3f7ee0086ce05e5