### PR TITLE
Add submit page tests and render correct form

### DIFF
--- a/core/tests/test_submit_page.py
+++ b/core/tests/test_submit_page.py
@@ -1,0 +1,73 @@
+from django.test import TestCase
+from django.urls import reverse
+from django.contrib.auth import get_user_model
+from django.core.cache import cache
+
+from ..models import Community
+
+
+class SubmitPageTests(TestCase):
+    def setUp(self):
+        cache.clear()
+        User = get_user_model()
+        self.user = User.objects.create_user("alice", password="pwd")
+        self.community = Community.objects.create(
+            slug="t", name="Test", title="Test", created_by=self.user
+        )
+        self.client.login(username="alice", password="pwd")
+
+    def test_get_submit_page(self):
+        resp = self.client.get(reverse("submit_post"))
+        self.assertEqual(resp.status_code, 200)
+        html = resp.content.decode()
+        self.assertIn("Submit a Post", html)
+        self.assertIn('type="radio"', html)
+
+    def test_preview_post(self):
+        resp = self.client.post(
+            reverse("preview_post"),
+            {
+                "community": self.community.pk,
+                "post_type": "text",
+                "title": "Hello",
+                "body": "Body",
+            },
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn("post-preview", resp.content.decode())
+
+    def test_text_without_body_validation(self):
+        resp = self.client.post(
+            reverse("submit_post"),
+            {
+                "community": self.community.pk,
+                "post_type": "text",
+                "title": "Hello",
+            },
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn("body", resp.context["form"].errors)
+
+    def test_link_without_url_validation(self):
+        resp = self.client.post(
+            reverse("submit_post"),
+            {
+                "community": self.community.pk,
+                "post_type": "link",
+                "title": "Link",
+            },
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn("content_url", resp.context["form"].errors)
+
+    def test_image_without_file_validation(self):
+        resp = self.client.post(
+            reverse("submit_post"),
+            {
+                "community": self.community.pk,
+                "post_type": "image",
+                "title": "Pic",
+            },
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn("image", resp.context["form"].errors)

--- a/core/views.py
+++ b/core/views.py
@@ -503,7 +503,7 @@ def submit_post(request):
         form = PostForm()
 
     context = {"form": form}
-    return render(request, "core/post_form.html", context)
+    return render(request, "core/submit_post.html", context)
 
 
 def community(request, slug):
@@ -572,7 +572,7 @@ def submit_post_community(request, slug):
         form = PostForm()
 
     context = {"form": form, "community": community}
-    return render(request, "core/post_form.html", context)
+    return render(request, "core/submit_post.html", context)
 
 
 def post_detail(request, community, pk, slug):

--- a/templates/core/partials/post_row.html
+++ b/templates/core/partials/post_row.html
@@ -6,20 +6,22 @@
     <span id="post-score-{{ post.pk }}" class="score">{{ post.score }}</span>
     <button hx-post="{% url 'vote_post' post.pk %}?v=-1" hx-target="#post-score-{{ post.pk }}" hx-swap="outerHTML" aria-label="Downvote" class="down" aria-pressed="false">▼</button>
   </div>
-  {% if not post.is_deleted and (post.embed_html or post.image_thumb or post.image) %}
-  <div class="post-image">
-    {% if post.embed_html %}
-      <div class="post-embed" style="position:relative;padding-top:56.25%;overflow:hidden;">
-        <div style="position:absolute;top:0;left:0;width:100%;height:100%;">
-          {{ post.embed_html|safe }}
+  {% if not post.is_deleted %}
+    {% if post.embed_html or post.image_thumb or post.image %}
+    <div class="post-image">
+      {% if post.embed_html %}
+        <div class="post-embed" style="position:relative;padding-top:56.25%;overflow:hidden;">
+          <div style="position:absolute;top:0;left:0;width:100%;height:100%;">
+            {{ post.embed_html|safe }}
+          </div>
         </div>
-      </div>
-    {% elif post.image_thumb %}
-      <img src="{{ post.image_thumb.url }}" loading="lazy" decoding="async" referrerpolicy="no-referrer">
-    {% elif post.image %}
-      <img src="{{ post.image.url }}" loading="lazy" decoding="async" referrerpolicy="no-referrer">
+      {% elif post.image_thumb %}
+        <img src="{{ post.image_thumb.url }}" loading="lazy" decoding="async" referrerpolicy="no-referrer">
+      {% elif post.image %}
+        <img src="{{ post.image.url }}" loading="lazy" decoding="async" referrerpolicy="no-referrer">
+      {% endif %}
+    </div>
     {% endif %}
-  </div>
   {% endif %}
   <div class="post-body">
     {% if post.is_deleted %}


### PR DESCRIPTION
## Summary
- add tests covering submit form, preview endpoint, and validation cases
- render `submit_post.html` for post submissions instead of `post_form.html`
- fix post row template conditional for image/embed preview

## Testing
- `DJANGO_ALLOWED_HOSTS='*' DJANGO_TESTS=1 python manage.py test core.tests.test_submit_page`
- `DJANGO_ALLOWED_HOSTS='*' DJANGO_TESTS=1 python manage.py test core.tests.test_astro` *(fails: ModuleNotFoundError: No module named 'freezegun')*


------
https://chatgpt.com/codex/tasks/task_e_68b4ed0679a8832cab18ef0256900b63