### PR TITLE
Improve card layout and text wrapping

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -22,13 +22,19 @@ main, .container, .wrap, .page, #page {
 
 /* Feed column should breathe on desktop */
 .post-list, .feed, .listing, .content-main {
-  max-width: clamp(720px, 92vw, var(--feed-max));
+  max-width: clamp(720px, 92vw, 960px);
   margin-inline: auto;
 }
 
 /* Prose: apply the 70ch cap ONLY to long-form text, not layout */
-.prose { max-width: var(--prose-max); }
-.prose img, .post-media img { max-width: 100%; height: auto; display: block; }
+.prose { max-width: 70ch; }
+
+/* Responsive media */
+img, iframe {
+  max-width: 100%;
+  height: auto;
+  display: block;
+}
 
 body {
   font-family:
@@ -59,10 +65,11 @@ pre,
 code {
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
   line-height: var(--line);
+  white-space: pre-wrap;
+  overflow-x: auto;
 }
 
 pre {
-  overflow-x: auto;
   padding: 8px;
   background: #f3f4f6;
   border-radius: 4px;
@@ -78,6 +85,29 @@ li + li {
   margin-top: 0.25em;
 }
 
+/* Post card layout */
+.post-card { position: relative; }
+
+.vote-col {
+  flex: 0 0 32px;
+  width: 32px;
+}
+
+.post-title {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.post-body,
+.comment-body,
+.post-meta,
+.comment-meta {
+  overflow-wrap: anywhere;
+  word-break: break-word;
+  hyphens: auto;
+}
 .post-form {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- make post cards relative with smaller vote column
- allow long text to wrap and truncate titles to two lines
- ensure media and code blocks resize responsively

## Testing
- `python manage.py test` *(fails: The file 'css/base.css' could not be found; 5 failures, 34 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b4c22b9a10832ca093df6968054016