### PR TITLE
Adjust layout test selectors and verify anti-astroturf bullets on methods page

### DIFF
--- a/core/tests/test_layout.py
+++ b/core/tests/test_layout.py
@@ -1,4 +1,5 @@
 import pytest
+from django.urls import reverse
 
 
 @pytest.mark.django_db
@@ -6,14 +7,15 @@ def test_homepage_layout(client):
     resp = client.get("/")
     assert resp.status_code == 200
     html = resp.content.decode()
-    assert '<main class="layout">' in html
-    assert '<section class="main feed">' in html
-    assert '<aside class="sidebar">' in html
+    assert '<div class="layout-grid">' in html
+    assert '<main class="feed-col">' in html
+    assert '<aside class="sidebar-col">' in html
 
 
 @pytest.mark.django_db
 def test_anti_astroturf_bullets(client):
-    resp = client.get("/anti-astroturf/")
+    url = reverse("transparency_methods")
+    resp = client.get(url)
     assert resp.status_code == 200
     html = resp.content.decode()
     assert "No undisclosed paid promotions or campaigns." in html

--- a/templates/core/transparency_methods.html
+++ b/templates/core/transparency_methods.html
@@ -4,6 +4,13 @@
   <h1>Astroturf detection methods</h1>
   <p>We monitor voting patterns to spot coordinated campaigns while protecting individual privacy.</p>
 
+  <h2>Policy</h2>
+  <ul>
+    <li>No undisclosed paid promotions or campaigns.</li>
+    <li>No vote manipulation or brigading.</li>
+    <li>Organizations and officials must identify themselves.</li>
+  </ul>
+
   <h2>Time windows</h2>
   <p>Votes are analysed in {{ ASTRO_WINDOW_S }}‑second windows and grouped into {{ ASTRO_BUCKET_S }}‑second buckets. Baseline activity comes from the last {{ ASTRO_BASELINE_LOOKBACK_D }} days.</p>
 


### PR DESCRIPTION
## Summary
- Update layout test to search for new grid and column class names
- Point anti-astroturf test to the `/methods` page and ensure policy bullets render there
- Surface anti-astroturf policy bullets on the transparency methods page

## Testing
- `DJANGO_SETTINGS_MODULE=config.settings pytest core/tests/test_layout.py`


------
https://chatgpt.com/codex/tasks/task_e_68b616313744832c8b4b7589622e254d