### PR TITLE
Refactor template layout for feed pages

### DIFF
--- a/templates/core/base.html
+++ b/templates/core/base.html
@@ -7,12 +7,7 @@
 </head>
 <body>
   {% include 'core/partials/header.html' %}
-  <div class="container">
-    <div class="grid">
-      <main id="feed-root" class="feed">{% block content %}{% endblock %}</main>
-      <aside class="sidebar">{% include 'core/partials/sidebar_minimal.html' %}</aside>
-    </div>
-  </div>
+  {% block content %}{% endblock %}
   <footer class="footer"><a href="{% url 'terms' %}">Terms</a> · <a href="{% url 'privacy' %}">Privacy</a> · <a href="{% url 'rules' %}">Rules</a></footer>
   <script src="{% static 'js/htmx.min.js' %}"></script>
   <script src="{% static 'js/htmx-csrf.js' %}"></script>

--- a/templates/core/community.html
+++ b/templates/core/community.html
@@ -1,14 +1,24 @@
 {% extends "core/base.html" %}
 {% block content %}
-<h1>{{ community.title }}</h1>
-<p>{{ community.description }}</p>
-{% if request.user.is_authenticated %}
-  <p><a class="button" href="{% url 'post_submit' %}" hx-boost="false">Submit</a></p>
-{% endif %}
-{% include "partials/sort_tabs.html" with active_sort=sort community_slug=community_slug sort_tabs=sort_tabs %}
-  <div class="feed">
-    <div id="feed-list">
-    {% include "core/partials/post_list.html" with posts=posts next_page=next_page sort_query=sort_query %}
+<div class="shell">
+  <div class="layout-grid">
+    <main class="feed-col">
+      <h1>{{ community.title }}</h1>
+      <p>{{ community.description }}</p>
+      {% if request.user.is_authenticated %}
+        <p><a class="button" href="{% url 'post_submit' %}" hx-boost="false">Submit</a></p>
+      {% endif %}
+      {% include "partials/sort_tabs.html" with active_sort=sort community_slug=community_slug sort_tabs=sort_tabs %}
+      <div class="feed">
+        <div id="feed-list">
+          {% include "core/partials/post_list.html" with posts=posts next_page=next_page sort_query=sort_query %}
+        </div>
+      </div>
+    </main>
+    <div class="gutter" aria-hidden="true"></div>
+    <aside class="sidebar-col">
+      {% include "core/partials/sidebar_minimal.html" %}
+    </aside>
   </div>
 </div>
 {% endblock %}

--- a/templates/core/home.html
+++ b/templates/core/home.html
@@ -1,44 +1,54 @@
 {% extends "core/base.html" %}
 {% block content %}
-  <section aria-labelledby="feed-heading">
-    <h1 id="feed-heading" class="sr-only">Feed</h1>
+<div class="shell">
+  <div class="layout-grid">
+    <main class="feed-col">
+      <section aria-labelledby="feed-heading">
+        <h1 id="feed-heading" class="sr-only">Feed</h1>
 
-    <form method="get" class="range-selector" style="margin-bottom:1rem;">
-      <input type="hidden" name="tab" value="{{ tab }}">
-      <label for="range">Time range:</label>
-      <select name="range" id="range">
-        <option value="day" {% if range == 'day' %}selected{% endif %}>Last Day</option>
-        <option value="7days" {% if range == '7days' %}selected{% endif %}>Last 7 Days</option>
-        <option value="month" {% if range == 'month' %}selected{% endif %}>Last Month</option>
-        <option value="year" {% if range == 'year' %}selected{% endif %}>Last Year</option>
-      </select>
-      <button type="submit" class="btn">Apply</button>
-    </form>
+        <form method="get" class="range-selector" style="margin-bottom:1rem;">
+          <input type="hidden" name="tab" value="{{ tab }}">
+          <label for="range">Time range:</label>
+          <select name="range" id="range">
+            <option value="day" {% if range == 'day' %}selected{% endif %}>Last Day</option>
+            <option value="7days" {% if range == '7days' %}selected{% endif %}>Last 7 Days</option>
+            <option value="month" {% if range == 'month' %}selected{% endif %}>Last Month</option>
+            <option value="year" {% if range == 'year' %}selected{% endif %}>Last Year</option>
+          </select>
+          <button type="submit" class="btn">Apply</button>
+        </form>
 
-    {% for post in page.object_list %}
-      <article class="card" data-testid="post-card">
-        <div class="meta">
-          r/{{ post.community.slug }} · u/{{ post.author.username }} · {{ post.created_at|timesince }} ago
-        </div>
-        <h2 class="title">
-          <a href="{% url 'post_detail' post.community.slug post.pk post.title|slugify %}">{{ post.title }}</a>
-        </h2>
-        {% if post.body %}
-          <p class="preview">{{ post.body|truncatechars:220 }}</p>
+        {% for post in page.object_list %}
+          <article class="card" data-testid="post-card">
+            <div class="meta">
+              r/{{ post.community.slug }} · u/{{ post.author.username }} · {{ post.created_at|timesince }} ago
+            </div>
+            <h2 class="title">
+              <a href="{% url 'post_detail' post.community.slug post.pk post.title|slugify %}">{{ post.title }}</a>
+            </h2>
+            {% if post.body %}
+              <p class="preview">{{ post.body|truncatechars:220 }}</p>
+            {% endif %}
+            <div class="actions">
+              <a href="{% url 'post_detail' post.community.slug post.pk post.title|slugify %}">{{ post.comment_count }} comments</a>
+            </div>
+          </article>
+        {% empty %}
+          <div class="card empty">No posts yet. <a href="{% url 'post_submit' %}">Be the first to post</a>.</div>
+        {% endfor %}
+
+        {% if page.has_next %}
+          <p style="text-align:center;margin:16px 0;">
+            <a class="btn" href="?page={{ page.next_page_number }}&tab={{ tab }}&range={{ range }}">Load more</a>
+          </p>
         {% endif %}
-        <div class="actions">
-          <a href="{% url 'post_detail' post.community.slug post.pk post.title|slugify %}">{{ post.comment_count }} comments</a>
-        </div>
-      </article>
-    {% empty %}
-      <div class="card empty">No posts yet. <a href="{% url 'post_submit' %}">Be the first to post</a>.</div>
-    {% endfor %}
-
-    {% if page.has_next %}
-      <p style="text-align:center;margin:16px 0;">
-        <a class="btn" href="?page={{ page.next_page_number }}&tab={{ tab }}&range={{ range }}">Load more</a>
-      </p>
-    {% endif %}
-  </section>
+      </section>
+    </main>
+    <div class="gutter" aria-hidden="true"></div>
+    <aside class="sidebar-col">
+      {% include "core/partials/sidebar_minimal.html" %}
+    </aside>
+  </div>
+</div>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- simplify base template to expose a raw content block without layout container or sidebar
- wrap home and community feeds in new shell/layout-grid structure with sidebar include

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68b611691b00832ca50adde707ae43ce