### PR TITLE
Add data-testid hooks for smoke tests

### DIFF
--- a/templates/core/home.html
+++ b/templates/core/home.html
@@ -16,7 +16,7 @@
     </form>
 
     {% for post in page.object_list %}
-      <article class="card">
+      <article class="card" data-testid="post-card">
         <div class="meta">
           r/{{ post.community.slug }} · u/{{ post.author.username }} · {{ post.created_at|timesince }} ago
         </div>

--- a/templates/core/partials/post_row.html
+++ b/templates/core/partials/post_row.html
@@ -1,5 +1,5 @@
 {% load url_domain %}
-<article class="post-row" id="post-{{ post.pk }}">
+<article class="post-row" id="post-{{ post.pk }}" data-testid="post-card">
   <div class="vote">
     <button hx-post="{% url 'vote_post' post.pk %}?v=1" hx-target="#score-{{ post.pk }}" hx-swap="outerHTML" aria-label="Upvote">▲</button>
     <span id="score-{{ post.pk }}" class="score">{{ post.score }}</span>

--- a/templates/core/partials/sidebar_minimal.html
+++ b/templates/core/partials/sidebar_minimal.html
@@ -1,5 +1,5 @@
 <div class="card">
-  <a class="btn btn-primary" href="{% url 'post_submit' %}">Submit Post</a>
-  <p class="muted"><a href="{% url 'anti_astroturf' %}">Anti-Astroturf</a></p>
+  <a class="btn btn-primary" href="{% url 'post_submit' %}" data-testid="sidebar-submit">Submit Post</a>
+  <p class="muted"><a href="{% url 'anti_astroturf' %}" data-testid="sidebar-astro">Anti-Astroturf</a></p>
 </div>
 

--- a/templates/core/post_submit.html
+++ b/templates/core/post_submit.html
@@ -5,7 +5,7 @@
 <div class="submit-wrapper">
   <a href="{% url 'home' %}">← Back to feed</a>
   <h1>Submit Post</h1>
-  <form id="post-form" method="post" enctype="multipart/form-data" hx-boost="false">
+  <form id="post-form" method="post" enctype="multipart/form-data" hx-boost="false" data-testid="submit-form">
     {% csrf_token %}
     <div id="form-errors" aria-live="assertive">{{ form.non_field_errors }}</div>
     <div class="form-row">

--- a/templates/partials/feed_card.html
+++ b/templates/partials/feed_card.html
@@ -1,5 +1,5 @@
 {% load url_domain astro_filters %}
-<article class="card feed-card" id="post-{{ post.pk }}"{% if load_more_url %} hx-get="{{ load_more_url }}" hx-trigger="revealed" hx-swap="outerHTML" hx-target="this" hx-push-url="true"{% endif %}>
+<article class="card feed-card" id="post-{{ post.pk }}" data-testid="post-card"{% if load_more_url %} hx-get="{{ load_more_url }}" hx-trigger="revealed" hx-swap="outerHTML" hx-target="this" hx-push-url="true"{% endif %}>
   <div class="vote">
     <button hx-post="{% url 'vote_post' post.pk %}?v=1" hx-target="#score-{{ post.pk }}" hx-swap="outerHTML" aria-label="Upvote">▲</button>
     <span id="score-{{ post.pk }}" class="score">{{ post.score }}</span>

--- a/templates/partials/sidebar_min.html
+++ b/templates/partials/sidebar_min.html
@@ -1,10 +1,10 @@
 <div class="sidebar-card">
   {% if community %}
-    <a class="button button-primary w-full" href="{% url 'post_submit' %}">Submit Post</a>
+    <a class="button button-primary w-full" href="{% url 'post_submit' %}" data-testid="sidebar-submit">Submit Post</a>
   {% else %}
     <a class="button button-primary w-full" href="{% url 'home' %}">Choose a Community</a>
   {% endif %}
 </div>
 <div class="sidebar-card">
-  <a class="link-plain" href="{% url 'anti_astroturf' %}">Anti-Astroturf</a>
+  <a class="link-plain" href="{% url 'anti_astroturf' %}" data-testid="sidebar-astro">Anti-Astroturf</a>
 </div>


### PR DESCRIPTION
## Summary
- add sidebar submit and anti-astro test IDs
- mark post card and submit form with data-testid attributes

## Testing
- `python manage.py migrate`
- `python manage.py smoke_ui_contract` *(fails: missing data-testid=post-card on Home; missing data-testid=submit-form on Submit)*

------
https://chatgpt.com/codex/tasks/task_e_68b568fd4854832ca43f354eda2ff6a5