### PR TITLE
Add sidebar buttons and styling utilities

### DIFF
--- a/static/css/theme.css
+++ b/static/css/theme.css
@@ -334,6 +334,10 @@ a:focus {
   color: var(--link);
 }
 
+.sidebar-card {
+  margin-bottom: 12px;
+}
+
 /* Comments ----------------------------------------------------------- */
 .comment {
   background: var(--panel);
@@ -378,6 +382,17 @@ textarea:focus {
 
 .button:hover {
   background: var(--border);
+}
+
+.button-primary {
+  background: var(--link);
+  color: #fff;
+}
+
+.w-full {
+  display: block;
+  width: 100%;
+  text-align: center;
 }
 
 button:focus,

--- a/templates/partials/sidebar_min.html
+++ b/templates/partials/sidebar_min.html
@@ -1,1 +1,6 @@
-<!-- minimal sidebar placeholder -->
+<div class="sidebar-card">
+  <a class="button button-primary w-full" href="{% url 'submit_post' %}">Submit Post</a>
+</div>
+<div class="sidebar-card">
+  <a class="link-plain" href="{% url 'anti_astroturf' %}">Anti-Astroturf</a>
+</div>


### PR DESCRIPTION
## Summary
- populate minimal sidebar partial with submit and anti-astroturf links
- style sidebar cards and primary buttons
- add utility for full-width buttons

## Testing
- `python manage.py test 2>&1 | tail -n 20` *(fails: css/base.css missing with whitenoise)*

------
https://chatgpt.com/codex/tasks/task_e_68b4da3a5cbc832cb0a04b6b79a45f7c