### PR TITLE
Add submit post script for mode toggling and preview

### DIFF
--- a/static/js/submit.js
+++ b/static/js/submit.js
@@ -1,0 +1,53 @@
+// Handles post type toggling and preview submission
+
+document.addEventListener('DOMContentLoaded', () => {
+  const form = document.querySelector('.post-form');
+  if (!form) return;
+
+  // Toggle post type modes
+  const radios = form.querySelectorAll('input[name="post_type"]');
+  const modes = {
+    text: form.querySelector('.mode-text'),
+    link: form.querySelector('.mode-link'),
+    image: form.querySelector('.mode-image'),
+  };
+  function updateMode() {
+    const val = form.querySelector('input[name="post_type"]:checked')?.value;
+    Object.entries(modes).forEach(([key, el]) => {
+      if (!el) return;
+      const active = key === val;
+      el.classList.toggle('active', active);
+      el.hidden = !active;
+    });
+  }
+  radios.forEach(r => r.addEventListener('change', updateMode));
+  updateMode();
+
+  // Preview button handler
+  const previewBtn = document.getElementById('preview-btn');
+  const previewPanel = document.getElementById('preview-panel');
+
+  function getCookie(name) {
+    let v = null;
+    if (document.cookie) {
+      document.cookie.split(';').forEach(c => {
+        c = c.trim();
+        if (c.startsWith(name + '=')) v = decodeURIComponent(c.slice(name.length + 1));
+      });
+    }
+    return v;
+  }
+
+  previewBtn?.addEventListener('click', () => {
+    const fd = new FormData(form);
+    fetch('/submit/preview/', {
+      method: 'POST',
+      headers: { 'X-CSRFToken': getCookie('csrftoken') },
+      body: fd,
+    })
+      .then(res => res.text())
+      .then(html => {
+        if (previewPanel) previewPanel.innerHTML = html;
+      });
+  });
+});

--- a/templates/core/submit_post.html
+++ b/templates/core/submit_post.html
@@ -42,7 +42,7 @@
     {{ form.post_type.errors }}
   </div>
 
-  <div class="form-row type-block" id="type-text">
+  <div class="form-row mode-text">
     {{ form.body.label_tag }}
     <div class="editor-container prose">
       {% include "core/partials/editor_toolbar.html" %}
@@ -51,13 +51,13 @@
     {{ form.body.errors }}
   </div>
 
-  <div class="form-row type-block" id="type-link">
+  <div class="form-row mode-link">
     {{ form.content_url.label_tag }}
     {{ form.content_url }}
     {{ form.content_url.errors }}
   </div>
 
-  <div class="form-row type-block" id="type-image">
+  <div class="form-row mode-image">
     {{ form.image.label_tag }}
     {{ form.image }}
     {{ form.image.errors }}
@@ -65,37 +65,18 @@
 
   <div class="form-actions">
     <button class="button" type="submit">Submit<span class="spinner" hidden aria-hidden="true"></span></button>
-    <button class="button secondary" type="button"
-            hx-post="{% url 'preview_post' %}"
-            hx-include="closest form"
-            hx-encoding="multipart/form-data"
-            hx-target="#preview-panel" hx-swap="innerHTML">Preview</button>
+    <button class="button secondary" type="button" id="preview-btn">Preview</button>
     <button class="button secondary" type="submit" name="save_as_draft" value="1">Save Draft</button>
   </div>
 </form>
 
 <div id="preview-panel"></div>
 
-<script>
-  (function() {
-    const blocks = {text: "#type-text", link: "#type-link", image: "#type-image"};
-    function show(v){
-      for (const k in blocks){
-        const el = document.querySelector(blocks[k]);
-        if (el) el.style.display = (k === v) ? "" : "none";
-      }
-    }
-    const inputs = document.querySelectorAll('input[name="{{ form.post_type.html_name }}"]');
-    inputs.forEach(inp => {
-      if (inp.checked) show(inp.value);
-      inp.addEventListener('change', e => show(e.target.value));
-    });
-  })();
-</script>
 {% endblock %}
 
 {% block scripts %}
 {{ block.super }}
 <script src="{% static 'js/editor.js' %}" defer></script>
+<script src="{% static 'js/submit.js' %}" defer></script>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- Add submit.js to handle post type switching and preview requests
- Wire up submit.js in submit_post.html

## Testing
- `python manage.py test` *(fails: The file 'css/base.css' could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4e9e26430832c8c0f9deb71ee8c24