### PR TITLE
Refactor post card templates

### DIFF
--- a/static/css/theme.css
+++ b/static/css/theme.css
@@ -213,7 +213,7 @@ a:focus {
 }
 
 /* Thing (post) card -------------------------------------------------- */
-.post-row {
+.post-card {
   display: flex;
   background: var(--panel);
   border: 1px solid var(--border);

--- a/templates/core/home.html
+++ b/templates/core/home.html
@@ -19,20 +19,7 @@
         </form>
 
         {% for post in page.object_list %}
-          <article class="card" data-testid="post-card">
-            <div class="meta">
-              r/{{ post.community.slug }} · u/{{ post.author.username }} · {{ post.created_at|timesince }} ago
-            </div>
-            <h2 class="title">
-              <a href="{% url 'post_detail' post.community.slug post.pk post.title|slugify %}">{{ post.title }}</a>
-            </h2>
-            {% if post.body %}
-              <p class="preview">{{ post.body|truncatechars:220 }}</p>
-            {% endif %}
-            <div class="actions">
-              <a href="{% url 'post_detail' post.community.slug post.pk post.title|slugify %}">{{ post.comment_count }} comments</a>
-            </div>
-          </article>
+          {% include "partials/feed_card.html" with post=post %}
         {% empty %}
           <div class="card empty">No posts yet. <a href="{% url 'post_submit' %}">Be the first to post</a>.</div>
         {% endfor %}

--- a/templates/core/partials/post_deleted_stub.html
+++ b/templates/core/partials/post_deleted_stub.html
@@ -1,9 +1,9 @@
 <!-- stub for deleted posts -->
-<article id="post-{{ post.pk }}" class="post-row">
+<article id="post-{{ post.pk }}" class="post-card" data-testid="post-card">
   <div class="vote"></div>
   <div class="post-body">
     <h2><em>[deleted]</em></h2>
-    <div class="meta">in r/{{ post.community.slug }}</div>
+    <div class="post-meta">in r/{{ post.community.slug }}</div>
   </div>
 </article>
 

--- a/templates/core/partials/post_row.html
+++ b/templates/core/partials/post_row.html
@@ -1,10 +1,5 @@
-{% load url_domain %}
-<article class="post-row" id="post-{{ post.pk }}" data-testid="post-card">
-  <div class="vote">
-    <button hx-post="{% url 'vote_post' post.pk %}?v=1" hx-target="#score-{{ post.pk }}" hx-swap="outerHTML" aria-label="Upvote">▲</button>
-    <span id="score-{{ post.pk }}" class="score">{{ post.score }}</span>
-    <button hx-post="{% url 'vote_post' post.pk %}?v=-1" hx-target="#score-{{ post.pk }}" hx-swap="outerHTML" aria-label="Downvote">▼</button>
-  </div>
+{% load url_domain astro_filters %}
+<article class="post-card" id="post-{{ post.pk }}" data-testid="post-card">
   {% if post.image_thumb or post.image %}
   <a href="{% url 'post_detail' post.community.slug post.pk post.slug %}" class="thumb">
     {% if post.image_thumb %}
@@ -14,26 +9,39 @@
     {% endif %}
   </a>
   {% endif %}
-  <div class="entry">
-    <div class="meta">
-      <a href="{% url 'community' post.community.slug %}">/r/{{ post.community.slug }}</a>
-      &middot;
-      <a href="{% url 'user_overview' post.author.username %}">{{ post.author.username }}</a>
-      &middot;
-      <time datetime="{{ post.created_at|date:'c' }}">{{ post.created_at|timesince }} ago</time>
-    </div>
-    <h3 class="post-title"><a href="{% url 'post_detail' post.community.slug post.pk post.slug %}">{{ post.title }}</a></h3>
-    {% if post.body %}
-    <p class="post-excerpt">{{ post.body|striptags|truncatechars:200 }}</p>
-    {% endif %}
-    {% if post.is_deleted %}<span class="state-badge">deleted</span>{% endif %}
-    {% if post.is_draft %}<span class="state-badge">draft</span>{% endif %}
-    <ul class="actions">
-      <li><a href="{% url 'post_detail' post.community.slug post.pk post.slug %}#comments">{{ post.comment_count }} comments</a></li>
-      <li><a href="#" class="copy-link" data-link="{% url 'post_detail' post.community.slug post.pk post.slug %}">share</a></li>
-      <li><a href="#">save</a></li>
-    </ul>
-    <a href="{% url 'post_detail' post.community.slug post.pk post.slug %}" class="read-more">Read more</a>
-    {% include "core/partials/mod_controls.html" with post=post %}
+  <div class="post-meta">
+    <a href="{% url 'community' post.community.slug %}">r/{{ post.community.slug }}</a>
+    •
+    <a href="{% url 'user_overview' post.author.username %}">{{ post.author.username }}</a>
+    •
+    <time datetime="{{ post.created_at|date:'c' }}">{{ post.created_at|timesince }}</time>
   </div>
+  <h2 class="post-title line-clamp"><a href="{% url 'post_detail' post.community.slug post.pk post.slug %}">{{ post.title }}</a></h2>
+  {% if post.body %}
+  <p class="post-excerpt">{{ post.body|striptags|truncatechars:200 }}</p>
+  {% endif %}
+  {% if post.is_deleted %}<span class="state-badge">deleted</span>{% endif %}
+  {% if post.is_draft %}<span class="state-badge">draft</span>{% endif %}
+  <div class="post-actions">
+    <div class="vote">
+      <button class="up" hx-post="{% url 'vote_post' post.pk %}?v=1" hx-target="#score-{{ post.pk }}" hx-swap="outerHTML" aria-label="Upvote">▲</button>
+      <span id="score-{{ post.pk }}" class="score">{{ post.score }}</span>
+      <button class="down" hx-post="{% url 'vote_post' post.pk %}?v=-1" hx-target="#score-{{ post.pk }}" hx-swap="outerHTML" aria-label="Downvote">▼</button>
+    </div>
+    <a href="{% url 'post_detail' post.community.slug post.pk post.slug %}#comments">{{ post.comment_count }} comments</a>
+    {% if post.astro_score %}
+    <details class="astro-why">
+      <summary class="chip {{ post.astro_score.score|astro_band }}">Astro {{ post.astro_score.score }}</summary>
+      <ul>
+        <li>Vote rate 15m: {{ post.astro_score.rate15 }}</li>
+        <li>Early new-account share: {{ post.astro_score.early_new_share|floatformat:2 }}</li>
+        <li>Discuss ratio: {{ post.astro_score.discuss_ratio|floatformat:2 }}</li>
+      </ul>
+    </details>
+    {% endif %}
+  </div>
+  {% if post.body %}
+  <a href="{% url 'post_detail' post.community.slug post.pk post.slug %}" class="read-more">Read more</a>
+  {% endif %}
+  {% include "core/partials/mod_controls.html" with post=post %}
 </article>

--- a/templates/partials/feed_card.html
+++ b/templates/partials/feed_card.html
@@ -1,10 +1,5 @@
 {% load url_domain astro_filters %}
-<article class="card feed-card" id="post-{{ post.pk }}" data-testid="post-card"{% if load_more_url %} hx-get="{{ load_more_url }}" hx-trigger="revealed" hx-swap="outerHTML" hx-target="this" hx-push-url="true"{% endif %}>
-  <div class="vote">
-    <button hx-post="{% url 'vote_post' post.pk %}?v=1" hx-target="#score-{{ post.pk }}" hx-swap="outerHTML" aria-label="Upvote">▲</button>
-    <span id="score-{{ post.pk }}" class="score">{{ post.score }}</span>
-    <button hx-post="{% url 'vote_post' post.pk %}?v=-1" hx-target="#score-{{ post.pk }}" hx-swap="outerHTML" aria-label="Downvote">▼</button>
-  </div>
+<article class="post-card" id="post-{{ post.pk }}" data-testid="post-card"{% if load_more_url %} hx-get="{{ load_more_url }}" hx-trigger="revealed" hx-swap="outerHTML" hx-target="this" hx-push-url="true"{% endif %}>
   {% if post.image_thumb or post.image %}
   <a href="{% url 'post_detail' post.community.slug post.pk post.slug %}" class="thumb">
     {% if post.image_thumb %}
@@ -14,22 +9,23 @@
     {% endif %}
   </a>
   {% endif %}
-  <div class="entry">
-    <div class="meta">
-      <a href="{% url 'community' post.community.slug %}">/r/{{ post.community.slug }}</a>
-      &middot;
-      <a href="{% url 'user_overview' post.author.username %}">{{ post.author.username }}</a>
-      &middot;
-      <time datetime="{{ post.created_at|date:'c' }}">{{ post.created_at|timesince }} ago</time>
+  <div class="post-meta">
+    <a href="{% url 'community' post.community.slug %}">r/{{ post.community.slug }}</a>
+    •
+    <a href="{% url 'user_overview' post.author.username %}">{{ post.author.username }}</a>
+    •
+    <time datetime="{{ post.created_at|date:'c' }}">{{ post.created_at|timesince }}</time>
+  </div>
+  <h2 class="post-title line-clamp"><a href="{% url 'post_detail' post.community.slug post.pk post.slug %}">{{ post.title }}</a></h2>
+  {% if post.is_deleted %}<span class="state-badge">deleted</span>{% endif %}
+  {% if post.is_draft %}<span class="state-badge">draft</span>{% endif %}
+  <div class="post-actions">
+    <div class="vote">
+      <button class="up" hx-post="{% url 'vote_post' post.pk %}?v=1" hx-target="#score-{{ post.pk }}" hx-swap="outerHTML" aria-label="Upvote">▲</button>
+      <span id="score-{{ post.pk }}" class="score">{{ post.score }}</span>
+      <button class="down" hx-post="{% url 'vote_post' post.pk %}?v=-1" hx-target="#score-{{ post.pk }}" hx-swap="outerHTML" aria-label="Downvote">▼</button>
     </div>
-    <h3 class="title line-clamp"><a href="{% url 'post_detail' post.community.slug post.pk post.slug %}">{{ post.title }}</a></h3>
-    {% if post.is_deleted %}<span class="state-badge">deleted</span>{% endif %}
-    {% if post.is_draft %}<span class="state-badge">draft</span>{% endif %}
-    <ul class="actions">
-      <li><a href="{% url 'post_detail' post.community.slug post.pk post.slug %}#comments">{{ post.comment_count }} comments</a></li>
-      <li><a href="#" class="copy-link" data-link="{% url 'post_detail' post.community.slug post.pk post.slug %}">share</a></li>
-      <li><a href="#">save</a></li>
-    </ul>
+    <a href="{% url 'post_detail' post.community.slug post.pk post.slug %}#comments">{{ post.comment_count }} comments</a>
     {% if post.astro_score %}
     <details class="astro-why">
       <summary class="chip {{ post.astro_score.score|astro_band }}">Astro {{ post.astro_score.score }}</summary>


### PR DESCRIPTION
## Summary
- simplify feed card HTML structure and rename root to `post-card`
- update user activity post row and deleted stub to match new card layout
- reuse `feed_card` partial on home feed and style `.post-card` in theme CSS

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68b6134355ac832cb7ba98c9d78bb1e0