### PR TITLE
Add moderation controls and astro monitoring page

### DIFF
--- a/core/migrations/0022_post_moderation_fields.py
+++ b/core/migrations/0022_post_moderation_fields.py
@@ -1,0 +1,31 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("core", "0021_astroscore_score_and_summaries"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="post",
+            name="is_locked",
+            field=models.BooleanField(default=False),
+        ),
+        migrations.AddField(
+            model_name="post",
+            name="slowmode",
+            field=models.PositiveIntegerField(default=0),
+        ),
+        migrations.AddField(
+            model_name="post",
+            name="domain_weight",
+            field=models.FloatField(default=1.0),
+        ),
+        migrations.AddField(
+            model_name="report",
+            name="is_note",
+            field=models.BooleanField(default=False, db_index=True),
+        ),
+    ]

--- a/core/models.py
+++ b/core/models.py
@@ -139,6 +139,9 @@ class Post(models.Model):
         on_delete=models.SET_NULL,
         related_name="+",
     )
+    is_locked = models.BooleanField(default=False)
+    slowmode = models.PositiveIntegerField(default=0)
+    domain_weight = models.FloatField(default=1.0)
     created_at = models.DateTimeField(auto_now_add=True)
 
     @property
@@ -320,6 +323,7 @@ class Report(models.Model):
     object_id = models.PositiveIntegerField()
     target = GenericForeignKey("content_type", "object_id")
     reason = models.TextField()
+    is_note = models.BooleanField(default=False, db_index=True)
     created_at = models.DateTimeField(auto_now_add=True)
 
     class Meta:

--- a/core/urls.py
+++ b/core/urls.py
@@ -66,6 +66,14 @@ urlpatterns = [
         name="post_delete_owner",
     ),
     path("post/<int:pk>/delete/", core_views.post_delete, name="post_delete"),
+    path("post/<int:pk>/remove/", core_views.post_remove, name="post_remove"),
+    path("post/<int:pk>/lock/", core_views.post_lock, name="post_lock"),
+    path("post/<int:pk>/slowmode/", core_views.post_slowmode, name="post_slowmode"),
+    path(
+        "post/<int:pk>/domain-throttle/",
+        core_views.post_domain_throttle,
+        name="post_domain_throttle",
+    ),
     path("report/", core_views.report, name="report"),
     path("reports/", core_views.report_list, name="report_list"),
 

--- a/core/views.py
+++ b/core/views.py
@@ -125,10 +125,17 @@ def anti_astroturf(request):
     return render(request, "pages/anti_astroturf.html")
 
 
+@staff_member_required
 def mod_astro(request):
-    """Moderator information about astroturf detection."""
-
-    return render(request, "core/mod_astro.html")
+    """List posts with high astroturf scores for moderators."""
+    posts = (
+        Post.objects.filter(
+            astro_score__score__gte=settings.ASTRO_BAND_RED, is_deleted=False
+        )
+        .select_related("community", "author", "astro_score")
+        .order_by("-astro_score__score")
+    )
+    return render(request, "core/mod_astro.html", {"posts": posts})
 
 
 def transparency_methods(request):
@@ -740,6 +747,12 @@ def comment_reply(request, post_id):
     if _is_banned(request.user):
         return HttpResponseForbidden("Account banned")
     post = get_object_or_404(Post, pk=post_id)
+    if post.is_locked:
+        return HttpResponseForbidden("Comments locked")
+    if post.slowmode:
+        rate = f"1/{post.slowmode}s"
+        if limit_or_429(request, f"slow_{post.pk}", rate):
+            return render(request, "429.html", status=429)
     if getattr(post, 'astro_score', None) and post.astro_score.score >= settings.ASTRO_SLOWMODE_THRESHOLD:
         if limit_or_429(request, f'astro_slow_{post.pk}', settings.ASTRO_SLOWMODE_RATE):
             return render(request, '429.html', status=429)
@@ -840,6 +853,8 @@ def comment_new(request):
     if not post_id:
         return HttpResponseBadRequest("Missing post")
     post = get_object_or_404(Post, pk=post_id)
+    if post.is_locked:
+        return HttpResponseForbidden("Comments locked")
     parent = None
     if parent_id:
         parent = get_object_or_404(Comment, pk=parent_id, post=post)
@@ -863,6 +878,12 @@ def comment_create(request):
     if not post_id:
         return HttpResponseBadRequest("Missing post")
     post = get_object_or_404(Post, pk=post_id)
+    if post.is_locked:
+        return HttpResponseForbidden("Comments locked")
+    if post.slowmode:
+        rate = f"1/{post.slowmode}s"
+        if limit_or_429(request, f"slow_{post.pk}", rate):
+            return render(request, "429.html", status=429)
     if getattr(post, 'astro_score', None) and post.astro_score.score >= settings.ASTRO_SLOWMODE_THRESHOLD:
         if limit_or_429(request, f'astro_slow_{post.pk}', settings.ASTRO_SLOWMODE_RATE):
             return render(request, '429.html', status=429)
@@ -927,6 +948,8 @@ def comment_reply_form(request, post_id):
         return HttpResponseBadRequest("Invalid request")
 
     post = get_object_or_404(Post, pk=post_id)
+    if post.is_locked:
+        return HttpResponseForbidden("Comments locked")
     parent_id = request.GET.get("parent_id")
     if not parent_id:
         return HttpResponseBadRequest("Missing parent_id")
@@ -1042,6 +1065,78 @@ def post_delete(request, pk):
 @login_required
 @require_POST
 @csrf_protect
+def post_remove(request, pk):
+    """Soft delete a post (moderator remove)."""
+    if not request.user.is_staff:
+        return HttpResponseForbidden("Forbidden")
+    post = get_object_or_404(Post, pk=pk)
+    post.soft_delete(request.user)
+    if request.headers.get("HX-Request") == "true":
+        html = render_to_string("core/partials/post_deleted_stub.html", {"post": post})
+        return HttpResponse(html)
+    return redirect(
+        "post_detail",
+        community=post.community.slug,
+        pk=post.id,
+        slug=post.slug,
+    )
+
+
+@login_required
+@require_POST
+@csrf_protect
+def post_lock(request, pk):
+    """Lock or unlock a post's comments."""
+    if not request.user.is_staff:
+        return HttpResponseForbidden("Forbidden")
+    post = get_object_or_404(Post, pk=pk)
+    state = request.POST.get("state")
+    post.is_locked = state == "1"
+    post.save(update_fields=["is_locked"])
+    html = render_to_string("core/partials/mod_controls.html", {"post": post}, request=request)
+    return HttpResponse(html)
+
+
+@login_required
+@require_POST
+@csrf_protect
+def post_slowmode(request, pk):
+    """Adjust per-post slowmode comment rate."""
+    if not request.user.is_staff:
+        return HttpResponseForbidden("Forbidden")
+    post = get_object_or_404(Post, pk=pk)
+    try:
+        seconds = int(request.POST.get("seconds", 0))
+    except (TypeError, ValueError):
+        return HttpResponseBadRequest("Invalid value")
+    if seconds not in {0, 30, 60, 120}:
+        return HttpResponseBadRequest("Invalid value")
+    post.slowmode = seconds
+    post.save(update_fields=["slowmode"])
+    html = render_to_string("core/partials/mod_controls.html", {"post": post}, request=request)
+    return HttpResponse(html)
+
+
+@login_required
+@require_POST
+@csrf_protect
+def post_domain_throttle(request, pk):
+    """Toggle domain throttling (-50% weight) for a post."""
+    if not request.user.is_staff:
+        return HttpResponseForbidden("Forbidden")
+    post = get_object_or_404(Post, pk=pk)
+    state = request.POST.get("state")
+    if state not in {"0", "1"}:
+        return HttpResponseBadRequest("Invalid value")
+    post.domain_weight = 0.5 if state == "1" else 1.0
+    post.save(update_fields=["domain_weight"])
+    html = render_to_string("core/partials/mod_controls.html", {"post": post}, request=request)
+    return HttpResponse(html)
+
+
+@login_required
+@require_POST
+@csrf_protect
 def comment_delete(request, pk):
     """Delete a comment if the requester is the author or staff."""
     if _is_banned(request.user):
@@ -1148,9 +1243,15 @@ def report(request):
     if request.method == "POST":
         target_type = request.POST.get("target_type")
         object_id = request.POST.get("object_id")
+        mode = request.POST.get("mode")
     else:
         target_type = request.GET.get("target_type")
         object_id = request.GET.get("object_id")
+        mode = request.GET.get("mode")
+
+    is_note = mode == "note"
+    if is_note and not request.user.is_staff:
+        return HttpResponseForbidden("Forbidden")
 
     if target_type not in {"post", "comment"}:
         return HttpResponseBadRequest("Invalid target")
@@ -1170,13 +1271,14 @@ def report(request):
             content_type=ContentType.objects.get_for_model(target),
             object_id=target.pk,
             reason=reason,
+            is_note=is_note,
         )
-        return render(request, "core/report_form.html", {"thanks": True})
+        return render(request, "core/report_form.html", {"thanks": True, "mode": mode})
 
     return render(
         request,
         "core/report_form.html",
-        {"target": target, "target_type": target_type, "object_id": object_id},
+        {"target": target, "target_type": target_type, "object_id": object_id, "mode": mode},
     )
 
 

--- a/templates/core/mod_astro.html
+++ b/templates/core/mod_astro.html
@@ -1,7 +1,13 @@
 {% extends "base.html" %}
 {% block content %}
 <div class="page container">
-  <h1>Moderator Astro Tools</h1>
-  <p>Guidelines for identifying and handling astroturfing campaigns.</p>
+  <h1>Astro Alerts</h1>
+  <ul>
+    {% for p in posts %}
+    <li><a href="{% url 'post_detail' p.community.slug p.pk p.slug %}">{{ p.title }}</a> ({{ p.astro_score.score }})</li>
+    {% empty %}
+    <li>No flagged posts.</li>
+    {% endfor %}
+  </ul>
 </div>
 {% endblock %}

--- a/templates/core/partials/mod_controls.html
+++ b/templates/core/partials/mod_controls.html
@@ -1,0 +1,30 @@
+{% if request.user.is_staff %}
+<div class="mod-controls" hx-target="this" hx-swap="outerHTML">
+  {% if not post.is_deleted %}
+  <form method="post" hx-post="{% url 'post_remove' post.pk %}" hx-confirm="Remove post?" hx-target="closest article" hx-swap="outerHTML">
+    {% csrf_token %}
+    <button type="submit">remove</button>
+  </form>
+  {% endif %}
+  <form method="post" hx-post="{% url 'post_lock' post.pk %}" hx-target="this" hx-swap="outerHTML">
+    {% csrf_token %}
+    <input type="hidden" name="state" value="{% if post.is_locked %}0{% else %}1{% endif %}">
+    <button type="submit">{% if post.is_locked %}unlock{% else %}lock{% endif %}</button>
+  </form>
+  <form method="post" hx-post="{% url 'post_slowmode' post.pk %}" hx-target="this" hx-swap="outerHTML">
+    {% csrf_token %}
+    <select name="seconds" onchange="this.form.submit()">
+      <option value="0" {% if post.slowmode == 0 %}selected{% endif %}>no slow</option>
+      <option value="30" {% if post.slowmode == 30 %}selected{% endif %}>30s</option>
+      <option value="60" {% if post.slowmode == 60 %}selected{% endif %}>60s</option>
+      <option value="120" {% if post.slowmode == 120 %}selected{% endif %}>120s</option>
+    </select>
+  </form>
+  <form method="post" hx-post="{% url 'post_domain_throttle' post.pk %}" hx-target="this" hx-swap="outerHTML">
+    {% csrf_token %}
+    <input type="hidden" name="state" value="{% if post.domain_weight < 1 %}0{% else %}1{% endif %}">
+    <button type="submit">{% if post.domain_weight < 1 %}unthrottle domain{% else %}throttle domain{% endif %}</button>
+  </form>
+  <a href="{% url 'report' %}?target_type=post&object_id={{ post.pk }}&mode=note">mod note</a>
+</div>
+{% endif %}

--- a/templates/core/partials/post_row.html
+++ b/templates/core/partials/post_row.html
@@ -34,5 +34,6 @@
       <li><a href="#">save</a></li>
     </ul>
     <a href="{% url 'post_detail' post.community.slug post.pk post.slug %}" class="read-more">Read more</a>
+    {% include "core/partials/mod_controls.html" with post=post %}
   </div>
 </article>

--- a/templates/core/post_detail.html
+++ b/templates/core/post_detail.html
@@ -83,6 +83,7 @@
         <a href="{% url 'report' %}?target_type=post&object_id={{ post.pk }}">[report]</a>
         {% endif %}
       </nav>
+      {% include "core/partials/mod_controls.html" with post=post %}
     </div>
   </article>
 </div>

--- a/templates/core/report_form.html
+++ b/templates/core/report_form.html
@@ -1,14 +1,15 @@
 {% extends "base.html" %}
 
 {% block content %}
-<h1>Report</h1>
+<h1>{% if mode == 'note' %}Mod Note{% else %}Report{% endif %}</h1>
 {% if thanks %}
-<p>Thanks for your report.</p>
+<p>{% if mode == 'note' %}Note recorded.{% else %}Thanks for your report.{% endif %}</p>
 {% else %}
 <form method="post">
   {% csrf_token %}
   <input type="hidden" name="target_type" value="{{ target_type }}">
   <input type="hidden" name="object_id" value="{{ object_id }}">
+  {% if mode == 'note' %}<input type="hidden" name="mode" value="note">{% endif %}
   {% if target %}<p>Reporting {{ target }}</p>{% endif %}
   <label for="id_reason">Reason:</label>
   <textarea id="id_reason" name="reason" required></textarea>

--- a/templates/core/report_list.html
+++ b/templates/core/report_list.html
@@ -4,7 +4,7 @@
 <h1>Reports</h1>
 <ul>
   {% for r in reports %}
-  <li>{{ r.created_at }} - {{ r.reporter }} reported {{ r.content_type }} {{ r.object_id }}: {{ r.reason }}</li>
+  <li>{{ r.created_at }} - {{ r.reporter }} {% if r.is_note %}noted{% else %}reported{% endif %} {{ r.content_type }} {{ r.object_id }}: {{ r.reason }}</li>
   {% empty %}
   <li>No reports.</li>
   {% endfor %}


### PR DESCRIPTION
## Summary
- Track post lock state, slowmode, and domain weight; track mod notes
- Provide moderator endpoints and controls for removing posts, locking, slowmode, domain throttling, and adding mod notes
- Add simple /mod/astro page listing high AstroScore posts

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68b532f9deb8832c9189525cb2056ed3