### PR TITLE
feat: tighten csp and add embed safeguards

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -77,6 +77,27 @@ SESSION_COOKIE_AGE = 60 * 60 * 8  # 8 hours
 SESSION_EXPIRE_AT_BROWSER_CLOSE = True
 CSRF_COOKIE_SECURE = not DEBUG
 
+ENABLE_TWITTER_EMBEDS = os.environ.get("ENABLE_TWITTER_EMBEDS", "0") in (
+    "1",
+    "true",
+    "True",
+)
+
+EMBED_WHITELIST = [
+    "https://www.youtube.com",
+    "https://www.youtube-nocookie.com",
+    "https://rumble.com",
+]
+if ENABLE_TWITTER_EMBEDS:
+    EMBED_WHITELIST.append("https://platform.twitter.com")
+
+# Simple per-user rate limits
+RATE_LIMITS = {
+    "post": {"limit": 20, "window": 86400},  # posts per day
+    "comment": {"limit": 60, "window": 60},  # comments per minute
+    "vote": {"limit": 120, "window": 60},  # votes per minute
+}
+
 if not DEBUG:
     SECURE_SSL_REDIRECT = True
     # Exempt Fly’s HTTP health probe hitting internal :8000
@@ -88,20 +109,11 @@ if not DEBUG:
     CONTENT_SECURITY_POLICY = {
         "DIRECTIVES": {
             "default-src": ("'self'",),
-            "script-src": (
-                "'self'",
-                "https://platform.twitter.com",
-                "https://cdn.syndication.twimg.com",
-            ),
+            "script-src": ("'self'",),
             "style-src": ("'self'", "'unsafe-inline'"),
             "img-src": ("'self'", "https:", "data:"),
             "connect-src": ("'self'",),
-            "frame-src": (
-                "'self'",
-                "https://www.youtube.com",
-                "https://www.youtube-nocookie.com",
-                "https://rumble.com",
-            ),
+            "frame-src": tuple(["'self'"] + EMBED_WHITELIST),
             "frame-ancestors": ("'self'",),
             "upgrade-insecure-requests": True,
             "base-uri": ("'self'",),
@@ -146,6 +158,7 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "django_htmx.middleware.HtmxMiddleware",
+    "core.middleware.ActionRateLimitMiddleware",
     "csp.middleware.CSPMiddleware",  # django-csp v4
 ]
 

--- a/core/middleware.py
+++ b/core/middleware.py
@@ -1,5 +1,7 @@
 from django.conf import settings
-from django.http import HttpResponseForbidden
+from django.http import HttpResponse, HttpResponseForbidden
+
+from .rate_limit import check_rate_limit
 
 
 def _client_ip(request):
@@ -32,4 +34,33 @@ class AdminIPAllowlistMiddleware:
             ip = _client_ip(request)
             if ip not in allowlist:
                 return HttpResponseForbidden("Forbidden")
+        return self.get_response(request)
+
+
+class ActionRateLimitMiddleware:
+    """Rate limit posts/day, comments/min, and votes/min."""
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+        self.limits = getattr(settings, "RATE_LIMITS", {})
+
+    def __call__(self, request):
+        if request.method == "POST" and request.user.is_authenticated:
+            path = request.path
+            action = None
+            if path.startswith("/submit/"):
+                action = "post"
+            elif path.startswith("/comment") or path.startswith("/comments"):
+                action = "comment"
+            elif path.startswith("/vote") or path.startswith("/comments/vote"):
+                action = "vote"
+            if action and action in self.limits:
+                cfg = self.limits[action]
+                limited, retry_after = check_rate_limit(
+                    request.user, action, cfg.get("limit"), cfg.get("window")
+                )
+                if limited:
+                    resp = HttpResponse("Rate limit exceeded", status=429)
+                    resp.headers["Retry-After"] = str(retry_after)
+                    return resp
         return self.get_response(request)

--- a/core/oembed.py
+++ b/core/oembed.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import re
 from urllib.parse import quote, urlparse
 
+from django.conf import settings
+
 import bleach
 import requests
 
@@ -22,9 +24,14 @@ def fetch_oembed(url: str) -> dict:
         "youtube.com": "https://www.youtube.com/oembed?format=json&url=",
         "youtu.be": "https://www.youtube.com/oembed?format=json&url=",
         "rumble.com": "https://rumble.com/api/oembed.json?url=",
-        "twitter.com": "https://publish.twitter.com/oembed?omit_script=1&url=",
-        "x.com": "https://publish.twitter.com/oembed?omit_script=1&url=",
     }
+    if settings.ENABLE_TWITTER_EMBEDS:
+        providers.update(
+            {
+                "twitter.com": "https://publish.twitter.com/oembed?omit_script=1&url=",
+                "x.com": "https://publish.twitter.com/oembed?omit_script=1&url=",
+            }
+        )
 
     parsed = urlparse(url)
     domain = parsed.netloc

--- a/core/views.py
+++ b/core/views.py
@@ -100,10 +100,13 @@ def oembed_preview(request):
     if not url:
         return HttpResponse("")
     try:
-        data = fetch_oembed(url)
+        embed, data = _build_embed(url)
+        ctx = {"type": "embed", **embed} if embed else data
     except Exception:
+        ctx = None
+    if not ctx:
         return HttpResponse("<p role='alert'>Preview unavailable.</p>", status=400)
-    html = render_to_string("core/partials/link_preview.html", data)
+    html = render_to_string("core/partials/link_preview.html", ctx)
     return HttpResponse(html)
 
 
@@ -206,23 +209,22 @@ def _cached_post_signals(pk):
 
 
 def _build_embed(url):
-    """Return embed metadata for known providers.
+    """Return (embed_meta, data) for known providers.
 
-    Generates a click-to-play "safe" embed using a sandboxed iframe for
-    YouTube and Rumble URLs.  Returns ``None`` if the URL is unsupported or
-    if fetching oEmbed data fails.
+    Generates a click-to-play "safe" embed using a sandboxed iframe. Returns
+    ``(None, data)`` when the URL is unsupported.
     """
 
     if not url:
-        return None
+        return None, None
     parsed = urlparse(url)
     domain = parsed.netloc.lower()
     try:
         data = fetch_oembed(url)
     except Exception:
-        return None
+        return None, None
     if data.get("type") != "embed":
-        return None
+        return None, data
     thumb = data.get("thumbnail_url")
 
     if "youtube" in domain:
@@ -242,16 +244,25 @@ def _build_embed(url):
         if not thumb:
             thumb = f"https://i.ytimg.com/vi/{vid}/hqdefault.jpg"
         src = f"https://www.youtube-nocookie.com/embed/{vid}"
-        return {"src": src, "thumb": thumb, "url": url}
+        return {"src": src, "thumb": thumb, "url": url}, data
 
     if "rumble.com" in domain:
         m = re.search(r'src="([^"]+)"', data.get("html", ""))
         if not m:
             return None
         src = m.group(1)
-        return {"src": src, "thumb": thumb, "url": url}
+        return {"src": src, "thumb": thumb, "url": url}, data
 
-    return None
+    if "twitter.com" in domain or "x.com" in domain:
+        if not settings.ENABLE_TWITTER_EMBEDS:
+            return None, data
+        m = re.search(r"status/(\d+)", url)
+        if not m:
+            return None, data
+        src = f"https://platform.twitter.com/embed/Tweet.html?id={m.group(1)}"
+        return {"src": src, "thumb": thumb, "url": url}, data
+
+    return None, data
 
 
 @require_GET
@@ -671,7 +682,7 @@ def post_detail(request, community, pk, slug):
     )
     comments = post.comments.select_related("author").order_by("path")
     form = CommentForm()
-    embed = _build_embed(post.content_url)
+    embed, _ = _build_embed(post.content_url)
     images = list(post.image_links.all())
     context = {
         "post": post,
@@ -689,7 +700,7 @@ def post_detail_id(request, pk):
     post = get_object_or_404(Post.objects.prefetch_related("image_links"), pk=pk)
     comments = post.comments.select_related("author").order_by("path")
     form = CommentForm()
-    embed = _build_embed(post.content_url)
+    embed, _ = _build_embed(post.content_url)
     images = list(post.image_links.all())
     context = {
         "post": post,

--- a/static/js/embeds.js
+++ b/static/js/embeds.js
@@ -1,0 +1,22 @@
+document.addEventListener('DOMContentLoaded', function () {
+  document.querySelectorAll('.post-embed[data-src]').forEach(function (wrapper) {
+    var link = wrapper.querySelector('a');
+    var src = wrapper.dataset.src;
+    if (!link) return;
+    link.addEventListener('click', function (e) {
+      e.preventDefault();
+      var iframe = document.createElement('iframe');
+      iframe.src = src;
+      iframe.setAttribute('sandbox', 'allow-scripts allow-same-origin');
+      iframe.setAttribute('allowfullscreen', '');
+      iframe.setAttribute('loading', 'lazy');
+      iframe.style.position = 'absolute';
+      iframe.style.top = '0';
+      iframe.style.left = '0';
+      iframe.style.width = '100%';
+      iframe.style.height = '100%';
+      wrapper.innerHTML = '';
+      wrapper.appendChild(iframe);
+    });
+  });
+});

--- a/templates/base.html
+++ b/templates/base.html
@@ -62,5 +62,6 @@
       {% block scripts %}{% endblock %}
       <script src="{% static 'js/htmx.min.js' %}" defer></script>
       <script src="{% static 'js/htmx-csrf.js' %}" defer></script>
+      <script src="{% static 'js/embeds.js' %}" defer></script>
     </body>
   </html>

--- a/templates/core/partials/link_preview.html
+++ b/templates/core/partials/link_preview.html
@@ -1,5 +1,11 @@
 {% if type == 'embed' %}
-<div class="link-embed">{{ html|safe }}</div>
+<div class="link-embed">
+  <div class="post-embed" data-src="{{ src }}" style="position:relative;padding-top:56.25%;overflow:hidden;">
+    <a href="{{ url }}" rel="noopener nofollow" style="position:absolute;top:0;left:0;width:100%;height:100%;display:block;">
+      <img src="{{ thumb }}" alt="" loading="lazy" decoding="async" referrerpolicy="no-referrer" style="width:100%;height:100%;object-fit:cover;">
+    </a>
+  </div>
+</div>
 {% elif type == 'link' %}
 <div class="link-card">
   <div class="link-card-inner">

--- a/templates/core/post_detail.html
+++ b/templates/core/post_detail.html
@@ -106,27 +106,5 @@
 {{ block.super }}
 <script src="{% static 'js/editor.js' %}" defer></script>
 <script src="{% static 'js/comments.js' %}" defer></script>
-<script>
-document.querySelectorAll('.post-embed[data-src]').forEach(function(wrapper){
-  var link = wrapper.querySelector('a');
-  var src = wrapper.dataset.src;
-  if(!link) return;
-  link.addEventListener('click', function(e){
-    e.preventDefault();
-    var iframe=document.createElement('iframe');
-    iframe.src=src;
-    iframe.setAttribute('sandbox','allow-scripts allow-same-origin');
-    iframe.setAttribute('allowfullscreen','');
-    iframe.setAttribute('loading','lazy');
-    iframe.style.position='absolute';
-    iframe.style.top='0';
-    iframe.style.left='0';
-    iframe.style.width='100%';
-    iframe.style.height='100%';
-    wrapper.innerHTML='';
-    wrapper.appendChild(iframe);
-  });
-});
-</script>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- enforce stricter CSP with whitelist for embeds and optional Twitter support
- gate third-party media behind click-to-play placeholders
- add per-user rate limit middleware for posts, comments, and votes

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68b534d1a654832cbb074998be1fda1a