### PR TITLE
Add link resolution tests and tidy post deletion view

### DIFF
--- a/core/tests/test_links.py
+++ b/core/tests/test_links.py
@@ -1,0 +1,53 @@
+from django.contrib.auth import get_user_model
+from django.core.cache import cache
+from django.test import TestCase
+from django.urls import reverse
+
+from ..models import Comment, Community, Post
+
+
+class CommentLinkTests(TestCase):
+    def setUp(self):
+        cache.clear()
+        U = get_user_model()
+        self.user = U.objects.create_user("alice", password="pwd")
+        self.other = U.objects.create_user("bob", password="pwd")
+        self.community = Community.objects.create(
+            slug="t", name="Test", title="Test", created_by=self.user
+        )
+        self.post = Post.objects.create(
+            community=self.community,
+            author=self.user,
+            post_type="text",
+            title="Hello",
+        )
+
+    def test_post_detail_comment_links(self):
+        root = Comment.objects.create(
+            post=self.post, author=self.user, body="root", path="0001"
+        )
+        child = Comment.objects.create(
+            post=self.post,
+            author=self.other,
+            parent=root,
+            body="child",
+            path="0001/0001",
+        )
+        self.post.comment_count = 2
+        self.post.save(update_fields=["comment_count"])
+
+        url = reverse(
+            "post_detail", args=[self.community.slug, self.post.pk, self.post.slug]
+        )
+        self.assertEqual(
+            url,
+            f"/r/{self.community.slug}/comments/{self.post.pk}/{self.post.slug}/",
+        )
+        resp = self.client.get(url)
+        self.assertEqual(resp.status_code, 200)
+
+        for comment in (root, child):
+            self.assertContains(resp, f'id="c{comment.pk}"')
+            user_url = reverse("user_overview", args=[comment.author.username])
+            self.assertEqual(user_url, f"/u/{comment.author.username}/")
+            self.assertContains(resp, f'href="{user_url}"')

--- a/core/urls.py
+++ b/core/urls.py
@@ -62,11 +62,6 @@ urlpatterns = [
         name="post_delete_owner",
     ),
     path("post/<int:pk>/delete/", core_views.post_delete, name="post_delete"),
-    path(
-        "post/<int:pk>/delete/owner/",
-        core_views.post_delete_owner,
-        name="post_delete_owner",
-    ),
     path("report/", core_views.report, name="report"),
     path("reports/", core_views.report_list, name="report_list"),
 

--- a/core/views.py
+++ b/core/views.py
@@ -862,23 +862,6 @@ def post_delete(request, pk):
 @login_required
 @require_POST
 @csrf_protect
-def post_delete_owner(request, pk):
-    """Delete a post if the requester is the author or staff."""
-    if _is_banned(request.user):
-        return HttpResponseForbidden("Account banned")
-
-    post = get_object_or_404(Post, pk=pk)
-    if request.user != post.author and not request.user.is_staff:
-        return HttpResponseForbidden("Forbidden")
-
-    slug = post.community.slug
-    post.delete()
-    return redirect("community", slug=slug)
-
-
-@login_required
-@require_POST
-@csrf_protect
 def comment_delete(request, pk):
     """Delete a comment if the requester is the author or staff."""
     if _is_banned(request.user):


### PR DESCRIPTION
## Summary
- test comment anchors and author profile links on post detail pages
- remove duplicate `post_delete_owner` view and redundant URL pattern

## Testing
- `DJANGO_TESTS=1 python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68b4c3bc71e0832c809ef276790266b5