### PR TITLE
Add UI contract smoke management command

### DIFF
--- a/core/management/__init__.py
+++ b/core/management/__init__.py
@@ -1,0 +1,1 @@
+"""Management utilities for the core app."""

--- a/core/management/commands/__init__.py
+++ b/core/management/commands/__init__.py
@@ -1,0 +1,1 @@
+"""Core app management commands."""

--- a/core/management/commands/smoke_ui_contract.py
+++ b/core/management/commands/smoke_ui_contract.py
@@ -1,0 +1,54 @@
+"""Smoke test for required UI contract hooks."""
+
+from django.core.management.base import BaseCommand
+from django.test import Client
+from django.urls import NoReverseMatch, reverse
+
+
+class Command(BaseCommand):
+    """Verify presence of critical ``data-testid`` hooks."""
+
+    HOME_NAMES = ["home", "index", "frontpage"]
+    SUBMIT_NAMES = ["submit_post", "submit", "post_submit", "new_post"]
+
+    def _resolve(self, names, label):
+        for name in names:
+            try:
+                return reverse(name)
+            except NoReverseMatch:
+                continue
+        self.stdout.write(f"✗ missing URL for {label}")
+        raise SystemExit(1)
+
+    def _has(self, html, testid):
+        token = f'data-testid="{testid}"'
+        token_alt = f"data-testid='{testid}'"
+        return token in html or token_alt in html
+
+    def handle(self, *args, **options):
+        client = Client()
+        missing = []
+
+        home_html = client.get(
+            self._resolve(self.HOME_NAMES, "home"), HTTP_HOST="localhost"
+        ).content.decode()
+        submit_html = client.get(
+            self._resolve(self.SUBMIT_NAMES, "submit"), HTTP_HOST="localhost"
+        ).content.decode()
+
+        for tid in ("sidebar-submit", "sidebar-astro"):
+            if not self._has(home_html, tid):
+                missing.append(f"✗ missing data-testid={tid} on Home")
+        if not self._has(home_html, "post-card"):
+            missing.append("✗ missing data-testid=post-card on Home")
+        if not self._has(submit_html, "submit-form"):
+            missing.append("✗ missing data-testid=submit-form on Submit")
+
+        if missing:
+            for line in missing:
+                self.stdout.write(line)
+            raise SystemExit(1)
+
+        self.stdout.write("UI contract smoke PASS")
+        raise SystemExit(0)
+


### PR DESCRIPTION
## Summary
- add smoke_ui_contract management command to verify required data-testid selectors
- document core management packages with minimal docstrings

## Testing
- `python manage.py smoke_ui_contract` *(fails: missing data-testid=sidebar-submit on Home)*
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68b5667a1b38832ca65e5846db1cb363