### PR TITLE
Add reference docs for components, routes, design tokens, and empty states

### DIFF
--- a/docs/Components-and-Selectors.md
+++ b/docs/Components-and-Selectors.md
@@ -1,0 +1,14 @@
+Change control: If templates affecting this surface change, update this file in the same PR.
+
+# Components and Required Selectors
+
+The following UI components must retain these `data-testid` hooks for tests and monitoring.
+
+| Component | Location | Selector |
+|-----------|----------|----------|
+| Post card | Feed lists and post stubs | `data-testid="post-card"` |
+| Sidebar submit CTA | Right sidebar | `data-testid="sidebar-submit"` |
+| Sidebar Anti-Astro link | Right sidebar | `data-testid="sidebar-astro"` |
+| Submit Post form | `/submit` page | `data-testid="submit-form"` |
+
+These selectors are exercised by the `smoke_ui_contract` management command.

--- a/docs/Design-Tokens.md
+++ b/docs/Design-Tokens.md
@@ -1,0 +1,30 @@
+Change control: If templates affecting this surface change, update this file in the same PR.
+
+# Design Tokens
+
+## Layout & Spacing
+
+| Token | Value | Description |
+|-------|-------|-------------|
+| `--maxw` | `1200px` | Max page width |
+| `--feed` | `720px` | Feed column width |
+| `--side` | `320px` | Sidebar width |
+| `--g` | `24px` | Column gutter |
+| `--s1` | `8px` | Small spacing |
+| `--s2` | `16px` | Base spacing |
+| `--s3` | `24px` | Large spacing |
+
+## Colors & Typography
+
+| Token | Value | Description |
+|-------|-------|-------------|
+| `--bg` | `#f6f7f8` | Page background |
+| `--panel` | `#ffffff` | Panel background |
+| `--border` | `#dddddd` | Standard border |
+| `--text` | `#111111` | Primary text color |
+| `--muted` | `#777777` | Muted text color |
+| `--link` | `#3366cc` | Link color |
+| `--link-visited` | `#551a8b` | Visited link color |
+| `--accent` | `#ff8b60` | Upvote accent |
+| `--accent-down` | `#5f99cf` | Downvote accent |
+| `--brand-font` | `'VCR OSD Mono', monospace` | Display font |

--- a/docs/Routes-and-Params.md
+++ b/docs/Routes-and-Params.md
@@ -1,0 +1,18 @@
+Change control: If templates affecting this surface change, update this file in the same PR.
+
+# Routes and Params
+
+Authoritative map of core routes and their accepted parameters.
+
+| Route | Path params | Query params | Description |
+|-------|-------------|--------------|-------------|
+| `/` | – | `tab`, `range`, `page` | Home feed |
+| `/r/<slug>/` | `slug` | `tab`, `range`, `page` | Community feed |
+| `/r/<community>/comments/<pk>/<slug>/` | `community`, `pk`, `slug` | – | Post detail + comments |
+| `/p/<pk>/` | `pk` | – | Post detail by id |
+| `/submit/` | – | – | Submit post form |
+| `/mod/astro/` | – | – | Astro alerts for moderators |
+| `/methods/` | – | – | Transparency methods |
+| `/transparency/posts` | – | `page`, `sort` | Flagged posts list |
+| `/mission/` | – | – | Mission page |
+| `/anti-astroturf/` | – | – | Anti-astroturf info |

--- a/docs/States-and-Empty.md
+++ b/docs/States-and-Empty.md
@@ -1,0 +1,17 @@
+Change control: If templates affecting this surface change, update this file in the same PR.
+
+# Empty State Strings
+
+Reference copy for empty listings and states. Keep these strings stable.
+
+| Context | String |
+|---------|--------|
+| Home feed | `No posts yet. Be the first to post.` |
+| Feed list partial | `No posts yet. Submit Post` |
+| Post list generic | `No posts yet. Be the first to submit!` |
+| Post detail comments | `No comments yet.` |
+| User comments | `No comments yet.` |
+| User overview activity | `No activity yet.` |
+| Mod Astro alerts | `No flagged posts.` |
+| Transparency posts table | `No flagged posts in the last 24 h.` |
+| Reports list | `No reports.` |


### PR DESCRIPTION
## Summary
- Document required `data-testid` hooks for key UI components
- Map routes, path parameters, and query parameters
- Record design tokens and empty-state strings for stable reference

## Testing
- `make test` *(fails: Makefile missing separator)*
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68b61d6d864c832ca3453cd9902cc552