### PR TITLE
Add time range selector to home page

### DIFF
--- a/templates/core/home.html
+++ b/templates/core/home.html
@@ -3,6 +3,18 @@
   <section aria-labelledby="feed-heading">
     <h1 id="feed-heading" class="sr-only">Feed</h1>
 
+    <form method="get" class="range-selector" style="margin-bottom:1rem;">
+      <input type="hidden" name="tab" value="{{ tab }}">
+      <label for="range">Time range:</label>
+      <select name="range" id="range">
+        <option value="day" {% if range == 'day' %}selected{% endif %}>Last Day</option>
+        <option value="7days" {% if range == '7days' %}selected{% endif %}>Last 7 Days</option>
+        <option value="month" {% if range == 'month' %}selected{% endif %}>Last Month</option>
+        <option value="year" {% if range == 'year' %}selected{% endif %}>Last Year</option>
+      </select>
+      <button type="submit" class="btn">Apply</button>
+    </form>
+
     {% for post in page.object_list %}
       <article class="card">
         <div class="meta">


### PR DESCRIPTION
## Summary
- Add drop-down to choose post time range on the home feed

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68b54ba80bf0832c8a4c1b2632f28a8e