### PR TITLE
Introduce design tokens and consolidate CSS

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -1,13 +1,61 @@
-:root{--maxw:1200px;--g:24px;--feed:720px;--side:320px;--s1:8px;--s2:16px;--s3:24px;--muted:#666;--border:#e5e7eb}
-*{box-sizing:border-box}html,body{margin:0;padding:0}body{font:16px/1.5 system-ui,Segoe UI,Roboto,Arial,sans-serif}
-.container{max-width:var(--maxw);margin:0 auto;padding:0 var(--s2)}
-.grid{display:grid;grid-template-columns:minmax(0,var(--feed)) var(--g) minmax(0,var(--side));align-items:start;margin-top:var(--s3)}
-.feed{grid-column:1;min-width:0}.sidebar{grid-column:3;min-width:0}
-.card{border:1px solid var(--border);border-radius:12px;padding:var(--s2);background:#fff;margin-bottom:var(--s2)}
-.title{margin:4px 0 0}.meta{color:var(--muted);font-size:14px}.preview{margin:8px 0 0}.btn{border:1px solid var(--border);border-radius:10px;padding:8px 12px;text-decoration:none}
-.footer{color:var(--muted);font-size:14px;padding:var(--s3) 0;text-align:center}
-@media (max-width:768px){.grid{grid-template-columns:1fr}.sidebar{grid-column:1;margin-top:var(--s3)}}
-.sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
+@import url("{% static 'css/tokens.css' %}");
 
-.line-clamp{display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:2;overflow:hidden}
+/* Global styles */
+* { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; }
+body {
+  font-family: var(--font-base);
+  background: var(--color-bg);
+  color: var(--color-text);
+  line-height: 1.5;
+}
 
+a { color: var(--color-link); }
+a:visited { color: var(--color-link-visited); }
+a:hover { text-decoration: underline; }
+
+/* Header */
+.site-header {
+  background: var(--color-surface);
+  border-bottom: 1px solid var(--color-border);
+}
+.header-inner {
+  max-width: var(--bp-lg);
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  padding: var(--space-3);
+}
+.hdr-left, .hdr-center, .hdr-right { flex: 1; }
+.hdr-center { text-align: center; }
+.hdr-right { text-align: right; }
+.mobile-submit { display: none; }
+
+@media (max-width: var(--bp-md)) {
+  .header-inner { flex-wrap: wrap; }
+  .mobile-submit { display: inline-block; }
+}
+
+/* Components */
+.sidebar-cta {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: var(--space-5);
+  background: var(--color-surface);
+  text-align: center;
+}
+
+.post-card {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: var(--space-5);
+  background: var(--color-surface);
+  margin-bottom: var(--space-5);
+}
+
+.empty-state {
+  text-align: center;
+  color: var(--color-muted);
+  padding: var(--space-5) 0;
+}

--- a/static/css/theme.css
+++ b/static/css/theme.css
@@ -55,146 +55,6 @@ a:focus {
   outline-offset: 2px;
 }
 
-/* Header ------------------------------------------------------------- */
-.site-header {
-  background: var(--panel);
-  border-bottom: 1px solid var(--border);
-  position: sticky;
-  top: 0;
-  z-index: 1000;
-}
-
-.header-inner {
-  max-width: 960px;
-  margin: 0 auto;
-  display: flex;
-  align-items: center;
-  gap: 16px;
-  padding: 8px 12px;
-}
-
-.site-brand {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-}
-
-.site-logo {
-  height: 108px;
-  width: auto;
-  display: block;
-}
-
-.site-title, h1, .page-title {
-  font-family: var(--brand-font);
-  letter-spacing: 0.25px;
-}
-
-.site-title {
-  font-size: 16px;
-  font-weight: 700;
-  line-height: 1;
-  color: var(--text);
-}
-
-.header-nav {
-  margin-left: auto;
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  align-items: flex-end;
-}
-
-.user-info {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  font-size: 11px;
-  color: var(--muted);
-}
-
-.user-info a {
-  color: var(--link);
-}
-
-.tab-bar {
-  display: flex;
-  gap: 4px;
-  padding: 4px 6px;
-  background: var(--panel);
-}
-
-.tab-bar a {
-  padding: 2px 4px;
-  border-bottom: 2px solid transparent;
-  color: var(--muted);
-  text-transform: uppercase;
-  letter-spacing: 0.02em;
-  font-size: 11px;
-}
-
-.tab-bar a:visited {
-  color: var(--muted);
-}
-
-.tab-bar a:hover {
-  text-decoration: underline;
-}
-
-.tab-bar a.active {
-  font-weight: bold;
-  color: var(--text);
-  border-bottom: 2px solid var(--link);
-}
-
-.tab-bar a.active:visited {
-  color: var(--text);
-}
-
-.tab-bar a.active:hover {
-  text-decoration: none;
-}
-
-/* Subreddit bar ------------------------------------------------------ */
-.subreddit-bar {
-  background: #f2f2f2;
-  border-bottom: 1px solid var(--border);
-  overflow-x: auto;
-  white-space: nowrap;
-}
-
-.subreddit-bar a {
-  display: inline-block;
-  white-space: nowrap;
-  padding: 4px 6px;
-  color: var(--link);
-}
-
-/* Sort tabs ---------------------------------------------------------- */
-.sort-tabs ul {
-  display: flex;
-  flex-wrap: nowrap;
-  gap: 16px;
-  list-style: none;
-  padding: 0;
-  margin: 0;
-}
-
-.sort-tabs li {
-  display: inline;
-}
-
-.sort-tabs a {
-  text-decoration: none;
-  color: #1a1a1a;
-}
-
-.sort-tabs a.active {
-  font-weight: bold;
-  border-bottom: 2px solid #2b6cb0;
-  padding-bottom: 3px;
-}
-
 /* Layout ------------------------------------------------------------- */
 .layout {
   max-width: 960px;
@@ -423,9 +283,6 @@ hr {
 
 /* Responsive --------------------------------------------------------- */
 @media (max-width: 768px) {
-  .site-logo { height: 24px; }
-  .site-title { display: none; }
-  .header-inner { padding: 6px 10px; }
   .layout {
     flex-direction: column;
   }
@@ -435,9 +292,6 @@ hr {
     width: auto;
   }
 
-  .tab-bar {
-    overflow-x: auto;
-  }
 }
 
 /* Post images: responsive + bounded */
@@ -568,74 +422,9 @@ hr {
 
 .preview-card { margin-top:12px; }
 
-.brand-mission { font-size:12px; margin-left:8px; color:#3366cc; }
-.brand-mission:hover { text-decoration:underline; }
 .mission h1 { font: normal 16px/1.2 Verdana, Arial, sans-serif; margin: 0 0 8px; }
 .mission h2 { font-size:13px; margin:12px 0 6px; }
 .mission h3 { font-size:12px; margin:10px 0 6px; }
 .mission p, .mission li { font-size:12px; }
 .mission .muted { color:#777; font-size:11px; }
 
-/* 3-column header layout */
-.header-3col {
-  max-width: 960px;
-  margin: 0 auto;
-  display: grid;
-  grid-template-columns: auto 1fr auto; /* left | center | right */
-  align-items: center;
-  gap: 10px;
-  padding: 8px 12px;
-}
-
-/* Left cluster: logo sits already, mission sits beside it */
-.hdr-left { display: flex; align-items: center; gap: 10px; }
-.brand-mission { font-size:12px; color:#3366cc; }
-.brand-mission:hover { text-decoration: underline; }
-
-/* Center communities */
-.hdr-center {
-  display:flex; justify-content:center; gap:16px;
-  text-transform: uppercase; font-size:12px;
-}
-.hdr-center a { color:#3366cc; }
-.hdr-center a:hover { text-decoration: underline; }
-
-/* Right: user menu sits inline */
-.hdr-right { display:flex; justify-content:flex-end; }
-.hdr-right .user-box a { color:#3366cc; }
-
-/* Mobile */
-@media (max-width: 768px) {
-  .header-3col {
-    grid-template-columns: 1fr auto; /* left + right */
-    grid-template-areas:
-      "left  right"
-      "center center";
-    row-gap: 6px;
-  }
-  .hdr-left  { grid-area: left; }
-  .hdr-right { grid-area: right; }
-  .hdr-center{
-    grid-area: center; justify-content: center; gap: 12px;
-    overflow-x: auto; white-space: nowrap; padding-bottom: 2px;
-  }
-}
-
-/* Bump header link sizes a bit */
-.brand-mission { font-size:14px; margin-left:0; }
-.hdr-center a   { font-size:14px; }
-.hdr-right .user-box,
-.hdr-right .user-box a { font-size:14px; }
-
-/* Keep tap targets comfy without changing layout */
-.hdr-center a,
-.brand-mission,
-.hdr-right .user-box a { line-height: 1.2; padding: 2px 2px; }
-
-/* Mobile: nudge down slightly if needed */
-@media (max-width: 768px) {
-  .brand-mission,
-  .hdr-center a,
-  .hdr-right .user-box,
-  .hdr-right .user-box a { font-size:13px; }
-}

--- a/static/css/tokens.css
+++ b/static/css/tokens.css
@@ -1,0 +1,33 @@
+:root {
+  /* Colors */
+  --color-bg: #f9fafb;
+  --color-surface: #ffffff;
+  --color-border: #e5e7eb;
+  --color-text: #111827;
+  --color-muted: #6b7280;
+  --color-link: #2563eb;
+  --color-link-visited: #7c3aed;
+  --color-accent: #f97316;
+  --color-accent-down: #6366f1;
+
+  /* Spacing */
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 16px;
+  --space-4: 24px;
+  --space-5: 32px;
+
+  /* Radius */
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 12px;
+
+  /* Fonts */
+  --font-base: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  --font-brand: 'VCR OSD Mono', monospace;
+
+  /* Breakpoints */
+  --bp-sm: 480px;
+  --bp-md: 768px;
+  --bp-lg: 1024px;
+}

--- a/static/css/ui_contract.css
+++ b/static/css/ui_contract.css
@@ -7,35 +7,11 @@
   --muted: #666;
 }
 
-.container,
-.header-inner {
+.container {
   max-width: var(--maxw);
   margin-left: auto;
   margin-right: auto;
   padding: 0 var(--gutter);
-}
-
-.header-inner {
-  display: flex;
-  align-items: center;
-}
-
-.hdr-left,
-.hdr-center,
-.hdr-right {
-  flex: 1;
-}
-
-.hdr-center {
-  text-align: center;
-}
-
-.hdr-right {
-  text-align: right;
-}
-
-.mobile-submit {
-  display: none;
 }
 
 .layout,
@@ -52,7 +28,6 @@
   .layout,
   .grid { grid-template-columns: 1fr; }
   .sidebar { grid-column: 1; margin-top: var(--gutter); }
-  .mobile-submit { display: inline-block; }
 }
 
 .post-card {

--- a/templates/base.html
+++ b/templates/base.html
@@ -7,10 +7,7 @@
     <title>{% block title %}SureJan{% endblock %}</title>
 
     <!-- Styles -->
-    <link rel="stylesheet" href="{% static 'css/base.css' %}">
-    <link rel="stylesheet" href="{% static 'css/theme.css' %}">
     <link rel="stylesheet" href="{% static 'css/app.css' %}">
-    <link rel="stylesheet" href="{% static 'css/ui_contract.css' %}">
     {% block head_extra %}{% endblock %}
 
   </head>

--- a/templates/core/base.html
+++ b/templates/core/base.html
@@ -3,7 +3,6 @@
   <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
   <title>{% block title %}SureJan{% endblock %}</title>
   <link rel="stylesheet" href="{% static 'css/app.css' %}">
-  <link rel="stylesheet" href="{% static 'css/ui_contract.css' %}">
 </head>
 <body>
   {% include 'core/partials/header.html' %}


### PR DESCRIPTION
## Summary
- add shared `tokens.css` with color, spacing, radius, font and breakpoint variables
- replace `app.css` with token-based global, header and component styles
- drop legacy header rules and unused CSS links in templates

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68b622627100832ca0f363e87101b801