### PR TITLE
Expose basic routes with paginated views

### DIFF
--- a/core/tests/test_routes.py
+++ b/core/tests/test_routes.py
@@ -1,0 +1,45 @@
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+
+from core.models import Community, Post
+
+
+class RouteTests(TestCase):
+    def setUp(self):
+        user_model = get_user_model()
+        self.user = user_model.objects.create_user("tester", password="pwd")
+        self.community = Community.objects.create(
+            slug="test", name="Test", title="Test", created_by=self.user
+        )
+        self.post = Post.objects.create(
+            community=self.community,
+            author=self.user,
+            post_type="text",
+            title="Hello",
+        )
+
+    def test_home(self):
+        resp = self.client.get(reverse("home"))
+        self.assertEqual(resp.status_code, 200)
+
+    def test_community(self):
+        resp = self.client.get(reverse("community", args=[self.community.slug]))
+        self.assertEqual(resp.status_code, 200)
+
+    def test_post_detail_id(self):
+        resp = self.client.get(reverse("post_detail_id", args=[self.post.pk]))
+        self.assertEqual(resp.status_code, 200)
+
+    def test_post_submit(self):
+        self.client.login(username="tester", password="pwd")
+        resp = self.client.get(reverse("post_submit"))
+        self.assertEqual(resp.status_code, 200)
+
+    def test_mod_astro(self):
+        resp = self.client.get(reverse("mod_astro"))
+        self.assertEqual(resp.status_code, 200)
+
+    def test_methods(self):
+        resp = self.client.get(reverse("transparency_methods"))
+        self.assertEqual(resp.status_code, 200)

--- a/core/urls.py
+++ b/core/urls.py
@@ -5,10 +5,12 @@ from core import views as core_views
 urlpatterns = [
     # Home / front page
     path("", core_views.home, name="home"),
+    path("p/<int:pk>/", core_views.post_detail_id, name="post_detail_id"),
     path("feed/", core_views.feed_list, name="feed_list"),
     path("mission/", core_views.mission, name="mission"),
     path("anti-astroturf/", core_views.anti_astroturf, name="anti_astroturf"),
-    path("transparency/methods", core_views.transparency_methods, name="transparency_methods"),
+    path("mod/astro/", core_views.mod_astro, name="mod_astro"),
+    path("methods/", core_views.transparency_methods, name="transparency_methods"),
     path("transparency/posts", core_views.transparency_posts, name="transparency_posts"),
     # Markdown preview endpoint
     path("preview/", core_views.preview_markdown, name="preview_markdown"),

--- a/core/views.py
+++ b/core/views.py
@@ -124,6 +124,12 @@ def anti_astroturf(request):
     return render(request, "pages/anti_astroturf.html")
 
 
+def mod_astro(request):
+    """Moderator information about astroturf detection."""
+
+    return render(request, "core/mod_astro.html")
+
+
 def transparency_methods(request):
     if not settings.ASTROTURF_WATCH:
         raise Http404
@@ -460,12 +466,22 @@ def feed_list(request):
 
 @require_GET
 def home(request):
+    """Render the front page with optional sorting and time filters."""
+
     tab = request.GET.get("tab", "hot")
+    if tab not in TAB_ORDER:
+        tab = "hot"
+
     rng = request.GET.get("range", "24h")
-    qs = Post.objects.select_related("community", "author").order_by("-created_at")
-    # TODO: apply real tab/range logic later; this is a safe default
-    page = Paginator(qs, 25).get_page(request.GET.get("page") or 1)
-    return render(request, "core/home.html", {"page": page, "tab": tab, "range": rng})
+    if rng not in RANGE_MAP and rng != "all":
+        rng = "24h"
+
+    page_number = request.GET.get("page") or 1
+    qs = feed_queryset(tab, rng)
+    page = Paginator(qs, PAGE_SIZE).get_page(page_number)
+
+    ctx = {"page": page, "tab": tab, "range": rng}
+    return render(request, "core/home.html", ctx)
 
 
 @ratelimit(key="user", rate="5/m", method=["POST"], block=False)
@@ -523,16 +539,32 @@ def community(request, slug):
     sort = request.GET.get("sort", "best")
     if sort not in FEED_ORDER:
         sort = "best"
+
+    rng = request.GET.get("range", "24h")
+    if rng not in RANGE_MAP and rng != "all":
+        rng = "24h"
+
     order = FEED_ORDER[sort]
     page = int(request.GET.get("page", "1") or 1)
 
     qs = community.posts.select_related("author").order_by(*order)
+    if rng != "all":
+        delta = RANGE_MAP.get(rng)
+        if delta:
+            since = timezone.now() - delta
+            qs = qs.filter(created_at__gte=since)
+
     offset = (page - 1) * PAGE_SIZE
     posts = list(qs[offset : offset + PAGE_SIZE + 1])
     next_page = page + 1 if len(posts) > PAGE_SIZE else None
     posts = posts[:PAGE_SIZE]
 
-    sort_query = f"&sort={sort}" if sort and sort != "best" else ""
+    sort_query = ""
+    if sort and sort != "best":
+        sort_query += f"&sort={sort}"
+    if rng and rng != "24h":
+        sort_query += f"&range={rng}"
+
     context = {
         "community": community,
         "community_slug": community.slug,
@@ -540,6 +572,7 @@ def community(request, slug):
         "next_page": next_page,
         "sort_query": sort_query,
         "sort": sort,
+        "range": rng,
         "sort_tabs": SORT_TABS,
     }
     if request.headers.get("HX-Request") == "true":
@@ -553,6 +586,16 @@ def post_detail(request, community, pk, slug):
     """Display a single post and its comments."""
 
     post = get_object_or_404(Post, pk=pk, community__slug=community)
+    comments = post.comments.select_related("author").order_by("path")
+    form = CommentForm()
+    context = {"post": post, "comments": comments, "form": form}
+    return render(request, "core/post_detail.html", context)
+
+
+def post_detail_id(request, pk):
+    """Simpler post detail view addressed by ID only."""
+
+    post = get_object_or_404(Post, pk=pk)
     comments = post.comments.select_related("author").order_by("path")
     form = CommentForm()
     context = {"post": post, "comments": comments, "form": form}

--- a/templates/core/mod_astro.html
+++ b/templates/core/mod_astro.html
@@ -1,0 +1,7 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="page container">
+  <h1>Moderator Astro Tools</h1>
+  <p>Guidelines for identifying and handling astroturfing campaigns.</p>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Add direct `/p/<id>`, `/mod/astro`, and `/methods` routes
- Support sorting and time-range filtering on home and community views
- Include moderator astro guidance template and route tests

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68b52777ba98832cb1412d45809990d7