### PR TITLE
Enforce case-insensitive community names

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -110,3 +110,13 @@ class CommunityCreateForm(forms.ModelForm):
         if Community.objects.filter(slug=slug).exists():
             raise forms.ValidationError("Community with this slug already exists.")
         return slug
+
+    def clean(self):
+        cleaned_data = super().clean()
+        name = cleaned_data.get("name")
+        if name is not None:
+            name = name.strip()
+            if Community.objects.filter(name__iexact=name).exists():
+                self.add_error("name", "Community with this name already exists.")
+            cleaned_data["name"] = name
+        return cleaned_data

--- a/core/migrations/0023_community_name_ci_unique.py
+++ b/core/migrations/0023_community_name_ci_unique.py
@@ -1,0 +1,22 @@
+from django.db import migrations, models
+from django.db.models.functions import Lower
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("core", "0022_post_moderation_fields"),
+    ]
+
+    operations = [
+        migrations.RemoveConstraint(
+            model_name="community",
+            name="uniq_community_name",
+        ),
+        migrations.AddConstraint(
+            model_name="community",
+            constraint=models.UniqueConstraint(
+                Lower("name"),
+                name="uniq_community_name_ci",
+            ),
+        ),
+    ]

--- a/core/models.py
+++ b/core/models.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 from django.db import models
 from django.db.models import F
+from django.db.models.functions import Lower
 from django.db.models.signals import post_save, post_delete, pre_save
 from django.dispatch import receiver
 from django.contrib.auth.hashers import make_password, check_password
@@ -81,7 +82,9 @@ class Community(models.Model):
 
     class Meta:
         constraints = [
-            models.UniqueConstraint(fields=["name"], name="uniq_community_name"),
+            models.UniqueConstraint(
+                Lower("name"), name="uniq_community_name_ci"
+            ),
         ]
 
     def __str__(self) -> str:

--- a/core/tests_community_create.py
+++ b/core/tests_community_create.py
@@ -1,4 +1,5 @@
 from django.contrib.auth import get_user_model
+from django.core.cache import cache
 from django.test import TestCase
 from django.urls import reverse
 
@@ -7,6 +8,7 @@ from .models import Community
 
 class CommunityCreateTests(TestCase):
     def setUp(self):
+        cache.clear()
         user_model = get_user_model()
         self.staff = user_model.objects.create_user("staff", password="pwd", is_staff=True)
         self.user = user_model.objects.create_user("user", password="pwd")
@@ -55,3 +57,45 @@ class CommunityCreateTests(TestCase):
             self.url, {"slug": "c6", "name": "C6", "title": "t"}
         )
         self.assertEqual(resp.status_code, 429)
+
+    def test_e_name_case_insensitive(self):
+        Community.objects.create(
+            slug="brisbane", name="Brisbane", title="Brisbane", created_by=self.staff
+        )
+        self.client.login(username="staff", password="pwd")
+        resp = self.client.post(
+            self.url,
+            {
+                "slug": "brisbane2",
+                "name": "brisbane",
+                "title": "Brisbane 2",
+                "description": "",
+            },
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertFormError(
+            resp.context["form"],
+            "name",
+            "Community with this name already exists.",
+        )
+
+    def test_f_name_whitespace_trimmed(self):
+        Community.objects.create(
+            slug="brisbane", name="Brisbane", title="Brisbane", created_by=self.staff
+        )
+        self.client.login(username="staff", password="pwd")
+        resp = self.client.post(
+            self.url,
+            {
+                "slug": "brisbane2",
+                "name": " Brisbane ",
+                "title": "Brisbane 2",
+                "description": "",
+            },
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertFormError(
+            resp.context["form"],
+            "name",
+            "Community with this name already exists.",
+        )


### PR DESCRIPTION
## Summary
- Ensure community names are unique regardless of case by adding a `Lower('name')` constraint
- Strip whitespace and validate against case-insensitive duplicates in `CommunityCreateForm`
- Add tests covering case and whitespace variants of community names

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68b54885aab0832caa2c81a778c8c1ce