### PR TITLE
Unify logo asset and clamp size

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -37,6 +37,12 @@ a:hover { text-decoration: underline; }
   .mobile-submit { display: inline-block; }
 }
 
+.site-logo {
+  display: block;
+  max-height: 28px;
+  width: auto;
+}
+
 /* Components */
 .sidebar-cta {
   border: 1px solid var(--color-border);

--- a/templates/core/base.html
+++ b/templates/core/base.html
@@ -13,7 +13,7 @@
     <div class="header-inner">
       <div class="hdr-left">
           <a href="{% url 'home' %}" class="site-brand" aria-label="Home">
-            <img src="{% static 'img/logo.svg' %}" alt="SureJan">
+            <img class="site-logo" src="{% static 'img/logo.svg' %}" alt="SureJan">
           </a>
       </div>
       <nav class="hdr-center" aria-label="Sort options">


### PR DESCRIPTION
## Summary
- ensure header uses canonical `logo.svg` via `site-logo` class
- add `.site-logo` rules to clamp logo height and maintain aspect ratio

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68b62aabe9f0832c9f16c461c1fdc9a7