### PR TITLE
Fix comment partial context handling

### DIFF
--- a/templates/core/partials/comment_children.html
+++ b/templates/core/partials/comment_children.html
@@ -1,6 +1,5 @@
-{% url 'post_detail' parent.post.community.slug parent.post.pk parent.post.slug as post_url %}
-{% for comment in children %}
-  {% include "core/partials/comment_item.html" with comment=comment %}
+{% for child in children %}
+  {% include "core/partials/comment_item.html" with comment=child %}
 {% endfor %}
 {% if remaining > 0 %}
   <button class="linklike load-more"

--- a/templates/core/partials/comment_item.html
+++ b/templates/core/partials/comment_item.html
@@ -1,9 +1,10 @@
 {% load permissions %}
+{% url 'post_detail' comment.post.community.slug comment.post.pk comment.post.slug as post_url %}
 <div id="comment-{{ comment.pk }}" class="comment" data-comment-id="{{ comment.pk }}" data-depth="{{ comment.depth }}">
   <a id="c{{ comment.pk }}"></a>
   <div class="meta">
     <button class="collapse-toggle" data-comment-id="{{ comment.pk }}" aria-label="Collapse thread">▾</button>
-    by <a href="{% url 'user_overview' comment.author.username %}">{{ comment.author.username }}</a>
+    by <a href="{% url 'user_overview' comment.author.username %}">{{ comment.author.username|default:"[deleted]" }}</a>
     • <time datetime="{{ comment.created_at|date:'c' }}" data-ts="{{ comment.created_at|date:'U' }}" title="{{ comment.created_at|date:'Y-m-d H:i' }}">{{ comment.created_at|timesince }} ago</time>
     <a href="{{ post_url }}#c{{ comment.pk }}" class="copy-link" data-link="{{ post_url }}#c{{ comment.pk }}" aria-label="Copy link to comment">🔗</a>
     {% if comment.edited_at %}
@@ -37,7 +38,7 @@
       </form>
     {% endif %}
   </div>
-  <div id="comment-body-{{ comment.pk }}" class="comment-body prose">{{ comment.body|safe }}</div>
+  <div id="comment-body-{{ comment.pk }}" class="comment-body prose">{{ comment.body|default:""|safe }}</div>
   <button type="button" class="quote-btn" hidden>Quote</button>
   {% if comment.depth < 5 %}
   <div class="children">

--- a/templates/core/post_detail.html
+++ b/templates/core/post_detail.html
@@ -84,9 +84,9 @@
 </div>
 
 <div id="comments">
-  {% for comment in comments %}
-    {% if not comment.parent_id %}
-      {% include "core/partials/comment_item.html" %}
+  {% for c in comments %}
+    {% if not c.parent_id %}
+      {% include "core/partials/comment.html" with comment=c user=request.user %}
     {% endif %}
   {% empty %}
     <p>No comments yet.</p>


### PR DESCRIPTION
## Summary
- Render comment links using each comment's own post
- Add safe defaults for missing comment author or body
- Simplify comment children and use comment partial in post detail with explicit variables

## Testing
- `python manage.py test core.tests_comment_reply`
- `python manage.py test core.tests_comment_edit core.tests_comment_delete`


------
https://chatgpt.com/codex/tasks/task_e_68b42c6c64ac832c81df2bfe107a04fe