### PR TITLE
Add post submission and preview

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -12,6 +12,8 @@ urlpatterns = [
     # Markdown preview endpoint
     path("preview", core_views.render_preview, name="preview"),
     path("oembed/preview/", core_views.oembed_preview, name="oembed_preview"),
+    path("submit/", core_views.submit_post, name="submit_post"),
+    path("submit/preview/", core_views.preview_post, name="preview_post"),
 
     # Post signals
     path("posts/<int:pk>/signals.json", core_views.post_signals_json, name="post_signals_json"),
@@ -35,7 +37,7 @@ urlpatterns = [
 
     # Community pages (slug-based, /r/<slug>/…)
     path("r/<slug:slug>/", core_views.community, name="community"),
-    path("r/<slug:slug>/submit/", core_views.submit_post, name="submit_post"),
+    path("r/<slug:slug>/submit/", core_views.submit_post_community, name="submit_post"),
     path("r/<slug:slug>/wiki/", core_views.community_wiki, name="community_wiki"),
 
     # Post detail (nested under community, with id + slug)

--- a/core/views.py
+++ b/core/views.py
@@ -101,6 +101,27 @@ def oembed_preview(request):
     return HttpResponse(html)
 
 
+@login_required
+@require_POST
+def preview_post(request):
+    """Validate post data and render a preview fragment."""
+    form = PostForm(request.POST, request.FILES)
+    if not form.is_valid():
+        return HttpResponseBadRequest("Invalid post data")
+    post = form.save(commit=False)
+    if post.content_url:
+        post.link_domain = urlparse(post.content_url).netloc
+        data = fetch_oembed(post.content_url)
+        post.embed_html = render_to_string("core/partials/link_preview.html", data)
+    if post.body:
+        html = markdown_renderer(post.body)
+        clean = bleach.clean(
+            html, tags=ALLOWED_TAGS, attributes=ALLOWED_ATTRIBUTES, strip=True
+        )
+        post.body = mark_safe(clean)
+    return render(request, "core/partials/post_preview.html", {"post": post})
+
+
 def mission(request):
     return render(request, "core/mission.html")
 
@@ -444,6 +465,47 @@ def home(request):
     return render(request, "core/home.html", context)
 
 
+@login_required
+@require_http_methods(["GET", "POST"])
+def submit_post(request):
+    """Submit a new post selecting a community."""
+
+    if _is_banned(request.user):
+        return HttpResponseForbidden("Account banned")
+
+    if request.method == "POST":
+        form = PostForm(request.POST, request.FILES)
+        if form.is_valid():
+            post = form.save(commit=False)
+            post.author = request.user
+            if request.POST.get("save_as_draft"):
+                post.is_draft = True
+                post.save()
+                messages.success(request, "Draft saved")
+                return redirect("submit_post")
+            if post.content_url:
+                post.link_domain = urlparse(post.content_url).netloc
+                data = fetch_oembed(post.content_url)
+                post.embed_html = render_to_string(
+                    "core/partials/link_preview.html", data
+                )
+            post.save()
+            messages.success(request, "Post submitted")
+            return redirect(
+                "post_detail",
+                community=post.community.slug,
+                pk=post.pk,
+                slug=post.slug,
+            )
+        else:
+            messages.error(request, "Please correct the errors below.")
+    else:
+        form = PostForm()
+
+    context = {"form": form}
+    return render(request, "core/post_form.html", context)
+
+
 def community(request, slug):
     """Display posts for a specific community."""
     community = get_object_or_404(Community, slug=slug)
@@ -476,7 +538,7 @@ def community(request, slug):
 
 @login_required
 @require_http_methods(["GET", "POST"])
-def submit_post(request, slug):
+def submit_post_community(request, slug):
     """Submit a new post to a community."""
 
     community = get_object_or_404(Community, slug=slug)

--- a/templates/core/partials/post_preview.html
+++ b/templates/core/partials/post_preview.html
@@ -1,0 +1,14 @@
+<article class="post-preview">
+  <h2>{{ post.title }}</h2>
+  {% if post.heading %}
+  <h3 class="post-heading">{{ post.heading }}</h3>
+  {% endif %}
+  {% if post.embed_html %}
+  <div class="post-embed">{{ post.embed_html|safe }}</div>
+  {% elif post.content_url %}
+  <div class="link-card"><a href="{{ post.content_url }}" rel="noopener nofollow">{{ post.link_domain }}</a></div>
+  {% endif %}
+  {% if post.body %}
+  <div class="post-caption prose">{{ post.body|safe }}</div>
+  {% endif %}
+</article>

--- a/templates/core/post_form.html
+++ b/templates/core/post_form.html
@@ -3,10 +3,17 @@
 
 {% block content %}
 <h1>Create Post</h1>
-<form method="post" action="{% url 'submit_post' community.slug %}" class="post-form" hx-boost="false" hx-swap="none">
+<form method="post" action="{% if community %}{% url 'submit_post' community.slug %}{% else %}{% url 'submit_post' %}{% endif %}" class="post-form" hx-boost="false" hx-swap="none">
   {% csrf_token %}
   <div class="draft-pill" hidden></div>
   {{ form.non_field_errors }}
+  {% if not community %}
+  <div class="form-row">
+    {{ form.community.label_tag }}
+    {{ form.community }}
+    {{ form.community.errors }}
+  </div>
+  {% endif %}
 
   <div class="form-row">
     {{ form.title.label_tag }}
@@ -47,7 +54,11 @@
 
   <div class="form-actions">
     <button class="button" type="submit">Submit<span class="spinner" hidden aria-hidden="true"></span></button>
+    {% if community %}
     <a href="{% url 'community' community.slug %}">cancel</a>
+    {% else %}
+    <a href="{% url 'home' %}">cancel</a>
+    {% endif %}
   </div>
 </form>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add standalone post submission view with draft support
- add preview endpoint and partial for post previews
- update URLs and post form to handle global submissions

## Testing
- `python manage.py test` *(fails: The file 'css/base.css' could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4e68fa180832cad32dae0234b162c