### PR TITLE
Refactor header with sort navigation and mobile submit

### DIFF
--- a/static/css/ui_contract.css
+++ b/static/css/ui_contract.css
@@ -15,6 +15,29 @@
   padding: 0 var(--gutter);
 }
 
+.header-inner {
+  display: flex;
+  align-items: center;
+}
+
+.hdr-left,
+.hdr-center,
+.hdr-right {
+  flex: 1;
+}
+
+.hdr-center {
+  text-align: center;
+}
+
+.hdr-right {
+  text-align: right;
+}
+
+.mobile-submit {
+  display: none;
+}
+
 .layout,
 .grid {
   display: grid;
@@ -29,17 +52,8 @@
   .layout,
   .grid { grid-template-columns: 1fr; }
   .sidebar { grid-column: 1; margin-top: var(--gutter); }
+  .mobile-submit { display: inline-block; }
 }
-
-.header-3col {
-  display: grid;
-  grid-template-columns: 1fr 1fr 1fr;
-  align-items: center;
-  gap: var(--gutter);
-}
-.hdr-left { justify-self: start; }
-.hdr-center { justify-self: center; }
-.hdr-right { justify-self: end; }
 
 .post-card {
   border: 1px solid var(--border);

--- a/templates/base.html
+++ b/templates/base.html
@@ -16,7 +16,7 @@
   </head>
   <body>
     <header class="site-header">
-      <div class="header-inner header-3col">
+      <div class="header-inner">
 
         <!-- Left: Logo + Our Mission -->
         <div class="hdr-left">
@@ -24,16 +24,19 @@
           <a href="{% url 'mission' %}" class="brand-mission" hx-boost="false">Our Mission</a>
         </div>
 
-        <!-- Center: NEWS / BRISBANE -->
-        <nav class="hdr-center" aria-label="Communities">
-          <a href="{% url 'community' 'news' %}">NEWS</a>
-          <a href="{% url 'community' 'brisbane' %}">BRISBANE</a>
+        <!-- Center: Sort tabs -->
+        <nav class="hdr-center" aria-label="Sort options">
+          <a href="{{ request.path }}?sort=hot">Hot</a>
+          <a href="{{ request.path }}?sort=new">New</a>
+          <a href="{{ request.path }}?sort=top">Top</a>
         </nav>
 
         <!-- Right: Login/Register or username menu -->
         <div class="hdr-right">
           {% include "partials/user_box.html" %}
         </div>
+
+        <a href="{% url 'post_submit' %}" class="mobile-submit" aria-label="Submit Post">Submit Post</a>
 
       </div>
     </header>

--- a/templates/core/partials/header.html
+++ b/templates/core/partials/header.html
@@ -1,16 +1,15 @@
 {% load static %}
 <header class="site-header">
-  <div class="container header-inner">
+  <div class="header-inner">
     <div class="hdr-left">
       <a href="{% url 'home' %}" class="site-brand" aria-label="Home">
         <img src="{% static 'SureJanLogo.png' %}" alt="SureJan" class="site-logo">
       </a>
     </div>
-    <nav class="hdr-center" aria-label="Main navigation">
-      <a href="{% url 'community' 'news' %}" aria-label="News">NEWS</a>
-      <a href="{% url 'community' 'brisbane' %}" aria-label="Brisbane">BRISBANE</a>
-      <a href="{% url 'community' 'politics' %}" aria-label="Politics">POLITICS</a>
-      <a href="{% url 'community' 'social' %}" aria-label="Social">SOCIAL</a>
+    <nav class="hdr-center" aria-label="Sort options">
+      <a href="{{ request.path }}?sort=hot" aria-label="Sort by hot">Hot</a>
+      <a href="{{ request.path }}?sort=new" aria-label="Sort by new">New</a>
+      <a href="{{ request.path }}?sort=top" aria-label="Sort by top">Top</a>
     </nav>
     <div class="hdr-right">
       {% if request.user.is_authenticated %}


### PR DESCRIPTION
## Summary
- Replace community navigation with sortable tabs (Hot/New/Top)
- Flex-based header layout with logo, tabs, and auth links
- Mobile-only "Submit Post" link

## Testing
- `python manage.py test`
- `pytest` *(fails: ModuleNotFoundError: No module named 'freezegun', relative import errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b6100d4084832ca23c4a803214c624