### PR TITLE
Refactor post row markup

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -88,11 +88,6 @@ li + li {
 /* Post card layout */
 .post-card { position: relative; }
 
-.vote-col {
-  flex: 0 0 32px;
-  width: 32px;
-}
-
 .post-title {
   display: -webkit-box;
   -webkit-line-clamp: 2;

--- a/static/css/theme.css
+++ b/static/css/theme.css
@@ -221,29 +221,6 @@ a:focus {
   margin-bottom: 8px;
 }
 
-.vote-col {
-  width: 40px;
-  text-align: center;
-  font-size: 16px;
-  line-height: 1;
-}
-
-.vote-col button {
-  background: none;
-  border: none;
-  cursor: pointer;
-  display: block;
-  width: 100%;
-  padding: 0;
-  font-size: 16px;
-}
-
-.vote-col span {
-  display: block;
-  margin: 4px 0;
-  font-weight: bold;
-}
-
 .vote {
   width: 40px;
   display: flex;
@@ -442,7 +419,7 @@ hr {
 }
 
 /* Post images: responsive + bounded */
-.post-image {
+.post-image img {
   display: block;
   max-width: 100%;
   height: auto;         /* preserve aspect ratio */
@@ -451,22 +428,22 @@ hr {
 }
 
 /* Tighter in feed cards so they don’t eat the page */
-.feed .post-image {
+.feed .post-image img {
   width: 100%;
   max-height: 360px;    /* tweak: 300–480px depending on taste */
   object-fit: cover;    /* crops gracefully to the box */
 }
 
 /* Roomier on the post detail page */
-.post .post-image {
+.post .post-image img {
   width: 100%;
   max-height: 640px;    /* show more of the image on detail */
   object-fit: contain;  /* avoid cropping on detail view */
 }
 
 @media (max-width: 768px) {
-  .feed .post-image { max-height: 240px; }
-  .post .post-image { max-height: 480px; }
+  .feed .post-image img { max-height: 240px; }
+  .post .post-image img { max-height: 480px; }
 }
 
 .linklike {
@@ -498,7 +475,7 @@ hr {
 .post-actions a + a:before { content:"•"; color:#aaa; position:absolute; left:-6px; }
 
 /* Image */
-.post-content .post-image { border:1px solid #e6e6e6; box-shadow:0 1px 0 #eee; }
+.post-content .post-image img { border:1px solid #e6e6e6; box-shadow:0 1px 0 #eee; }
 
 /* Comment tree */
 .comment { background:#fff; border:1px solid #ddd; padding:8px; margin:8px 0; font-size:11px; }
@@ -516,7 +493,7 @@ hr {
 }
 
 /* Feed images: compact cards (does not affect post detail) */
-.feed .post-image {
+.feed .post-image img {
   width: 100%;
   max-height: 360px;
   object-fit: cover;        /* crop to fit the card */
@@ -524,7 +501,7 @@ hr {
   box-shadow: 0 1px 0 #eee;
 }
 @media (max-width: 768px) {
-  .feed .post-image { max-height: 240px; }
+  .feed .post-image img { max-height: 240px; }
 }
 
 /* Submit panel */

--- a/templates/core/partials/post_deleted_stub.html
+++ b/templates/core/partials/post_deleted_stub.html
@@ -1,9 +1,9 @@
 <!-- stub for deleted posts -->
-<li id="post-{{ post.pk }}" class="post-row">
+<article id="post-{{ post.pk }}" class="post-row">
   <div class="vote"></div>
   <div class="post-body">
     <h2><em>[deleted]</em></h2>
     <div class="meta">in r/{{ post.community.slug }}</div>
   </div>
-</li>
+</article>
 

--- a/templates/core/partials/post_row.html
+++ b/templates/core/partials/post_row.html
@@ -1,11 +1,26 @@
 {% load url_domain %}
 {% load permissions %}
-<div class="post-row" id="post-{{ post.pk }}">
-  <div class="vote-col">
-    <button hx-post="{% url 'vote_post' post.pk %}?v=1" hx-target="#post-score-{{ post.pk }}" hx-swap="outerHTML" aria-label="Upvote">▲</button>
-    <span id="post-score-{{ post.pk }}">{{ post.score }}</span>
-    <button hx-post="{% url 'vote_post' post.pk %}?v=-1" hx-target="#post-score-{{ post.pk }}" hx-swap="outerHTML" aria-label="Downvote">▼</button>
+<article class="post-row" id="post-{{ post.pk }}">
+  <div class="vote">
+    <button hx-post="{% url 'vote_post' post.pk %}?v=1" hx-target="#post-score-{{ post.pk }}" hx-swap="outerHTML" aria-label="Upvote" class="up" aria-pressed="false">▲</button>
+    <span id="post-score-{{ post.pk }}" class="score">{{ post.score }}</span>
+    <button hx-post="{% url 'vote_post' post.pk %}?v=-1" hx-target="#post-score-{{ post.pk }}" hx-swap="outerHTML" aria-label="Downvote" class="down" aria-pressed="false">▼</button>
   </div>
+  {% if not post.is_deleted and (post.embed_html or post.image_thumb or post.image) %}
+  <div class="post-image">
+    {% if post.embed_html %}
+      <div class="post-embed" style="position:relative;padding-top:56.25%;overflow:hidden;">
+        <div style="position:absolute;top:0;left:0;width:100%;height:100%;">
+          {{ post.embed_html|safe }}
+        </div>
+      </div>
+    {% elif post.image_thumb %}
+      <img src="{{ post.image_thumb.url }}" loading="lazy" decoding="async" referrerpolicy="no-referrer">
+    {% elif post.image %}
+      <img src="{{ post.image.url }}" loading="lazy" decoding="async" referrerpolicy="no-referrer">
+    {% endif %}
+  </div>
+  {% endif %}
   <div class="post-body">
     {% if post.is_deleted %}
       <em>[deleted]</em>
@@ -16,19 +31,7 @@
       {% if post.heading %}
         <h3 class="post-heading">{{ post.heading }}</h3>
       {% endif %}
-      {% if post.embed_html %}
-        <div class="post-embed" style="position:relative;padding-top:56.25%;overflow:hidden;">
-          <div style="position:absolute;top:0;left:0;width:100%;height:100%;">
-            {{ post.embed_html|safe }}
-          </div>
-        </div>
-      {% elif post.image_thumb or post.image %}
-        {% if post.image_thumb %}
-          <img src="{{ post.image_thumb.url }}" class="post-image" loading="lazy" decoding="async" referrerpolicy="no-referrer">
-        {% else %}
-          <img src="{{ post.image.url }}" class="post-image" loading="lazy" decoding="async" referrerpolicy="no-referrer">
-        {% endif %}
-      {% elif post.content_url %}
+      {% if not post.embed_html and not post.image_thumb and not post.image and post.content_url %}
         <div class="link-card">
           <a href="{{ post.content_url }}" rel="noopener nofollow">{{ post.link_domain }}</a>
         </div>
@@ -37,33 +40,29 @@
         <div class="post-caption prose">{{ post.body|safe }}</div>
       {% endif %}
     {% endif %}
-    <p class="meta">
+    <div class="meta">
       <a href="{% url 'community' post.community.slug %}">/r/{{ post.community.slug }}/</a>
       · <a href="{% url 'user_overview' post.author.username %}">{{ post.author.username }}</a>
       · <time datetime="{{ post.created_at|date:'c' }}" data-ts="{{ post.created_at|date:'U' }}" title="{{ post.created_at|date:'Y-m-d H:i' }}">{{ post.created_at|timesince }} ago</time>
-      · <a href="{% url 'post_detail' post.community.slug post.pk post.slug %}#comments">{{ post.comment_count }} comments</a>
+    </div>
+    <div class="actions">
+      <a href="{% url 'post_detail' post.community.slug post.pk post.slug %}#comments">{{ post.comment_count }} comments</a>
+      <a href="#" class="copy-link" data-link="{% url 'post_detail' post.community.slug post.pk post.slug %}" aria-label="Copy link">share</a>
+      <a href="#">save</a>
       {% if user.is_authenticated %}
-      · <a href="{% url 'report' %}?target_type=post&object_id={{ post.pk }}">[report]</a>
+      <a href="{% url 'report' %}?target_type=post&object_id={{ post.pk }}">report</a>
       {% endif %}
       {% if request.user.is_authenticated and not post.is_deleted %}
         {% if request.user.is_staff or post|can_author_delete:request.user %}
-        · <form method="post"
-              action="{% url 'post_delete_owner' post.pk %}"
-              style="display:inline"
-              hx-post="{% url 'post_delete_owner' post.pk %}"
-              hx-target="#post-{{ post.pk }}"
-              hx-swap="outerHTML"
-              hx-confirm="Delete this post? (If it has comments, only the content will be deleted)">
-            {% csrf_token %}
-            <button type="submit" class="linklike">delete</button>
-          </form>
+        <form method="post" action="{% url 'post_delete_owner' post.pk %}" style="display:inline" hx-post="{% url 'post_delete_owner' post.pk %}" hx-target="#post-{{ post.pk }}" hx-swap="outerHTML" hx-confirm="Delete this post? (If it has comments, only the content will be deleted)">
+          {% csrf_token %}
+          <button type="submit" class="linklike">delete</button>
+        </form>
         {% endif %}
       {% endif %}
-    </p>
+    </div>
     {% if ASTROTURF_WATCH %}
-    <div id="chips-{{ post.id }}"
-         hx-get="{% url 'post_signals_chips' post.id %}"
-         hx-trigger="load" hx-swap="innerHTML"></div>
+    <div id="chips-{{ post.id }}" hx-get="{% url 'post_signals_chips' post.id %}" hx-trigger="load" hx-swap="innerHTML"></div>
     {% endif %}
   </div>
-</div>
+</article>


### PR DESCRIPTION
## Summary
- structure post rows as `<article>` with vote, media, meta, and action sections
- drop `vote-col` and align CSS with `.vote` and `.post-image` containers
- update deleted post stub to match new markup

## Testing
- `python manage.py test` *(fails: ValueError: The file 'css/base.css' could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4d83d1f08832cb69fa79d66f30ca4