### PR TITLE
Add safe media embeds and image slideshow to post detail

### DIFF
--- a/core/oembed.py
+++ b/core/oembed.py
@@ -40,6 +40,7 @@ def fetch_oembed(url: str) -> dict:
             resp.raise_for_status()
             data = resp.json()
             html = data.get("html", "")
+            thumb = data.get("thumbnail_url")
             clean = bleach.clean(
                 html,
                 tags=[
@@ -68,7 +69,7 @@ def fetch_oembed(url: str) -> dict:
                 },
                 strip=True,
             )
-            return {"type": "embed", "html": clean}
+            return {"type": "embed", "html": clean, "thumbnail_url": thumb}
         except Exception:
             pass
 

--- a/core/tests/test_post_detail_media.py
+++ b/core/tests/test_post_detail_media.py
@@ -1,0 +1,71 @@
+from unittest.mock import patch
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+
+from core.models import Community, Post, PostImageLink
+
+
+class PostDetailMediaTests(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.user = User.objects.create_user("author", password="pw")
+        self.community = Community.objects.create(
+            slug="test", name="Test", title="Test", created_by=self.user
+        )
+
+    @patch("core.views.fetch_oembed")
+    def test_youtube_embed_has_placeholder(self, mock_oembed):
+        mock_oembed.return_value = {
+            "type": "embed",
+            "html": '<iframe src="https://www.youtube.com/embed/abc"></iframe>',
+            "thumbnail_url": "http://img.youtube.com/vi/abc/hqdefault.jpg",
+        }
+        post = Post.objects.create(
+            community=self.community,
+            author=self.user,
+            post_type="link",
+            title="Video",
+            content_url="https://www.youtube.com/watch?v=abc",
+        )
+        resp = self.client.get(
+            reverse("post_detail", args=[self.community.slug, post.pk, post.slug])
+        )
+        self.assertContains(resp, 'data-src="https://www.youtube-nocookie.com/embed/abc"')
+        self.assertContains(resp, 'href="https://www.youtube.com/watch?v=abc"')
+
+    @patch("core.views.fetch_oembed")
+    def test_rumble_embed_has_placeholder(self, mock_oembed):
+        mock_oembed.return_value = {
+            "type": "embed",
+            "html": '<iframe src="https://rumble.com/embed/vxyz/?pub=4"></iframe>',
+            "thumbnail_url": "http://thumb.jpg",
+        }
+        post = Post.objects.create(
+            community=self.community,
+            author=self.user,
+            post_type="link",
+            title="Rumble",
+            content_url="https://rumble.com/vxyz-test.html",
+        )
+        resp = self.client.get(
+            reverse("post_detail", args=[self.community.slug, post.pk, post.slug])
+        )
+        self.assertContains(resp, 'data-src="https://rumble.com/embed/vxyz/?pub=4"')
+        self.assertContains(resp, 'href="https://rumble.com/vxyz-test.html"')
+
+    def test_image_slideshow_renders(self):
+        post = Post.objects.create(
+            community=self.community,
+            author=self.user,
+            post_type="text",
+            title="Images",
+        )
+        for i in range(3):
+            PostImageLink.objects.create(post=post, url=f"http://example.com/{i}.jpg")
+        resp = self.client.get(
+            reverse("post_detail", args=[self.community.slug, post.pk, post.slug])
+        )
+        self.assertContains(resp, 'class="post-images"')
+        self.assertContains(resp, 'href="#img1"')

--- a/core/views.py
+++ b/core/views.py
@@ -193,6 +193,55 @@ def _cached_post_signals(pk):
     return data
 
 
+def _build_embed(url):
+    """Return embed metadata for known providers.
+
+    Generates a click-to-play "safe" embed using a sandboxed iframe for
+    YouTube and Rumble URLs.  Returns ``None`` if the URL is unsupported or
+    if fetching oEmbed data fails.
+    """
+
+    if not url:
+        return None
+    parsed = urlparse(url)
+    domain = parsed.netloc.lower()
+    try:
+        data = fetch_oembed(url)
+    except Exception:
+        return None
+    if data.get("type") != "embed":
+        return None
+    thumb = data.get("thumbnail_url")
+
+    if "youtube" in domain:
+        vid = None
+        # Try to extract the 11-char video id from various URL formats
+        for pattern in [r"v=([\w-]{11})", r"be/([\w-]{11})", r"embed/([\w-]{11})"]:
+            m = re.search(pattern, url)
+            if m:
+                vid = m.group(1)
+                break
+        if not vid:
+            m = re.search(r"embed/([\w-]{11})", data.get("html", ""))
+            if m:
+                vid = m.group(1)
+        if not vid:
+            return None
+        if not thumb:
+            thumb = f"https://i.ytimg.com/vi/{vid}/hqdefault.jpg"
+        src = f"https://www.youtube-nocookie.com/embed/{vid}"
+        return {"src": src, "thumb": thumb, "url": url}
+
+    if "rumble.com" in domain:
+        m = re.search(r'src="([^"]+)"', data.get("html", ""))
+        if not m:
+            return None
+        src = m.group(1)
+        return {"src": src, "thumb": thumb, "url": url}
+
+    return None
+
+
 @require_GET
 def post_signals_json(request, pk):
     if not settings.ASTROTURF_WATCH:
@@ -585,20 +634,38 @@ def community(request, slug):
 def post_detail(request, community, pk, slug):
     """Display a single post and its comments."""
 
-    post = get_object_or_404(Post, pk=pk, community__slug=community)
+    post = get_object_or_404(
+        Post.objects.prefetch_related("image_links"), pk=pk, community__slug=community
+    )
     comments = post.comments.select_related("author").order_by("path")
     form = CommentForm()
-    context = {"post": post, "comments": comments, "form": form}
+    embed = _build_embed(post.content_url)
+    images = list(post.image_links.all())
+    context = {
+        "post": post,
+        "comments": comments,
+        "form": form,
+        "embed": embed,
+        "images": images,
+    }
     return render(request, "core/post_detail.html", context)
 
 
 def post_detail_id(request, pk):
     """Simpler post detail view addressed by ID only."""
 
-    post = get_object_or_404(Post, pk=pk)
+    post = get_object_or_404(Post.objects.prefetch_related("image_links"), pk=pk)
     comments = post.comments.select_related("author").order_by("path")
     form = CommentForm()
-    context = {"post": post, "comments": comments, "form": form}
+    embed = _build_embed(post.content_url)
+    images = list(post.image_links.all())
+    context = {
+        "post": post,
+        "comments": comments,
+        "form": form,
+        "embed": embed,
+        "images": images,
+    }
     return render(request, "core/post_detail.html", context)
 
 

--- a/templates/core/post_detail.html
+++ b/templates/core/post_detail.html
@@ -37,14 +37,18 @@
           {% if post.heading %}
             <h2 class="post-heading">{{ post.heading }}</h2>
           {% endif %}
-          {% if post.embed_html %}
-            <div class="post-embed" style="position:relative;padding-top:56.25%;overflow:hidden;">
-              <div style="position:absolute;top:0;left:0;width:100%;height:100%;">
-                {{ post.embed_html|safe }}
-              </div>
+          {% if embed %}
+            <div class="post-embed" data-src="{{ embed.src }}" style="position:relative;padding-top:56.25%;overflow:hidden;">
+              <a href="{{ embed.url }}" rel="noopener nofollow" style="position:absolute;top:0;left:0;width:100%;height:100%;display:block;">
+                <img src="{{ embed.thumb }}" alt="" loading="lazy" decoding="async" referrerpolicy="no-referrer" style="width:100%;height:100%;object-fit:cover;">
+              </a>
             </div>
           {% elif post.image %}
             <img src="{{ post.image.url }}" alt="" class="post-image" loading="lazy" decoding="async" referrerpolicy="no-referrer">
+          {% elif images %}
+            {% include "partials/post_images.html" with images=images %}
+          {% elif post.embed_html %}
+            <div class="post-embed">{{ post.embed_html|safe }}</div>
           {% elif post.content_url %}
             <div class="link-card">
               <a href="{{ post.content_url }}" rel="noopener nofollow">{{ post.link_domain }}</a>
@@ -101,5 +105,27 @@
 {{ block.super }}
 <script src="{% static 'js/editor.js' %}" defer></script>
 <script src="{% static 'js/comments.js' %}" defer></script>
+<script>
+document.querySelectorAll('.post-embed[data-src]').forEach(function(wrapper){
+  var link = wrapper.querySelector('a');
+  var src = wrapper.dataset.src;
+  if(!link) return;
+  link.addEventListener('click', function(e){
+    e.preventDefault();
+    var iframe=document.createElement('iframe');
+    iframe.src=src;
+    iframe.setAttribute('sandbox','allow-scripts allow-same-origin');
+    iframe.setAttribute('allowfullscreen','');
+    iframe.setAttribute('loading','lazy');
+    iframe.style.position='absolute';
+    iframe.style.top='0';
+    iframe.style.left='0';
+    iframe.style.width='100%';
+    iframe.style.height='100%';
+    wrapper.innerHTML='';
+    wrapper.appendChild(iframe);
+  });
+});
+</script>
 {% endblock %}
 

--- a/templates/partials/post_images.html
+++ b/templates/partials/post_images.html
@@ -1,0 +1,23 @@
+{% if images %}
+<div class="post-images">
+  {% for img in images|slice:":5" %}
+  <figure id="img{{ forloop.counter }}" class="post-image{% if forloop.first %} active{% endif %}">
+    <img src="{{ img.url }}" alt="" loading="lazy" decoding="async" referrerpolicy="no-referrer">
+  </figure>
+  {% endfor %}
+  {% if images|length > 1 %}
+  <nav class="post-image-nav">
+    {% for img in images|slice:":5" %}
+    <a href="#img{{ forloop.counter }}">{{ forloop.counter }}</a>
+    {% endfor %}
+  </nav>
+  {% endif %}
+</div>
+<style>
+.post-images .post-image{display:none;}
+.post-images .post-image.active,
+.post-images .post-image:target{display:block;}
+.post-image-nav{margin-top:.5rem;text-align:center;}
+.post-image-nav a{margin:0 .25rem;text-decoration:none;}
+</style>
+{% endif %}


### PR DESCRIPTION
## Summary
- render click-to-play, sandboxed embeds for YouTube and Rumble
- support up to five external images with a CSS slideshow
- include new media widgets in post detail view and template

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68b52bcaef90832c825c471392c30595