### PR TITLE
Add anti-astroturf page and route

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -6,6 +6,7 @@ urlpatterns = [
     # Home / front page
     path("", core_views.home, name="home"),
     path("mission/", core_views.mission, name="mission"),
+    path("anti-astroturf/", core_views.anti_astroturf, name="anti_astroturf"),
     path("transparency/methods", core_views.transparency_methods, name="transparency_methods"),
     path("transparency/posts", core_views.transparency_posts, name="transparency_posts"),
     # Markdown preview endpoint

--- a/core/views.py
+++ b/core/views.py
@@ -105,6 +105,10 @@ def mission(request):
     return render(request, "core/mission.html")
 
 
+def anti_astroturf(request):
+    return render(request, "pages/anti_astroturf.html")
+
+
 def transparency_methods(request):
     if not settings.ASTROTURF_WATCH:
         raise Http404

--- a/templates/pages/anti_astroturf.html
+++ b/templates/pages/anti_astroturf.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+
+{% block title %}Anti-Astroturf{% endblock %}
+
+{% block content %}
+<div class="page container">
+  <h1>Our Anti-Astroturf Policy</h1>
+  <p>We are committed to ensuring discussions reflect authentic voices. Astroturfing—coordinated or paid campaigns masquerading as grassroots participation—is not welcome on SureJan.</p>
+  <ul>
+    <li>No undisclosed paid promotions or campaigns.</li>
+    <li>No vote manipulation or brigading.</li>
+    <li>Organizations and officials must identify themselves.</li>
+  </ul>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add Anti-Astroturf static page and template
- expose new view and URL pattern

## Testing
- `python manage.py shell -c "from django.urls import reverse; print(reverse('anti_astroturf'))"`
- `python manage.py test` *(fails: The file 'css/base.css' could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4db64d48c832ca74cc921a52b7bca