### PR TITLE
Fix submit link for minimal sidebar

### DIFF
--- a/templates/partials/sidebar_min.html
+++ b/templates/partials/sidebar_min.html
@@ -1,5 +1,9 @@
 <div class="sidebar-card">
-  <a class="button button-primary w-full" href="{% url 'submit_post' %}">Submit Post</a>
+  {% if community %}
+    <a class="button button-primary w-full" href="{% url 'submit_post' community.slug %}">Submit Post</a>
+  {% else %}
+    <a class="button button-primary w-full" href="{% url 'home' %}">Choose a Community</a>
+  {% endif %}
 </div>
 <div class="sidebar-card">
   <a class="link-plain" href="{% url 'anti_astroturf' %}">Anti-Astroturf</a>


### PR DESCRIPTION
## Summary
- Avoid NoReverseMatch on pages without a community by rendering the submit button conditionally

## Testing
- `python manage.py test` *(fails: The file 'css/base.css' could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4dc32c81c832c8669a6e454c0094e