### PR TITLE
Add core layout templates and responsive CSS utilities

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -279,3 +279,91 @@ form button:focus,
   background: #d1d5db;
   text-decoration: underline;
 }
+/* --- Layout container and spacing scale --- */
+.container {
+  max-width: 1200px;
+  margin-inline: auto;
+  padding-inline: 24px;
+}
+:root {
+  --space-1: 8px;
+  --space-2: 16px;
+  --space-3: 24px;
+}
+.m-1 { margin: var(--space-1); }
+.m-2 { margin: var(--space-2); }
+.m-3 { margin: var(--space-3); }
+.p-1 { padding: var(--space-1); }
+.p-2 { padding: var(--space-2); }
+.p-3 { padding: var(--space-3); }
+
+/* --- Text clamp utilities --- */
+.clamp-1, .clamp-2, .clamp-3 {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.clamp-1 { -webkit-line-clamp: 1; }
+.clamp-2 { -webkit-line-clamp: 2; }
+.clamp-3 { -webkit-line-clamp: 3; }
+
+/* --- Media thumbnails --- */
+.media-thumb {
+  width: 120px;
+  height: 120px;
+  object-fit: cover;
+  border-radius: 12px;
+  display: block;
+}
+
+/* --- Focus rings --- */
+a:focus-visible,
+button:focus-visible {
+  outline: 2px solid #1d4ed8;
+  outline-offset: 2px;
+}
+
+/* --- Responsive layout and controls --- */
+@media (min-width: 768px) {
+  #feed-root {
+    display: flex;
+    gap: 24px;
+  }
+  #right-gutter { width: 300px; }
+  .mobile-submit { display: none; }
+}
+@media (max-width: 767px) {
+  #feed-root { display: block; }
+  #right-gutter { display: none; }
+  .tab-chips {
+    display: flex;
+    overflow-x: auto;
+    gap: 8px;
+    -webkit-overflow-scrolling: touch;
+  }
+  .mobile-submit {
+    position: fixed;
+    bottom: 24px;
+    right: 24px;
+    display: inline-block;
+    padding: 12px 16px;
+    background: #1d4ed8;
+    color: #fff;
+    border-radius: 9999px;
+    text-decoration: none;
+  }
+}
+
+/* --- Submit Post button in sidebar --- */
+.button-primary {
+  background: #1d4ed8;
+  color: #fff;
+  text-align: center;
+  padding: 8px 16px;
+  border-radius: 4px;
+  display: inline-block;
+}
+.button-primary:focus-visible {
+  outline: 2px solid #2563eb;
+  outline-offset: 2px;
+}

--- a/templates/core/base.html
+++ b/templates/core/base.html
@@ -1,0 +1,35 @@
+{% load static %}
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{% block title %}SureJan{% endblock %}</title>
+    <link rel="stylesheet" href="{% static 'css/app.css' %}">
+    {% block head_extra %}{% endblock %}
+  </head>
+  <body>
+    {% include 'core/partials/header.html' %}
+    {% block subnav %}{% endblock %}
+    <main id="feed-root">
+      <section class="main" id="content">
+        {% block content %}{% endblock %}
+      </section>
+      <aside id="right-gutter">
+        {% block sidebar %}
+          {% include 'core/partials/sidebar_minimal.html' %}
+        {% endblock %}
+      </aside>
+    </main>
+    <footer class="site-footer">
+      <div class="container" style="text-align:center;">
+        <a href="{% url 'terms' %}" aria-label="Terms">Terms</a>
+        &middot;
+        <a href="{% url 'privacy' %}" aria-label="Privacy">Privacy</a>
+        &middot;
+        <a href="{% url 'rules' %}" aria-label="Rules">Rules</a>
+      </div>
+    </footer>
+    {% block scripts %}{% endblock %}
+  </body>
+</html>

--- a/templates/core/partials/header.html
+++ b/templates/core/partials/header.html
@@ -1,0 +1,26 @@
+{% load static %}
+<header class="site-header">
+  <div class="container header-inner">
+    <div class="hdr-left">
+      <a href="{% url 'home' %}" class="site-brand" aria-label="Home">
+        <img src="{% static 'SureJanLogo.png' %}" alt="SureJan" class="site-logo">
+      </a>
+    </div>
+    <nav class="hdr-center" aria-label="Main navigation">
+      <a href="{% url 'community' 'news' %}" aria-label="News">NEWS</a>
+      <a href="{% url 'community' 'brisbane' %}" aria-label="Brisbane">BRISBANE</a>
+      <a href="{% url 'community' 'politics' %}" aria-label="Politics">POLITICS</a>
+      <a href="{% url 'community' 'social' %}" aria-label="Social">SOCIAL</a>
+    </nav>
+    <div class="hdr-right">
+      {% if request.user.is_authenticated %}
+        <a href="{% url 'user_overview' request.user.username %}" aria-label="Account">{{ request.user.username }}</a>
+      {% else %}
+        <a href="{% url 'login' %}" aria-label="Login">Login</a>
+        <span>/</span>
+        <a href="{% url 'signup' %}" aria-label="Sign up">Sign up</a>
+      {% endif %}
+    </div>
+    <a href="{% url 'submit_post' %}" class="mobile-submit" aria-label="Submit Post">Submit Post</a>
+  </div>
+</header>

--- a/templates/core/partials/sidebar_minimal.html
+++ b/templates/core/partials/sidebar_minimal.html
@@ -1,0 +1,6 @@
+<div class="sidebar-card">
+  <a class="button button-primary w-full" href="{% url 'submit_post' %}" aria-label="Submit Post">Submit Post</a>
+</div>
+<div class="sidebar-card">
+  <a class="link-plain" href="{% url 'anti_astroturf' %}" aria-label="Anti-Astroturf">Anti-Astroturf</a>
+</div>


### PR DESCRIPTION
## Summary
- Add core base template with header, subnav block, and sidebar
- Implement header and sidebar partials with accessible links and mobile submit button
- Extend app.css with container, spacing utilities, text clamps, media thumbnail and responsive rules

## Testing
- `python -m pytest` *(fails: Requested setting INSTALLED_APPS, but settings are not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68b5077b321c832cb868449c1123066e