### PR TITLE
Align time filter docs and code

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ SureJan is an independent, Brisbane-built community forum inspired by the old Re
 ## Features (MVP)
 
 * **Community Feeds**: Old-Reddit style feeds with sorting options (Best, Hot, New, Rising, Controversial, Top). Pagination set to 25 posts per page.
-* **Time Filters**: Buttons let you view posts from the last day, last 7 days, last month, or last year.
+* **Time Filters**: When sorting by Top, buttons let you view posts from the last 24 hours, last 7 days, or all time.
 * **Seed Communities**: Two initial communities, `news` and `brisbane`, seeded via a management command.
 * **User Accounts**: Username and password based authentication (email optional). Accounts display total “points” (sum of post and comment votes).
 * **Posts**: Supports text or link submissions. Posts can be assigned to communities and rendered with basic Markdown formatting.

--- a/core/services/feed.py
+++ b/core/services/feed.py
@@ -13,19 +13,17 @@ TAB_ORDER = {
 }
 
 RANGE_MAP = {
-    "day": timedelta(days=1),
-    "7days": timedelta(days=7),
-    "month": timedelta(days=30),
-    "year": timedelta(days=365),
+    "24h": timedelta(days=1),
+    "7d": timedelta(days=7),
 }
 
 
-def feed_queryset(tab: str, range_: str):
+def feed_queryset(tab: str, t: str):
     """Return a queryset for the given tab and time range."""
     order = TAB_ORDER.get(tab, TAB_ORDER["hot"])
     qs = Post.objects.select_related("community", "author").order_by(*order)
-    if range_ != "all":
-        delta = RANGE_MAP.get(range_)
+    if t and t != "all":
+        delta = RANGE_MAP.get(t)
         if delta:
             since = timezone.now() - delta
             qs = qs.filter(created_at__gte=since)

--- a/core/tests_feed_tabs.py
+++ b/core/tests_feed_tabs.py
@@ -37,7 +37,7 @@ class FeedTabOrderTests(TestCase):
 
     def _first_post(self, tab):
         resp = self.client.get(
-            reverse("feed_list"), {"tab": tab, "range": "day"}, HTTP_HX_REQUEST="true"
+            reverse("feed_list"), {"tab": tab}, HTTP_HX_REQUEST="true"
         )
         return resp.context["posts"][0]
 

--- a/core/tests_feed_time_filters.py
+++ b/core/tests_feed_time_filters.py
@@ -65,29 +65,22 @@ class FeedRangeMixin:
 
 
 class FeedRangeFilterHTMXTests(FeedRangeMixin, TestCase):
-    def _ids(self, range_):
-        resp = self.client.get(
-            reverse("feed_list"), {"range": range_}, HTTP_HX_REQUEST="true"
-        )
+    def _ids(self, t):
+        params = {"t": t} if t is not None else {}
+        resp = self.client.get(reverse("feed_list"), params, HTTP_HX_REQUEST="true")
         return [p.pk for p in resp.context["posts"]]
 
-    def test_day_filter(self):
-        ids = self._ids("day")
+    def test_24h_filter(self):
+        ids = self._ids("24h")
         self.assertEqual(ids, [self.day_post.pk])
         self.assertNotIn(self.week_post.pk, ids)
 
-    def test_7days_filter(self):
-        ids = self._ids("7days")
+    def test_7d_filter(self):
+        ids = self._ids("7d")
         self.assertSetEqual(set(ids), {self.day_post.pk, self.week_post.pk})
 
-    def test_month_filter(self):
-        ids = self._ids("month")
-        self.assertSetEqual(
-            set(ids), {self.day_post.pk, self.week_post.pk, self.month_post.pk}
-        )
-
-    def test_year_filter(self):
-        ids = self._ids("year")
+    def test_all_filter(self):
+        ids = self._ids("all")
         self.assertSetEqual(
             set(ids),
             {
@@ -95,33 +88,41 @@ class FeedRangeFilterHTMXTests(FeedRangeMixin, TestCase):
                 self.week_post.pk,
                 self.month_post.pk,
                 self.year_post.pk,
+                self.old_post.pk,
             },
         )
-        self.assertNotIn(self.old_post.pk, ids)
+
+    def test_default_all(self):
+        ids = self._ids(None)
+        self.assertSetEqual(
+            set(ids),
+            {
+                self.day_post.pk,
+                self.week_post.pk,
+                self.month_post.pk,
+                self.year_post.pk,
+                self.old_post.pk,
+            },
+        )
 
 
 class FeedRangeFilterHomeTests(FeedRangeMixin, TestCase):
-    def _ids(self, range_):
-        resp = self.client.get(reverse("home"), {"range": range_})
+    def _ids(self, t):
+        params = {"t": t} if t is not None else {}
+        resp = self.client.get(reverse("home"), params)
         return [p.pk for p in resp.context["page"].object_list]
 
-    def test_day_filter(self):
-        ids = self._ids("day")
+    def test_24h_filter(self):
+        ids = self._ids("24h")
         self.assertEqual(ids, [self.day_post.pk])
         self.assertNotIn(self.week_post.pk, ids)
 
-    def test_7days_filter(self):
-        ids = self._ids("7days")
+    def test_7d_filter(self):
+        ids = self._ids("7d")
         self.assertSetEqual(set(ids), {self.day_post.pk, self.week_post.pk})
 
-    def test_month_filter(self):
-        ids = self._ids("month")
-        self.assertSetEqual(
-            set(ids), {self.day_post.pk, self.week_post.pk, self.month_post.pk}
-        )
-
-    def test_year_filter(self):
-        ids = self._ids("year")
+    def test_all_filter(self):
+        ids = self._ids("all")
         self.assertSetEqual(
             set(ids),
             {
@@ -129,6 +130,19 @@ class FeedRangeFilterHomeTests(FeedRangeMixin, TestCase):
                 self.week_post.pk,
                 self.month_post.pk,
                 self.year_post.pk,
+                self.old_post.pk,
             },
         )
-        self.assertNotIn(self.old_post.pk, ids)
+
+    def test_default_all(self):
+        ids = self._ids(None)
+        self.assertSetEqual(
+            set(ids),
+            {
+                self.day_post.pk,
+                self.week_post.pk,
+                self.month_post.pk,
+                self.year_post.pk,
+                self.old_post.pk,
+            },
+        )

--- a/core/tests_hot.py
+++ b/core/tests_hot.py
@@ -69,6 +69,6 @@ class HotRankTests(TestCase):
         )
         p2.recompute_hot()
         resp = self.client.get(
-            reverse("feed_list"), {"tab": "hot", "range": "day"}, HTTP_HX_REQUEST="true"
+            reverse("feed_list"), {"tab": "hot"}, HTTP_HX_REQUEST="true"
         )
         self.assertEqual(resp.context["posts"][0].pk, p1.pk)

--- a/core/views.py
+++ b/core/views.py
@@ -513,25 +513,25 @@ def feed_list(request):
     if tab not in TAB_ORDER:
         tab = "hot"
 
-    range_ = request.GET.get("range", "day")
-    if range_ not in RANGE_MAP and range_ != "all":
-        range_ = "day"
+    t = request.GET.get("t", "all")
+    if t not in RANGE_MAP and t != "all":
+        t = "all"
 
     if request.headers.get("HX-Request") == "true":
         page = int(request.GET.get("page", "1") or 1)
         size = int(request.GET.get("size", PAGE_SIZE) or PAGE_SIZE)
-        qs = feed_queryset(tab, range_)
+        qs = feed_queryset(tab, t)
         paginator = Paginator(qs, size)
         page_obj = paginator.get_page(page)
         ctx = {
             "posts": list(page_obj.object_list),
             "next_page": page_obj.next_page_number() if page_obj.has_next() else None,
             "tab": tab,
-            "range": range_,
+            "t": t,
         }
         return render(request, "core/partials/feed_list.html", ctx)
 
-    ctx = {"tab": tab, "range": range_}
+    ctx = {"tab": tab, "t": t}
     return render(request, "core/feed.html", ctx)
 
 
@@ -543,15 +543,15 @@ def home(request):
     if tab not in TAB_ORDER:
         tab = "hot"
 
-    rng = request.GET.get("range", "day")
-    if rng not in RANGE_MAP and rng != "all":
-        rng = "day"
+    t = request.GET.get("t", "all")
+    if t not in RANGE_MAP and t != "all":
+        t = "all"
 
     page_number = request.GET.get("page") or 1
-    qs = feed_queryset(tab, rng)
+    qs = feed_queryset(tab, t)
     page = Paginator(qs, PAGE_SIZE).get_page(page_number)
 
-    ctx = {"page": page, "tab": tab, "range": rng}
+    ctx = {"page": page, "tab": tab, "t": t}
     return render(request, "core/home.html", ctx)
 
 
@@ -646,16 +646,16 @@ def community(request, slug):
     if sort not in FEED_ORDER:
         sort = "best"
 
-    rng = request.GET.get("range", "day")
-    if rng not in RANGE_MAP and rng != "all":
-        rng = "day"
+    t = request.GET.get("t", "all")
+    if t not in RANGE_MAP and t != "all":
+        t = "all"
 
     order = FEED_ORDER[sort]
     page = int(request.GET.get("page", "1") or 1)
 
     qs = community.posts.select_related("author").order_by(*order)
-    if rng != "all":
-        delta = RANGE_MAP.get(rng)
+    if t and t != "all":
+        delta = RANGE_MAP.get(t)
         if delta:
             since = timezone.now() - delta
             qs = qs.filter(created_at__gte=since)
@@ -668,8 +668,8 @@ def community(request, slug):
     sort_query = ""
     if sort and sort != "best":
         sort_query += f"&sort={sort}"
-    if rng and rng != "day":
-        sort_query += f"&range={rng}"
+    if t and t != "all":
+        sort_query += f"&t={t}"
 
     context = {
         "community": community,
@@ -678,7 +678,7 @@ def community(request, slug):
         "next_page": next_page,
         "sort_query": sort_query,
         "sort": sort,
-        "range": rng,
+        "t": t,
         "sort_tabs": SORT_TABS,
     }
     if request.headers.get("HX-Request") == "true":

--- a/docs/Routes-and-Params.md
+++ b/docs/Routes-and-Params.md
@@ -2,8 +2,9 @@ Change control: If templates affecting this surface change, update this file in 
 
 Route | Params | Defaults | Notes
 ---|---|---|---
-/ | sort, t | sort=hot, t=24h | Front page feed
-/r/<slug> | sort=hot|new|top, t=24h|7d|30d|all | sort=hot, t=24h | Community feed
-/p/<id> | — | — | 404 allowed if not found
-/submit | — | — | GET form, POST create
-/methods | — | — | Static info
+/ | sort, t | sort=hot, t unset | Home feed
+/r/<slug> | sort=hot|new|top, t=24h|7d|all | Time filter only when requested
+/p/<id> | — | — | Post detail; 404 allowed if missing
+/submit | — | — | Submit post
+/mod/astro | — | — | Minimal mod list (reports/high-score)
+/methods | — | — | AstroShield v1 + safety write-up

--- a/docs/V2-onepager.md
+++ b/docs/V2-onepager.md
@@ -29,8 +29,8 @@ Ship a small, fast, safe, **local forum** for 4 starter communities with simple 
 - `/submit` — Submit post.  
 - `/mod/astro` — Minimal mod list (reports/notes + high-score posts).  
 - `/methods` — Public write-up of AstroShield v1 and safety measures.  
-**Sort:** Hot (default), New, Top(24h/7d/All).  
-**Time filter:** Applied **only** when requested (`?t=24h|7d|all`).
+**Sort:** Hot (default), New, Top.
+**Time filter (Top only):** none by default; apply when requested (`?t=24h|7d|all`).
 
 ## 4) UX & Layout (baseline)
 - **Centered feed** (≈700px) with **right gutter** sidebar (300–320px) containing only: **Submit Post** (primary CTA) and **Anti-Astroturf** link.  

--- a/templates/core/feed.html
+++ b/templates/core/feed.html
@@ -2,7 +2,7 @@
 
 {% block content %}
 {% include "core/partials/feed_controls.html" %}
-<div id="feed-list" hx-get="{% url 'feed_list' %}?tab={{ tab }}&range={{ range }}" hx-trigger="load" hx-swap="innerHTML">
+<div id="feed-list" hx-get="{% url 'feed_list' %}?tab={{ tab }}{% if t and t != 'all' %}&t={{ t }}{% endif %}" hx-trigger="load" hx-swap="innerHTML">
   <div class="skeleton" style="height:80px;margin-bottom:1rem;"></div>
   <div class="skeleton" style="height:80px;"></div>
 </div>

--- a/templates/core/home.html
+++ b/templates/core/home.html
@@ -8,12 +8,11 @@
 
         <form method="get" class="range-selector" style="margin-bottom:1rem;">
           <input type="hidden" name="tab" value="{{ tab }}">
-          <label for="range">Time range:</label>
-          <select name="range" id="range">
-            <option value="day" {% if range == 'day' %}selected{% endif %}>Last Day</option>
-            <option value="7days" {% if range == '7days' %}selected{% endif %}>Last 7 Days</option>
-            <option value="month" {% if range == 'month' %}selected{% endif %}>Last Month</option>
-            <option value="year" {% if range == 'year' %}selected{% endif %}>Last Year</option>
+          <label for="t">Time range:</label>
+          <select name="t" id="t">
+            <option value="24h" {% if t == '24h' %}selected{% endif %}>Last 24 Hours</option>
+            <option value="7d" {% if t == '7d' %}selected{% endif %}>Last 7 Days</option>
+            <option value="all" {% if t == 'all' %}selected{% endif %}>All Time</option>
           </select>
           <button type="submit" class="btn">Apply</button>
         </form>
@@ -26,7 +25,7 @@
 
         {% if page.has_next %}
           <p style="text-align:center;margin:16px 0;">
-            <a class="btn" href="?page={{ page.next_page_number }}&tab={{ tab }}&range={{ range }}">Load more</a>
+            <a class="btn" href="?page={{ page.next_page_number }}&tab={{ tab }}{% if t and t != 'all' %}&t={{ t }}{% endif %}">Load more</a>
           </p>
         {% endif %}
       </section>

--- a/templates/core/partials/feed_controls.html
+++ b/templates/core/partials/feed_controls.html
@@ -1,17 +1,16 @@
 <nav id="feed-controls" class="feed-controls" hx-target="#feed-list" aria-label="Feed controls">
   <div class="tabs">
-    <a href="?tab=hot&range={{ range }}" hx-get="{% url 'feed_list' %}?tab=hot&range={{ range }}" hx-push-url="true" hx-target="#feed-list" class="{% if tab == 'hot' %}active{% endif %}" aria-label="Show hot posts">HOT</a>
-    <a href="?tab=new&range={{ range }}" hx-get="{% url 'feed_list' %}?tab=new&range={{ range }}" hx-push-url="true" hx-target="#feed-list" class="{% if tab == 'new' %}active{% endif %}" aria-label="Show new posts">NEW</a>
-    <a href="?tab=rising&range={{ range }}" hx-get="{% url 'feed_list' %}?tab=rising&range={{ range }}" hx-push-url="true" hx-target="#feed-list" class="{% if tab == 'rising' %}active{% endif %}" aria-label="Show rising posts">RISING</a>
-    <a href="?tab=controversial&range={{ range }}" hx-get="{% url 'feed_list' %}?tab=controversial&range={{ range }}" hx-push-url="true" hx-target="#feed-list" class="{% if tab == 'controversial' %}active{% endif %}" aria-label="Show controversial posts">CONTROVERSIAL</a>
-    <a href="?tab=top&range={{ range }}" hx-get="{% url 'feed_list' %}?tab=top&range={{ range }}" hx-push-url="true" hx-target="#feed-list" class="{% if tab == 'top' %}active{% endif %}" aria-label="Show top posts">TOP</a>
+    <a href="?tab=hot{% if t and t != 'all' %}&t={{ t }}{% endif %}" hx-get="{% url 'feed_list' %}?tab=hot{% if t and t != 'all' %}&t={{ t }}{% endif %}" hx-push-url="true" hx-target="#feed-list" class="{% if tab == 'hot' %}active{% endif %}" aria-label="Show hot posts">HOT</a>
+    <a href="?tab=new{% if t and t != 'all' %}&t={{ t }}{% endif %}" hx-get="{% url 'feed_list' %}?tab=new{% if t and t != 'all' %}&t={{ t }}{% endif %}" hx-push-url="true" hx-target="#feed-list" class="{% if tab == 'new' %}active{% endif %}" aria-label="Show new posts">NEW</a>
+    <a href="?tab=rising{% if t and t != 'all' %}&t={{ t }}{% endif %}" hx-get="{% url 'feed_list' %}?tab=rising{% if t and t != 'all' %}&t={{ t }}{% endif %}" hx-push-url="true" hx-target="#feed-list" class="{% if tab == 'rising' %}active{% endif %}" aria-label="Show rising posts">RISING</a>
+    <a href="?tab=controversial{% if t and t != 'all' %}&t={{ t }}{% endif %}" hx-get="{% url 'feed_list' %}?tab=controversial{% if t and t != 'all' %}&t={{ t }}{% endif %}" hx-push-url="true" hx-target="#feed-list" class="{% if tab == 'controversial' %}active{% endif %}" aria-label="Show controversial posts">CONTROVERSIAL</a>
+    <a href="?tab=top{% if t and t != 'all' %}&t={{ t }}{% endif %}" hx-get="{% url 'feed_list' %}?tab=top{% if t and t != 'all' %}&t={{ t }}{% endif %}" hx-push-url="true" hx-target="#feed-list" class="{% if tab == 'top' %}active{% endif %}" aria-label="Show top posts">TOP</a>
   </div>
   <div class="sort">
     <div class="btn-group" role="group" aria-label="Select time range">
-      <button type="button" hx-get="{% url 'feed_list' %}?tab={{ tab }}&range=day" hx-target="#feed-list" hx-push-url="true" class="{% if range == 'day' %}active{% endif %}">Last Day</button>
-      <button type="button" hx-get="{% url 'feed_list' %}?tab={{ tab }}&range=7days" hx-target="#feed-list" hx-push-url="true" class="{% if range == '7days' %}active{% endif %}">Last 7 Days</button>
-      <button type="button" hx-get="{% url 'feed_list' %}?tab={{ tab }}&range=month" hx-target="#feed-list" hx-push-url="true" class="{% if range == 'month' %}active{% endif %}">Last Month</button>
-      <button type="button" hx-get="{% url 'feed_list' %}?tab={{ tab }}&range=year" hx-target="#feed-list" hx-push-url="true" class="{% if range == 'year' %}active{% endif %}">Last Year</button>
+      <button type="button" hx-get="{% url 'feed_list' %}?tab={{ tab }}&t=24h" hx-target="#feed-list" hx-push-url="true" class="{% if t == '24h' %}active{% endif %}">Last 24h</button>
+      <button type="button" hx-get="{% url 'feed_list' %}?tab={{ tab }}&t=7d" hx-target="#feed-list" hx-push-url="true" class="{% if t == '7d' %}active{% endif %}">Last 7d</button>
+      <button type="button" hx-get="{% url 'feed_list' %}?tab={{ tab }}" hx-target="#feed-list" hx-push-url="true" class="{% if not t or t == 'all' %}active{% endif %}">All</button>
     </div>
   </div>
 </nav>

--- a/templates/core/partials/feed_list.html
+++ b/templates/core/partials/feed_list.html
@@ -1,7 +1,11 @@
 {% url 'feed_list' as feed_url %}
 {% for post in posts %}
   {% if forloop.last and next_page %}
-    {% include "partials/feed_card.html" with post=post load_more_url=feed_url|add:'?tab='|add:tab|add:'&range='|add:range|add:'&page='|add:next_page %}
+    {% if t and t != 'all' %}
+      {% include "partials/feed_card.html" with post=post load_more_url=feed_url|add:'?tab='|add:tab|add:'&t='|add:t|add:'&page='|add:next_page %}
+    {% else %}
+      {% include "partials/feed_card.html" with post=post load_more_url=feed_url|add:'?tab='|add:tab|add:'&page='|add:next_page %}
+    {% endif %}
   {% else %}
     {% include "partials/feed_card.html" with post=post %}
   {% endif %}

--- a/templates/partials/sort_tabs.html
+++ b/templates/partials/sort_tabs.html
@@ -5,11 +5,11 @@
       {% if key == 'wiki' %}
         <a href="{% url 'community_wiki' community_slug %}" class="{% if active_sort == key %}active{% endif %}">{{ label }}</a>
       {% else %}
-        <a href="{% url 'community' community_slug %}?sort={{ key }}" class="{% if active_sort == key %}active{% endif %}">{{ label }}</a>
+        <a href="{% url 'community' community_slug %}?sort={{ key }}{% if t and t != 'all' %}&t={{ t }}{% endif %}" class="{% if active_sort == key %}active{% endif %}">{{ label }}</a>
       {% endif %}
     {% else %}
       {% if key != 'wiki' %}
-        <a href="/?sort={{ key }}" class="{% if active_sort == key %}active{% endif %}">{{ label }}</a>
+        <a href="/?sort={{ key }}{% if t and t != 'all' %}&t={{ t }}{% endif %}" class="{% if active_sort == key %}active{% endif %}">{{ label }}</a>
       {% endif %}
     {% endif %}
   {% endfor %}


### PR DESCRIPTION
## Summary
- document default sort and time filter behaviour and include `/mod/astro`
- use `t` param with 24h/7d/all ranges in feeds and services
- update UI/tests for new time filter names

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b638209300832caabd9ff507754f96