### PR TITLE
Add post type validation to PostForm

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -8,8 +8,25 @@ from .utils.link_safety import check_url_safety
 class PostForm(forms.ModelForm):
     class Meta:
         model = Post
-        fields = ["title", "heading", "body", "content_url", "image"]
+        fields = [
+            "community",
+            "title",
+            "heading",
+            "post_type",
+            "body",
+            "content_url",
+            "image",
+        ]
         widgets = {"body": forms.Textarea(attrs={"data-editor": "1"})}
+        help_texts = {
+            "community": "Where to post.",
+            "title": "Brief post title.",
+            "heading": "Optional heading.",
+            "post_type": "Choose text, link or image.",
+            "body": "Required for text posts.",
+            "content_url": "Required for link posts.",
+            "image": "Required for image posts.",
+        }
 
     def clean_image(self):
         image = self.cleaned_data.get("image")
@@ -27,29 +44,42 @@ class PostForm(forms.ModelForm):
         heading = (cleaned_data.get("heading") or "").strip()
         body = (cleaned_data.get("body") or "").strip()
         content_url = (cleaned_data.get("content_url") or "").strip()
+        post_type = cleaned_data.get("post_type")
+        image = cleaned_data.get("image")
 
-        cleaned_data["title"] = title
-        cleaned_data["heading"] = heading
-        cleaned_data["body"] = body
-        cleaned_data["content_url"] = content_url
+        cleaned_data.update(
+            {
+                "title": title,
+                "heading": heading,
+                "body": body,
+                "content_url": content_url,
+            }
+        )
 
         if not title:
             self.add_error("title", "Title is required.")
 
-        if not body and not content_url:
-            raise forms.ValidationError("Body or URL is required.")
-
-        if content_url and not check_url_safety(content_url):
-            self.add_error("content_url", "URL flagged as unsafe.")
+        if post_type == "text":
+            if not body:
+                self.add_error("body", "Body required for text posts.")
+        elif post_type == "link":
+            if not content_url:
+                self.add_error("content_url", "URL required for link posts.")
+            elif content_url and not check_url_safety(content_url):
+                self.add_error("content_url", "URL flagged as unsafe.")
+        elif post_type == "image":
+            if not image:
+                self.add_error("image", "Image required for image posts.")
+        else:
+            raise forms.ValidationError("Invalid post type.")
 
         return cleaned_data
 
     def save(self, commit=True):
         instance = super().save(commit=False)
-        if instance.image:
-            instance.post_type = "image"
-        elif instance.content_url:
-            instance.post_type = "link"
+        post_type = self.cleaned_data.get("post_type")
+        if post_type in dict(Post._meta.get_field("post_type").choices):
+            instance.post_type = post_type
         else:
             instance.post_type = "text"
         if commit:

--- a/core/tests/__init__.py
+++ b/core/tests/__init__.py
@@ -28,7 +28,15 @@ class SubmitPostTests(TestCase):
 
     def test_submit_text_post(self):
         url = reverse("submit_post", args=[self.community.slug])
-        resp = self.client.post(url, {"title": "Hello", "body": "Body"})
+        resp = self.client.post(
+            url,
+            {
+                "community": self.community.pk,
+                "post_type": "text",
+                "title": "Hello",
+                "body": "Body",
+            },
+        )
         self.assertRedirects(resp, reverse("community", args=[self.community.slug]))
         post = Post.objects.get()
         self.assertEqual(post.post_type, "text")
@@ -40,8 +48,9 @@ class SubmitPostTests(TestCase):
         resp = self.client.post(
             url,
             {
+                "community": self.community.pk,
+                "post_type": "link",
                 "title": "Link",
-                "body": "",
                 "content_url": "https://example.com",
             },
         )
@@ -60,9 +69,10 @@ class SubmitPostTests(TestCase):
         resp = self.client.post(
             url,
             {
+                "community": self.community.pk,
+                "post_type": "image",
                 "title": "Pic",
                 "body": "caption",
-                "content_url": "",
                 "image": SimpleUploadedFile("pic.png", buf.read(), content_type="image/png"),
             },
         )
@@ -74,14 +84,38 @@ class SubmitPostTests(TestCase):
     def test_requires_login(self):
         self.client.logout()
         url = reverse("submit_post", args=[self.community.slug])
-        resp = self.client.post(url, {"title": "Hello", "body": "Body"})
+        resp = self.client.post(
+            url,
+            {
+                "community": self.community.pk,
+                "post_type": "text",
+                "title": "Hello",
+                "body": "Body",
+            },
+        )
         self.assertEqual(resp.status_code, 302)
 
     def test_rate_limit(self):
         url = reverse("submit_post", args=[self.community.slug])
         for i in range(3):
-            self.client.post(url, {"title": f"H{i}", "body": "test"})
-        resp = self.client.post(url, {"title": "H3", "body": "test"})
+            self.client.post(
+                url,
+                {
+                    "community": self.community.pk,
+                    "post_type": "text",
+                    "title": f"H{i}",
+                    "body": "test",
+                },
+            )
+        resp = self.client.post(
+            url,
+            {
+                "community": self.community.pk,
+                "post_type": "text",
+                "title": "H3",
+                "body": "test",
+            },
+        )
         self.assertEqual(resp.status_code, 429)
 
     def test_rate_limit_established_user(self):
@@ -89,9 +123,25 @@ class SubmitPostTests(TestCase):
         self.user.save()
         url = reverse("submit_post", args=[self.community.slug])
         for i in range(10):
-            resp = self.client.post(url, {"title": f"E{i}", "body": "test"})
+            resp = self.client.post(
+                url,
+                {
+                    "community": self.community.pk,
+                    "post_type": "text",
+                    "title": f"E{i}",
+                    "body": "test",
+                },
+            )
             self.assertNotEqual(resp.status_code, 429)
-        resp = self.client.post(url, {"title": "E10", "body": "test"})
+        resp = self.client.post(
+            url,
+            {
+                "community": self.community.pk,
+                "post_type": "text",
+                "title": "E10",
+                "body": "test",
+            },
+        )
         self.assertEqual(resp.status_code, 429)
 
 

--- a/core/tests/test_compose.py
+++ b/core/tests/test_compose.py
@@ -24,7 +24,15 @@ class PostCreationTests(TestCase):
         self.client.login(username="alice", password="pwd")
 
     def test_body_only(self):
-        resp = self.client.post(self.url, {"title": "Hello", "body": "Body"})
+        resp = self.client.post(
+            self.url,
+            {
+                "community": self.community.pk,
+                "post_type": "text",
+                "title": "Hello",
+                "body": "Body",
+            },
+        )
         self.assertEqual(resp.status_code, 302)
         post = Post.objects.get()
         self.assertEqual(post.post_type, "text")
@@ -33,7 +41,13 @@ class PostCreationTests(TestCase):
 
     def test_url_only(self):
         resp = self.client.post(
-            self.url, {"title": "Link", "content_url": "https://example.com"}
+            self.url,
+            {
+                "community": self.community.pk,
+                "post_type": "link",
+                "title": "Link",
+                "content_url": "https://example.com",
+            },
         )
         self.assertEqual(resp.status_code, 302)
         post = Post.objects.get()
@@ -45,6 +59,8 @@ class PostCreationTests(TestCase):
         resp = self.client.post(
             self.url,
             {
+                "community": self.community.pk,
+                "post_type": "link",
                 "title": "Both",
                 "body": "Body",
                 "content_url": "https://example.com",

--- a/core/tests_auth_flow.py
+++ b/core/tests_auth_flow.py
@@ -26,7 +26,12 @@ class AuthFlowTests(TestCase):
     def test_submit_text_post_requires_login(self):
         resp = self.client.post(
             reverse("submit_post", args=[self.community.slug]),
-            {"title": "Hi", "body": "Body"},
+            {
+                "community": self.community.pk,
+                "post_type": "text",
+                "title": "Hi",
+                "body": "Body",
+            },
         )
         self.assertEqual(resp.status_code, 302)
         self.assertIn(reverse("login"), resp["Location"])
@@ -40,7 +45,12 @@ class AuthFlowTests(TestCase):
         )
         resp = self.client.post(
             reverse("submit_post", args=[self.community.slug]),
-            {"title": "Hello", "body": "World"},
+            {
+                "community": self.community.pk,
+                "post_type": "text",
+                "title": "Hello",
+                "body": "World",
+            },
         )
         self.assertRedirects(resp, reverse("community", args=[self.community.slug]))
         self.assertTrue(

--- a/core/tests_link_safety.py
+++ b/core/tests_link_safety.py
@@ -25,7 +25,12 @@ class LinkSafetyTests(TestCase):
         mock_post.return_value.status_code = 200
         resp = self.client.post(
             self.url,
-            {"title": "Link", "body": "", "content_url": "https://example.com"},
+            {
+                "community": self.community.pk,
+                "post_type": "link",
+                "title": "Link",
+                "content_url": "https://example.com",
+            },
         )
         self.assertRedirects(resp, reverse("community", args=[self.community.slug]))
         self.assertEqual(Post.objects.count(), 1)
@@ -39,7 +44,12 @@ class LinkSafetyTests(TestCase):
         mock_post.return_value.status_code = 200
         resp = self.client.post(
             self.url,
-            {"title": "Bad", "body": "", "content_url": "http://malware.test"},
+            {
+                "community": self.community.pk,
+                "post_type": "link",
+                "title": "Bad",
+                "content_url": "http://malware.test",
+            },
         )
         self.assertEqual(resp.status_code, 200)
         self.assertFormError(resp.context["form"], "content_url", "URL flagged as unsafe.")


### PR DESCRIPTION
## Summary
- expand `PostForm` with community and post_type fields and help texts
- enforce required fields based on `post_type`
- update tests for new form API

## Testing
- `STATICFILES_STORAGE=django.contrib.staticfiles.storage.StaticFilesStorage python manage.py test` *(fails: The file 'css/base.css' could not be found with <whitenoise.storage.CompressedManifestStaticFilesStorage object ...)*

------
https://chatgpt.com/codex/tasks/task_e_68b4e4f9c564832c9263b94abf28a60b