### PR TITLE
Refactor sidebar CTA markup and update selectors

### DIFF
--- a/core/management/commands/smoke_ui_contract.py
+++ b/core/management/commands/smoke_ui_contract.py
@@ -36,9 +36,8 @@ class Command(BaseCommand):
             self._resolve(self.SUBMIT_NAMES, "submit"), HTTP_HOST="localhost"
         ).content.decode()
 
-        for tid in ("sidebar-submit", "sidebar-astro"):
-            if not self._has(home_html, tid):
-                missing.append(f"✗ missing data-testid={tid} on Home")
+        if not self._has(home_html, "sidebar-cta"):
+            missing.append("✗ missing data-testid=sidebar-cta on Home")
         if not self._has(home_html, "post-card"):
             missing.append("✗ missing data-testid=post-card on Home")
         if not self._has(submit_html, "submit-form"):

--- a/docs/Components-and-Selectors.md
+++ b/docs/Components-and-Selectors.md
@@ -7,8 +7,7 @@ The following UI components must retain these `data-testid` hooks for tests and 
 | Component | Location | Selector |
 |-----------|----------|----------|
 | Post card | Feed lists and post stubs | `data-testid="post-card"` |
-| Sidebar submit CTA | Right sidebar | `data-testid="sidebar-submit"` |
-| Sidebar Anti-Astro link | Right sidebar | `data-testid="sidebar-astro"` |
+| Sidebar CTA block | Right sidebar | `data-testid="sidebar-cta"` |
 | Submit Post form | `/submit` page | `data-testid="submit-form"` |
 
 These selectors are exercised by the `smoke_ui_contract` management command.

--- a/docs/UI-contract.md
+++ b/docs/UI-contract.md
@@ -64,8 +64,7 @@
 +
 +## Test selectors (must exist)
 +- Feed: each post card root has `data-testid="post-card"`
-+- Sidebar CTA: `data-testid="sidebar-submit"`
-+- Anti-Astro link: `data-testid="sidebar-astro"`
++- Sidebar CTA block: `data-testid="sidebar-cta"`
 +- Submit form: `data-testid="submit-form"`
 +
 +## Change control

--- a/templates/core/partials/sidebar_minimal.html
+++ b/templates/core/partials/sidebar_minimal.html
@@ -1,5 +1,5 @@
 <aside class="sidebar-cta" data-testid="sidebar-cta">
-  <a class="btn btn-primary" href="{% url 'post_submit' %}" data-testid="sidebar-submit">Submit Post</a>
-  <p class="muted"><a href="{% url 'transparency_methods' %}" data-testid="sidebar-astro">Anti-Astroturf</a></p>
+  <a class="btn btn-primary" href="{% url 'post_submit' %}">Submit Post</a>
+  <p class="muted"><a href="{% url 'transparency_methods' %}">Anti-Astroturf</a></p>
 </aside>
 

--- a/templates/partials/sidebar_min.html
+++ b/templates/partials/sidebar_min.html
@@ -1,5 +1,5 @@
 <aside class="sidebar-cta" data-testid="sidebar-cta">
-  <a class="btn btn-primary" href="{% url 'post_submit' %}" data-testid="sidebar-submit">Submit Post</a>
-  <p class="muted"><a href="{% url 'transparency_methods' %}" data-testid="sidebar-astro">Anti-Astroturf</a></p>
+  <a class="btn btn-primary" href="{% url 'post_submit' %}">Submit Post</a>
+  <p class="muted"><a href="{% url 'transparency_methods' %}">Anti-Astroturf</a></p>
 </aside>
 

--- a/tests/test_routes_and_selectors.py
+++ b/tests/test_routes_and_selectors.py
@@ -44,8 +44,7 @@ def test_required_selectors_present(client):
     assert home_resp.status_code in {200, 302, 404}
     html = home_resp.content.decode()
     assert 'data-testid="post-card"' in html
-    assert 'data-testid="sidebar-submit"' in html
-    assert 'data-testid="sidebar-astro"' in html
+    assert 'data-testid="sidebar-cta"' in html
 
     client.force_login(user)
     submit_resp = client.get(reverse('post_submit'))


### PR DESCRIPTION
## Summary
- streamline sidebar partials with unified `.sidebar-cta` block and drop old test IDs
- update UI contract docs, management command, and tests for `sidebar-cta`
- document required selectors after removing submit/astro link hooks

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'freezegun')*
- `python manage.py smoke_ui_contract` *(fails: missing data-testid=post-card on Home; missing data-testid=submit-form on Submit)*

------
https://chatgpt.com/codex/tasks/task_e_68b627a7074c832ca798c1d5e3b2a340