### PR TITLE
feat: make astroturf watch configurable via env

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ python manage.py runserver
 
 Visit `http://127.0.0.1:8000` to access the dev server.
 
+### Feature flags
+
+Set the `ASTROTURF_WATCH` environment variable to control astroturf-detection
+features. It defaults to `1`; set `ASTROTURF_WATCH=0` to hide engagement chips
+and transparency pages.
+
 ## Status
 
 SureJan is an early-stage MVP. Contributions, bug reports, and feedback are welcome.

--- a/config/settings.py
+++ b/config/settings.py
@@ -292,7 +292,11 @@ LOGOUT_REDIRECT_URL = "/"
 # -----------------------------------------------------------------------------
 # Astroturf detection constants
 # -----------------------------------------------------------------------------
-ASTROTURF_WATCH = True
+ASTROTURF_WATCH = os.environ.get("ASTROTURF_WATCH", "1") in (
+    "1",
+    "true",
+    "True",
+)
 ASTRO_WINDOW_S = 300
 ASTRO_BUCKET_S = 30
 ASTRO_BASELINE_LOOKBACK_D = 30

--- a/core/tests/test_astro.py
+++ b/core/tests/test_astro.py
@@ -1,8 +1,11 @@
 from datetime import datetime, timedelta, timezone as dt_timezone
+import importlib
+import os
+from unittest import mock
 
 from django.contrib.auth import get_user_model
 from django.core.management import call_command
-from django.test import TestCase, override_settings
+from django.test import SimpleTestCase, TestCase, override_settings
 from django.urls import reverse
 from django.utils import timezone
 from freezegun import freeze_time
@@ -192,3 +195,23 @@ class AstroFeatureFlagViewTests(TestCase):
         with override_settings(ASTROTURF_WATCH=False):
             self.assertNotContains(self.client.get(detail_url), chips_url)
             self.assertNotContains(self.client.get(reverse("home")), chips_url)
+
+
+class AstroEnvVarToggleTests(SimpleTestCase):
+    def test_astroturf_watch_env_var_controls_flag(self):
+        import config.settings as config_settings
+        old = os.environ.get("ASTROTURF_WATCH")
+        try:
+            with mock.patch.dict(os.environ, {"ASTROTURF_WATCH": "0"}):
+                importlib.reload(config_settings)
+                self.assertFalse(config_settings.ASTROTURF_WATCH)
+            with mock.patch.dict(os.environ, {"ASTROTURF_WATCH": "1"}):
+                importlib.reload(config_settings)
+                self.assertTrue(config_settings.ASTROTURF_WATCH)
+        finally:
+            if old is None:
+                os.environ.pop("ASTROTURF_WATCH", None)
+            else:
+                os.environ["ASTROTURF_WATCH"] = old
+            importlib.reload(config_settings)
+

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -10,9 +10,9 @@ monitor at this path.
 
 ### Feature flags
 
-`ASTROTURF_WATCH` controls all astroturf-detection features. Set it to
-`False` to hide engagement chips and block transparency pages; related
-endpoints will return 404.
+The `ASTROTURF_WATCH` environment variable (default `1`) controls all
+astroturf-detection features. Set `ASTROTURF_WATCH=0` to hide engagement
+chips and block transparency pages; related endpoints will return 404.
 
 ```bash
 git add -A


### PR DESCRIPTION
## Summary
- respect `ASTROTURF_WATCH` environment variable to toggle astroturf detection
- test that the feature flag responds to environment settings
- document how to disable astroturf features via `ASTROTURF_WATCH`

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68b55cbbcfc4832c8db7900be47d163f