### PR TITLE
Add post media URL support, live preview, and rate limiting

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -19,6 +19,12 @@ class PostForm(forms.Form):
         widget=forms.Textarea(attrs={"data-editor": "1"}), required=False
     )
     link = forms.URLField(required=False)
+    image_urls = forms.CharField(
+        required=False,
+        widget=forms.Textarea(
+            attrs={"placeholder": "One image URL per line", "rows": 3}
+        ),
+    )
 
     def clean_media(self):
         media = self.cleaned_data.get("media")
@@ -35,19 +41,43 @@ class PostForm(forms.Form):
         body = (cleaned.get("body") or "").strip()
         caption = (cleaned.get("caption") or "").strip()
         link = (cleaned.get("link") or "").strip()
+        image_urls_raw = (cleaned.get("image_urls") or "").strip()
         heading = (cleaned.get("heading") or "").strip()
         media = cleaned.get("media")
 
-        cleaned.update({"title": title, "body": body, "caption": caption, "link": link, "heading": heading})
+        # Normalize and validate image URLs
+        urls = [u.strip() for u in image_urls_raw.splitlines() if u.strip()]
+        if len(urls) > 5:
+            self.add_error("image_urls", "A maximum of five image URLs is allowed.")
+        for u in urls:
+            if not check_url_safety(u):
+                self.add_error("image_urls", "One or more image URLs are flagged as unsafe.")
+                break
+
+        cleaned.update(
+            {
+                "title": title,
+                "body": body,
+                "caption": caption,
+                "link": link,
+                "heading": heading,
+                "image_urls": urls,
+            }
+        )
 
         if not title:
             self.add_error("title", "Title is required.")
 
-        if not body and not media:
+        has_media = bool(media or link or urls)
+        if not body and not has_media:
             raise forms.ValidationError("Provide body text or media.")
 
-        if caption and not media:
+        if caption and not (media or urls):
             self.add_error("caption", "Caption requires media.")
+
+        if link and urls:
+            self.add_error("link", "Choose a link or image URLs, not both.")
+            self.add_error("image_urls", "Choose a link or image URLs, not both.")
 
         if link and not check_url_safety(link):
             self.add_error("link", "URL flagged as unsafe.")

--- a/core/rate_limit.py
+++ b/core/rate_limit.py
@@ -1,0 +1,47 @@
+"""Per-user action rate limiting utilities."""
+
+from datetime import timedelta
+
+from django.utils import timezone
+
+from .models import RateLimitCounter, get_points
+
+
+def _is_new_user(user):
+    return (timezone.now() - user.date_joined) < timedelta(hours=24) or get_points(user) == 0
+
+
+def check_rate_limit(user, action: str, limit, window: int = 60):
+    """Return (limited, retry_after) for ``action`` within ``window`` seconds.
+
+    ``limit`` may be an ``int`` or ``(new_limit, old_limit)`` tuple where the
+    first value applies to new users and the second to established users.
+    ``retry_after`` is the remaining number of seconds until the window resets
+    when ``limited`` is True.
+    """
+
+    if not user.is_authenticated:
+        return False, 0
+
+    limit_value = limit
+    if isinstance(limit, tuple):
+        new_limit, old_limit = limit
+        limit_value = new_limit if _is_new_user(user) else old_limit
+
+    now = timezone.now()
+    counter, _ = RateLimitCounter.objects.get_or_create(
+        user=user, action=action, defaults={"period_start": now}
+    )
+    elapsed = (now - counter.period_start).total_seconds()
+    if elapsed >= window:
+        counter.count = 0
+        counter.period_start = now
+        elapsed = 0
+
+    if counter.count >= limit_value:
+        retry_after = max(int(window - elapsed), 0)
+        return True, retry_after
+
+    counter.count += 1
+    counter.save(update_fields=["count", "period_start"])
+    return False, 0

--- a/core/tests_post_form_validation.py
+++ b/core/tests_post_form_validation.py
@@ -47,3 +47,36 @@ class PostFormValidationTests(TestCase):
             files={"media": image},
         )
         self.assertTrue(form.is_valid())
+
+    def test_link_only_allowed(self):
+        form = PostForm(
+            data={
+                "community": self.community.id,
+                "title": "T",
+                "link": "http://example.com",
+            }
+        )
+        self.assertTrue(form.is_valid())
+
+    def test_image_urls_allowed(self):
+        urls = "\n".join(f"http://ex.com/{i}.jpg" for i in range(3))
+        form = PostForm(
+            data={
+                "community": self.community.id,
+                "title": "T",
+                "image_urls": urls,
+                "caption": "C",
+            }
+        )
+        self.assertTrue(form.is_valid())
+
+    def test_image_urls_limit(self):
+        urls = "\n".join(f"http://ex.com/{i}.jpg" for i in range(6))
+        form = PostForm(
+            data={
+                "community": self.community.id,
+                "title": "T",
+                "image_urls": urls,
+            }
+        )
+        self.assertFalse(form.is_valid())

--- a/core/views.py
+++ b/core/views.py
@@ -43,12 +43,13 @@ from django.urls import reverse
 from urllib.parse import urlparse
 
 from .forms import CommentForm, PostForm, CommunityCreateForm
-from .models import Comment, Community, Post, RecoveryCode, Report
+from .models import Comment, Community, Post, PostImageLink, RecoveryCode, Report
 from .votes import apply_vote
 from .pagination import PAGE_SIZE
 from .services.astro import compute_post_signals, compute_user_post_summary
 from .services.feed import TAB_ORDER, RANGE_MAP, feed_queryset
 from .oembed import fetch_oembed
+from .rate_limit import check_rate_limit
 
 
 def _is_banned(user):
@@ -548,17 +549,35 @@ def post_submit(request):
 
     initial = request.session.pop("post_data", None)
     if request.method == "POST":
+        limited, retry_after = check_rate_limit(request.user, "post", limit=(3, 10), window=60)
         form = PostForm(request.POST, request.FILES)
+        if limited:
+            form.add_error(None, "You're posting too fast. Please wait before trying again.")
+            resp = render(request, "core/post_submit.html", {"form": form}, status=429)
+            resp.headers["Retry-After"] = str(retry_after)
+            return resp
         if form.is_valid():
+            link = form.cleaned_data.get("link", "")
+            image_urls = form.cleaned_data.get("image_urls", [])
+            media = form.cleaned_data.get("media")
+            body = form.cleaned_data.get("body") or form.cleaned_data.get("caption", "")
+
+            if link:
+                post_type = "link"
+            elif media or image_urls:
+                post_type = "image"
+            else:
+                post_type = "text"
+
             post = Post(
                 community=form.cleaned_data["community"],
                 author=request.user,
+                post_type=post_type,
                 title=form.cleaned_data["title"],
                 heading=form.cleaned_data.get("heading", ""),
-                body=form.cleaned_data.get("body", ""),
-                content_url=form.cleaned_data.get("link", ""),
+                body=body,
+                content_url=link,
             )
-            media = form.cleaned_data.get("media")
             if media:
                 post.image = media
             if request.POST.get("save_draft"):
@@ -567,6 +586,8 @@ def post_submit(request):
                 messages.success(request, "Draft saved")
                 return redirect("post_submit")
             post.save()
+            for url in image_urls:
+                PostImageLink.objects.create(post=post, url=url)
             messages.success(request, "Post submitted")
             return redirect(
                 "post_detail",

--- a/templates/core/post_submit.html
+++ b/templates/core/post_submit.html
@@ -10,12 +10,15 @@
     <div id="form-errors" aria-live="assertive">{{ form.non_field_errors }}</div>
     <div class="form-row">
       {{ form.community.label_tag }} {{ form.community }}
+      {{ form.community.errors }}
     </div>
     <div class="form-row">
       {{ form.title.label_tag }} {{ form.title }}
+      {{ form.title.errors }}
     </div>
     <div class="form-row">
       {{ form.heading.label_tag }} {{ form.heading }}
+      {{ form.heading.errors }}
     </div>
     <div class="form-row">
       {{ form.body.label_tag }}
@@ -23,9 +26,11 @@
         {% include "core/partials/editor_toolbar.html" %}
         {{ form.body }}
       </div>
+      {{ form.body.errors }}
     </div>
     <div class="form-row">
       {{ form.media.label_tag }} {{ form.media }}
+      {{ form.media.errors }}
     </div>
     <div class="form-row">
       {{ form.caption.label_tag }}
@@ -33,11 +38,18 @@
         {% include "core/partials/editor_toolbar.html" %}
         {{ form.caption }}
       </div>
+      {{ form.caption.errors }}
     </div>
     <div class="form-row">
       {{ form.link.label_tag }} {{ form.link }}
+      {{ form.link.errors }}
+    </div>
+    <div class="form-row">
+      {{ form.image_urls.label_tag }} {{ form.image_urls }}
+      {{ form.image_urls.errors }}
     </div>
     <div class="form-actions desktop-actions">
+      <label><input type="checkbox" id="live-preview-toggle"> Live preview</label>
       <button type="button" class="button secondary" id="preview-btn" aria-label="Preview post"
               hx-post="{% url 'preview_markdown' %}"
               hx-include="[name='body'], [name='caption']"
@@ -52,6 +64,7 @@
 </div>
 
 <div class="sticky-bar mobile-actions">
+  <label><input type="checkbox" id="live-preview-toggle-mobile"> Live preview</label>
   <button type="button" class="button secondary" hx-post="{% url 'preview_markdown' %}"
           hx-include="[name='body'], [name='caption']" hx-target="#preview" hx-swap="innerHTML" aria-label="Preview post">Preview</button>
   <button type="submit" form="post-form" class="button primary" id="post-btn-mobile" disabled aria-label="Submit post">Post</button>
@@ -66,10 +79,36 @@ function validatePost(){
   const title=document.getElementById('id_title').value.trim();
   const body=document.getElementById('id_body').value.trim();
   const media=document.getElementById('id_media').value;
+  const link=document.getElementById('id_link').value.trim();
+  const images=document.getElementById('id_image_urls').value.trim();
   const buttons=document.querySelectorAll('#post-btn,#post-btn-mobile');
-  const valid=title && (body || media);
+  const valid=title && (body || media || link || images);
   buttons.forEach(btn=>btn.disabled=!valid);
 }
 document.addEventListener('input', validatePost);
+
+const liveToggle=document.getElementById('live-preview-toggle');
+const liveToggleMobile=document.getElementById('live-preview-toggle-mobile');
+const previewUrl="{% url 'preview_markdown' %}";
+function updateLivePreview(){
+  const enabled=liveToggle.checked || liveToggleMobile.checked;
+  const fields=[document.getElementById('id_body'), document.getElementById('id_caption')];
+  fields.forEach(f=>{
+    if(enabled){
+      f.setAttribute('hx-post', previewUrl);
+      f.setAttribute('hx-trigger', 'input delay:500ms');
+      f.setAttribute('hx-target', '#preview');
+      f.setAttribute('hx-swap', 'innerHTML');
+    }else{
+      f.removeAttribute('hx-post');
+      f.removeAttribute('hx-trigger');
+      f.removeAttribute('hx-target');
+      f.removeAttribute('hx-swap');
+    }
+  });
+}
+liveToggle.addEventListener('change', updateLivePreview);
+liveToggleMobile.addEventListener('change', updateLivePreview);
+updateLivePreview();
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- allow posts to include a link or up to five image URLs and require title plus body or media
- add live markdown preview toggle on the post submission page with field-level errors
- enforce server-side post submission rate limits for new and established users

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68b52d5a9178832c91507eca19c51ec3