### PR TITLE
Align feed tabs and time filters with spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ SureJan is an independent, Brisbane-built community forum inspired by the old Re
 
 ## Features (MVP)
 
-* **Community Feeds**: Old-Reddit style feeds with sorting options (Best, Hot, New, Rising, Controversial, Top). Pagination set to 25 posts per page.
+* **Community Feeds**: Old-Reddit style feeds with sorting options (Hot, New, Top). Pagination set to 25 posts per page.
 * **Time Filters**: When sorting by Top, buttons let you view posts from the last 24 hours, last 7 days, or all time.
 * **Seed Communities**: Two initial communities, `news` and `brisbane`, seeded via a management command.
 * **User Accounts**: Username and password based authentication (email optional). Accounts display total “points” (sum of post and comment votes).

--- a/core/services/feed.py
+++ b/core/services/feed.py
@@ -7,8 +7,6 @@ from ..models import Post
 TAB_ORDER = {
     "hot": ["-hot_rank", "-created_at", "-id"],
     "new": ["-created_at", "-id"],
-    "rising": ["-rising_rank", "-created_at", "-id"],
-    "controversial": ["-controversy", "-created_at", "-id"],
     "top": ["-score", "-created_at", "-id"],
 }
 
@@ -22,7 +20,7 @@ def feed_queryset(tab: str, t: str):
     """Return a queryset for the given tab and time range."""
     order = TAB_ORDER.get(tab, TAB_ORDER["hot"])
     qs = Post.objects.select_related("community", "author").order_by(*order)
-    if t and t != "all":
+    if tab == "top" and t and t != "all":
         delta = RANGE_MAP.get(t)
         if delta:
             since = timezone.now() - delta

--- a/core/tests_feed_tabs.py
+++ b/core/tests_feed_tabs.py
@@ -25,13 +25,9 @@ class FeedTabOrderTests(TestCase):
             title="new",
             score=3,
         )
-        # Give the older post better rankings so ordering is obvious
-        Post.objects.filter(pk=self.old.pk).update(
-            best_rank=10, rising_rank=10, controversy=10, hot_rank=10
-        )
-        Post.objects.filter(pk=self.new.pk).update(
-            best_rank=1, rising_rank=1, controversy=1, hot_rank=1
-        )
+        # Give the older post better hot ranking so ordering is obvious
+        Post.objects.filter(pk=self.old.pk).update(hot_rank=10)
+        Post.objects.filter(pk=self.new.pk).update(hot_rank=1)
         self.old.refresh_from_db()
         self.new.refresh_from_db()
 
@@ -46,12 +42,6 @@ class FeedTabOrderTests(TestCase):
 
     def test_new_order(self):
         self.assertEqual(self._first_post("new").pk, self.new.pk)
-
-    def test_rising_order(self):
-        self.assertEqual(self._first_post("rising").pk, self.old.pk)
-
-    def test_controversial_order(self):
-        self.assertEqual(self._first_post("controversial").pk, self.old.pk)
 
     def test_top_order(self):
         self.assertEqual(self._first_post("top").pk, self.old.pk)
@@ -77,12 +67,8 @@ class CommunityFeedTabOrderTests(TestCase):
             title="new",
             score=3,
         )
-        Post.objects.filter(pk=self.old.pk).update(
-            best_rank=10, rising_rank=10, controversy=10, hot_rank=10
-        )
-        Post.objects.filter(pk=self.new.pk).update(
-            best_rank=1, rising_rank=1, controversy=1, hot_rank=1
-        )
+        Post.objects.filter(pk=self.old.pk).update(hot_rank=10)
+        Post.objects.filter(pk=self.new.pk).update(hot_rank=1)
         self.old.refresh_from_db()
         self.new.refresh_from_db()
 
@@ -91,17 +77,11 @@ class CommunityFeedTabOrderTests(TestCase):
         resp = self.client.get(url)
         return resp.context["posts"][0]
 
-    def test_best_order(self):
-        self.assertEqual(self._first_post("best").pk, self.old.pk)
-
     def test_new_order(self):
         self.assertEqual(self._first_post("new").pk, self.new.pk)
 
-    def test_rising_order(self):
-        self.assertEqual(self._first_post("rising").pk, self.old.pk)
-
-    def test_controversial_order(self):
-        self.assertEqual(self._first_post("controversial").pk, self.old.pk)
-
     def test_top_order(self):
         self.assertEqual(self._first_post("top").pk, self.old.pk)
+
+    def test_hot_order(self):
+        self.assertEqual(self._first_post("hot").pk, self.old.pk)

--- a/core/tests_feed_time_filters.py
+++ b/core/tests_feed_time_filters.py
@@ -66,7 +66,9 @@ class FeedRangeMixin:
 
 class FeedRangeFilterHTMXTests(FeedRangeMixin, TestCase):
     def _ids(self, t):
-        params = {"t": t} if t is not None else {}
+        params = {"tab": "top"}
+        if t is not None:
+            params["t"] = t
         resp = self.client.get(reverse("feed_list"), params, HTTP_HX_REQUEST="true")
         return [p.pk for p in resp.context["posts"]]
 
@@ -108,7 +110,9 @@ class FeedRangeFilterHTMXTests(FeedRangeMixin, TestCase):
 
 class FeedRangeFilterHomeTests(FeedRangeMixin, TestCase):
     def _ids(self, t):
-        params = {"t": t} if t is not None else {}
+        params = {"tab": "top"}
+        if t is not None:
+            params["t"] = t
         resp = self.client.get(reverse("home"), params)
         return [p.pk for p in resp.context["page"].object_list]
 

--- a/core/urls.py
+++ b/core/urls.py
@@ -11,7 +11,7 @@ urlpatterns = [
     path("anti-astroturf", core_views.anti_astroturf, name="anti_astroturf"),
     path("mod/astro", core_views.mod_astro, name="mod_astro"),
     path("methods", core_views.transparency_methods, name="transparency_methods"),
-    path("transparency/posts", core_views.transparency_posts, name="transparency_posts"),
+    path("posts", core_views.transparency_posts, name="transparency_posts"),
     # Markdown preview endpoint
     path("preview", core_views.preview_markdown, name="preview_markdown"),
     path("oembed/preview", core_views.oembed_preview, name="oembed_preview"),

--- a/core/views.py
+++ b/core/views.py
@@ -471,20 +471,14 @@ def regenerate_recovery_codes(request):
 # Mapping of feed tabs to their ordering in the database.  Each ordering
 # includes ``-id`` as the final column to guarantee deterministic results.
 FEED_ORDER = {
-    "best": ["-best_rank", "-created_at", "-id"],
     "hot": ["-hot_rank", "-created_at", "-id"],
     "new": ["-created_at", "-id"],
-    "rising": ["-rising_rank", "-created_at", "-id"],
-    "controversial": ["-controversy", "-created_at", "-id"],
     "top": ["-score", "-created_at", "-id"],
 }
 
 SORT_TABS = [
-    ("best", "BEST"),
     ("hot", "HOT"),
     ("new", "NEW"),
-    ("rising", "RISING"),
-    ("controversial", "CONTROVERSIAL"),
     ("top", "TOP"),
     ("wiki", "WIKI"),
 ]
@@ -513,7 +507,7 @@ def feed_list(request):
     if tab not in TAB_ORDER:
         tab = "hot"
 
-    t = request.GET.get("t", "all")
+    t = request.GET.get("t", "all") if tab == "top" else "all"
     if t not in RANGE_MAP and t != "all":
         t = "all"
 
@@ -543,7 +537,7 @@ def home(request):
     if tab not in TAB_ORDER:
         tab = "hot"
 
-    t = request.GET.get("t", "all")
+    t = request.GET.get("t", "all") if tab == "top" else "all"
     if t not in RANGE_MAP and t != "all":
         t = "all"
 
@@ -642,11 +636,11 @@ def community(request, slug):
         community = Community.objects.get(slug=slug)
     except Community.DoesNotExist:
         return redirect("/")
-    sort = request.GET.get("sort", "best")
+    sort = request.GET.get("sort", "hot")
     if sort not in FEED_ORDER:
-        sort = "best"
+        sort = "hot"
 
-    t = request.GET.get("t", "all")
+    t = request.GET.get("t", "all") if sort == "top" else "all"
     if t not in RANGE_MAP and t != "all":
         t = "all"
 
@@ -654,7 +648,7 @@ def community(request, slug):
     page = int(request.GET.get("page", "1") or 1)
 
     qs = community.posts.select_related("author").order_by(*order)
-    if t and t != "all":
+    if sort == "top" and t and t != "all":
         delta = RANGE_MAP.get(t)
         if delta:
             since = timezone.now() - delta
@@ -666,9 +660,9 @@ def community(request, slug):
     posts = posts[:PAGE_SIZE]
 
     sort_query = ""
-    if sort and sort != "best":
+    if sort and sort != "hot":
         sort_query += f"&sort={sort}"
-    if t and t != "all":
+    if sort == "top" and t and t != "all":
         sort_query += f"&t={t}"
 
     context = {

--- a/docs/Routes-and-Params.md
+++ b/docs/Routes-and-Params.md
@@ -2,9 +2,10 @@ Change control: If templates affecting this surface change, update this file in 
 
 Route | Params | Defaults | Notes
 ---|---|---|---
-/ | sort, t | sort=hot, t unset | Home feed
-/r/<slug> | sort=hot|new|top, t=24h|7d|all | Time filter only when requested
+/ | sort=hot|new|top, t=24h|7d|all | sort=hot, t unset | Home feed; time filter only when sort=top
+/r/<slug> | sort=hot|new|top, t=24h|7d|all | sort=hot, t unset | Time filter only when sort=top
 /p/<id> | — | — | Post detail; 404 allowed if missing
 /submit | — | — | Submit post
 /mod/astro | — | — | Minimal mod list (reports/high-score)
 /methods | — | — | AstroShield v1 + safety write-up
+/posts | — | — | AstroShield flagged posts

--- a/templates/core/community.html
+++ b/templates/core/community.html
@@ -9,6 +9,15 @@
         <p><a class="button" href="{% url 'post_submit' %}" hx-boost="false">Submit</a></p>
       {% endif %}
       {% include "partials/sort_tabs.html" with active_sort=sort community_slug=community_slug sort_tabs=sort_tabs %}
+      {% if sort == 'top' %}
+      <div class="sort">
+        <div class="btn-group" role="group" aria-label="Select time range">
+          <a href="{% url 'community' community_slug %}?sort=top&t=24h" class="{% if t == '24h' %}active{% endif %}">Last 24h</a>
+          <a href="{% url 'community' community_slug %}?sort=top&t=7d" class="{% if t == '7d' %}active{% endif %}">Last 7d</a>
+          <a href="{% url 'community' community_slug %}?sort=top" class="{% if t == 'all' %}active{% endif %}">All</a>
+        </div>
+      </div>
+      {% endif %}
       <div class="feed">
         <div id="feed-list">
           {% include "core/partials/post_list.html" with posts=posts next_page=next_page sort_query=sort_query %}

--- a/templates/core/partials/feed_controls.html
+++ b/templates/core/partials/feed_controls.html
@@ -1,16 +1,16 @@
 <nav id="feed-controls" class="feed-controls" hx-target="#feed-list" aria-label="Feed controls">
   <div class="tabs">
-    <a href="?tab=hot{% if t and t != 'all' %}&t={{ t }}{% endif %}" hx-get="{% url 'feed_list' %}?tab=hot{% if t and t != 'all' %}&t={{ t }}{% endif %}" hx-push-url="true" hx-target="#feed-list" class="{% if tab == 'hot' %}active{% endif %}" aria-label="Show hot posts">HOT</a>
-    <a href="?tab=new{% if t and t != 'all' %}&t={{ t }}{% endif %}" hx-get="{% url 'feed_list' %}?tab=new{% if t and t != 'all' %}&t={{ t }}{% endif %}" hx-push-url="true" hx-target="#feed-list" class="{% if tab == 'new' %}active{% endif %}" aria-label="Show new posts">NEW</a>
-    <a href="?tab=rising{% if t and t != 'all' %}&t={{ t }}{% endif %}" hx-get="{% url 'feed_list' %}?tab=rising{% if t and t != 'all' %}&t={{ t }}{% endif %}" hx-push-url="true" hx-target="#feed-list" class="{% if tab == 'rising' %}active{% endif %}" aria-label="Show rising posts">RISING</a>
-    <a href="?tab=controversial{% if t and t != 'all' %}&t={{ t }}{% endif %}" hx-get="{% url 'feed_list' %}?tab=controversial{% if t and t != 'all' %}&t={{ t }}{% endif %}" hx-push-url="true" hx-target="#feed-list" class="{% if tab == 'controversial' %}active{% endif %}" aria-label="Show controversial posts">CONTROVERSIAL</a>
+    <a href="?tab=hot" hx-get="{% url 'feed_list' %}?tab=hot" hx-push-url="true" hx-target="#feed-list" class="{% if tab == 'hot' %}active{% endif %}" aria-label="Show hot posts">HOT</a>
+    <a href="?tab=new" hx-get="{% url 'feed_list' %}?tab=new" hx-push-url="true" hx-target="#feed-list" class="{% if tab == 'new' %}active{% endif %}" aria-label="Show new posts">NEW</a>
     <a href="?tab=top{% if t and t != 'all' %}&t={{ t }}{% endif %}" hx-get="{% url 'feed_list' %}?tab=top{% if t and t != 'all' %}&t={{ t }}{% endif %}" hx-push-url="true" hx-target="#feed-list" class="{% if tab == 'top' %}active{% endif %}" aria-label="Show top posts">TOP</a>
   </div>
+  {% if tab == 'top' %}
   <div class="sort">
     <div class="btn-group" role="group" aria-label="Select time range">
-      <button type="button" hx-get="{% url 'feed_list' %}?tab={{ tab }}&t=24h" hx-target="#feed-list" hx-push-url="true" class="{% if t == '24h' %}active{% endif %}">Last 24h</button>
-      <button type="button" hx-get="{% url 'feed_list' %}?tab={{ tab }}&t=7d" hx-target="#feed-list" hx-push-url="true" class="{% if t == '7d' %}active{% endif %}">Last 7d</button>
-      <button type="button" hx-get="{% url 'feed_list' %}?tab={{ tab }}" hx-target="#feed-list" hx-push-url="true" class="{% if not t or t == 'all' %}active{% endif %}">All</button>
+      <button type="button" hx-get="{% url 'feed_list' %}?tab=top&t=24h" hx-target="#feed-list" hx-push-url="true" class="{% if t == '24h' %}active{% endif %}">Last 24h</button>
+      <button type="button" hx-get="{% url 'feed_list' %}?tab=top&t=7d" hx-target="#feed-list" hx-push-url="true" class="{% if t == '7d' %}active{% endif %}">Last 7d</button>
+      <button type="button" hx-get="{% url 'feed_list' %}?tab=top" hx-target="#feed-list" hx-push-url="true" class="{% if t == 'all' %}active{% endif %}">All</button>
     </div>
   </div>
+  {% endif %}
 </nav>

--- a/templates/partials/sort_tabs.html
+++ b/templates/partials/sort_tabs.html
@@ -5,11 +5,11 @@
       {% if key == 'wiki' %}
         <a href="{% url 'community_wiki' community_slug %}" class="{% if active_sort == key %}active{% endif %}">{{ label }}</a>
       {% else %}
-        <a href="{% url 'community' community_slug %}?sort={{ key }}{% if t and t != 'all' %}&t={{ t }}{% endif %}" class="{% if active_sort == key %}active{% endif %}">{{ label }}</a>
+        <a href="{% url 'community' community_slug %}?sort={{ key }}{% if key == 'top' and t and t != 'all' %}&t={{ t }}{% endif %}" class="{% if active_sort == key %}active{% endif %}">{{ label }}</a>
       {% endif %}
     {% else %}
       {% if key != 'wiki' %}
-        <a href="/?sort={{ key }}{% if t and t != 'all' %}&t={{ t }}{% endif %}" class="{% if active_sort == key %}active{% endif %}">{{ label }}</a>
+        <a href="/?sort={{ key }}{% if key == 'top' and t and t != 'all' %}&t={{ t }}{% endif %}" class="{% if active_sort == key %}active{% endif %}">{{ label }}</a>
       {% endif %}
     {% endif %}
   {% endfor %}


### PR DESCRIPTION
## Summary
- Limit feed tabs to Hot, New, and Top
- Apply time filters only on Top and document new /posts transparency route
- Rename transparency posts path and update docs/README

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68b63ada6c7c832c83e0f4f45bf8b338