### PR TITLE
test: add layout tests

### DIFF
--- a/core/tests/test_layout.py
+++ b/core/tests/test_layout.py
@@ -1,0 +1,21 @@
+import pytest
+
+
+@pytest.mark.django_db
+def test_homepage_layout(client):
+    resp = client.get("/")
+    assert resp.status_code == 200
+    html = resp.content.decode()
+    assert '<main class="layout">' in html
+    assert '<section class="main feed">' in html
+    assert '<aside class="sidebar">' in html
+
+
+@pytest.mark.django_db
+def test_anti_astroturf_bullets(client):
+    resp = client.get("/anti-astroturf/")
+    assert resp.status_code == 200
+    html = resp.content.decode()
+    assert "No undisclosed paid promotions or campaigns." in html
+    assert "No vote manipulation or brigading." in html
+    assert "Organizations and officials must identify themselves." in html


### PR DESCRIPTION
## Summary
- add tests for home page layout structure
- test anti-astroturf page content

## Testing
- `pytest core/tests/test_layout.py`


------
https://chatgpt.com/codex/tasks/task_e_68b4df8ff39c832cb10567c852c70700