### PR TITLE
Use core base layout for community templates

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -36,7 +36,6 @@
 
       </div>
     </header>
-    {% include "partials/subreddit_bar.html" %}
 
     <!-- Main feed container constrained by --feed-max -->
     <main class="layout">

--- a/templates/core/community.html
+++ b/templates/core/community.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "core/base.html" %}
 {% block content %}
 <h1>{{ community.title }}</h1>
 <p>{{ community.description }}</p>

--- a/templates/core/community_wiki.html
+++ b/templates/core/community_wiki.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "core/base.html" %}
 {% block content %}
 <h1>{{ community.title }} wiki</h1>
 {% if community.wiki_html %}

--- a/templates/core/mission.html
+++ b/templates/core/mission.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "core/base.html" %}
 {% block content %}
 <!-- mission v2 no-emdash -->
 <div class="mission page container">

--- a/templates/core/mod_astro.html
+++ b/templates/core/mod_astro.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "core/base.html" %}
 {% block content %}
 <div class="page container">
   <h1>Astro Alerts</h1>

--- a/templates/core/post_detail.html
+++ b/templates/core/post_detail.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "core/base.html" %}
 {% load permissions static %}
 {% url 'post_detail' post.community.slug post.pk post.slug as post_url %}
 

--- a/templates/core/post_form.html
+++ b/templates/core/post_form.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "core/base.html" %}
 {% load static %}
 
 {% block content %}

--- a/templates/core/post_submit.html
+++ b/templates/core/post_submit.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "core/base.html" %}
 {% load static %}
 
 {% block content %}

--- a/templates/core/report_form.html
+++ b/templates/core/report_form.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "core/base.html" %}
 
 {% block content %}
 <h1>{% if mode == 'note' %}Mod Note{% else %}Report{% endif %}</h1>

--- a/templates/core/report_list.html
+++ b/templates/core/report_list.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "core/base.html" %}
 
 {% block content %}
 <h1>Reports</h1>

--- a/templates/core/transparency_methods.html
+++ b/templates/core/transparency_methods.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "core/base.html" %}
 {% block content %}
 <div class="page container">
   <h1>Astroturf detection methods</h1>

--- a/templates/core/transparency_posts.html
+++ b/templates/core/transparency_posts.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "core/base.html" %}
 {% block content %}
 <div class="page container">
   <h1>Flagged posts (last 24 h)</h1>

--- a/templates/core/user_comments.html
+++ b/templates/core/user_comments.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "core/base.html" %}
 {% block content %}
 <h1>u/{{ profile_user.username }}</h1>
 {% include "core/partials/user_tab_bar.html" %}

--- a/templates/core/user_overview.html
+++ b/templates/core/user_overview.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "core/base.html" %}
 {% block content %}
 <h1>
   u/{{ profile_user.username }}

--- a/templates/core/user_submitted.html
+++ b/templates/core/user_submitted.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "core/base.html" %}
 {% block content %}
 <h1>u/{{ profile_user.username }}</h1>
 {% include "core/partials/user_tab_bar.html" %}

--- a/templates/partials/subreddit_bar.html
+++ b/templates/partials/subreddit_bar.html
@@ -1,4 +1,0 @@
-<nav class="subreddit-bar">
-  <a href="/r/news/">/r/news/</a>
-  <a href="/r/brisbane/">/r/brisbane/</a>
-</nav>


### PR DESCRIPTION
## Summary
- switch community-related templates to extend `core/base.html`
- drop `subreddit_bar.html` to prevent duplicate NEWS/BRISBANE header
- ensure root base template no longer includes the removed partial

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68b556f23258832c90da9c93c4a87852