### PR TITLE
Implement UI contract styles and link stylesheet

### DIFF
--- a/static/css/ui_contract.css
+++ b/static/css/ui_contract.css
@@ -1,0 +1,63 @@
+:root {
+  --maxw: 1200px;
+  --feed-col: 700px;
+  --gutter: 24px;
+  --sidebar-col: 300px;
+  --border: #e5e7eb;
+  --muted: #666;
+}
+
+.container,
+.header-inner {
+  max-width: var(--maxw);
+  margin-left: auto;
+  margin-right: auto;
+  padding: 0 var(--gutter);
+}
+
+.layout,
+.grid {
+  display: grid;
+  grid-template-columns: minmax(0, var(--feed-col)) var(--gutter) minmax(0, var(--sidebar-col));
+  align-items: start;
+}
+
+.feed { grid-column: 1; min-width: 0; }
+.sidebar { grid-column: 3; min-width: 0; }
+
+@media (max-width: 768px) {
+  .layout,
+  .grid { grid-template-columns: 1fr; }
+  .sidebar { grid-column: 1; margin-top: var(--gutter); }
+}
+
+.header-3col {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  align-items: center;
+  gap: var(--gutter);
+}
+.hdr-left { justify-self: start; }
+.hdr-center { justify-self: center; }
+.hdr-right { justify-self: end; }
+
+.post-card {
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: var(--gutter);
+  margin-bottom: var(--gutter);
+  background: #fff;
+}
+
+.post-meta {
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.post-title {
+  margin: 0;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  overflow: hidden;
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="{% static 'css/base.css' %}">
     <link rel="stylesheet" href="{% static 'css/theme.css' %}">
     <link rel="stylesheet" href="{% static 'css/app.css' %}">
+    <link rel="stylesheet" href="{% static 'css/ui_contract.css' %}">
     {% block head_extra %}{% endblock %}
 
   </head>

--- a/templates/core/base.html
+++ b/templates/core/base.html
@@ -3,6 +3,7 @@
   <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
   <title>{% block title %}SureJan{% endblock %}</title>
   <link rel="stylesheet" href="{% static 'css/app.css' %}">
+  <link rel="stylesheet" href="{% static 'css/ui_contract.css' %}">
 </head>
 <body>
   {% include 'core/partials/header.html' %}


### PR DESCRIPTION
## Summary
- Add `ui_contract.css` defining container, grid, header, and post-card utility styles
- Include new stylesheet in base templates so layout utilities are loaded everywhere

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68b60eb83e48832c93c4f883000f1f4d