### PR TITLE
Switch to light theme

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -1,11 +1,17 @@
 @import "tokens.css";
 
+:root{
+  --color-bg:#ffffff;
+  --color-surface:#f5f5f5;
+  --color-text:#111111;
+}
+
 html,body{background:var(--color-bg); color:var(--color-text); font-family:var(--font-sans);}
 
 header.header-bar{
   position:sticky; top:0; z-index:1000;
   background:var(--color-surface);
-  border-bottom:1px solid #23232a;
+  border-bottom:1px solid #e0e0e0;
   display:flex; align-items:center; gap:var(--space-4);
   padding: var(--space-3) var(--space-6);
 }
@@ -13,7 +19,7 @@ header.header-bar{
 .site-logo{max-height:28px;width:auto;display:block}
 
 .nav-links a{ padding:4px 8px; border-radius:6px; text-decoration:none; }
-.nav-links a[aria-current="page"]{ background:rgba(255,255,255,.06); }
+.nav-links a[aria-current="page"]{ background:rgba(0,0,0,.06); }
 
 .sidebar-cta{ background:var(--color-surface); padding:var(--space-5); border-radius:var(--radius-lg); }
 .post-card{
@@ -22,4 +28,4 @@ header.header-bar{
   border-radius:var(--radius-lg);
   margin-bottom:var(--space-5);
 }
-.empty-state{ color:#a7a7b3; padding:var(--space-6) 0; text-align:center; }
+.empty-state{ color:#666666; padding:var(--space-6) 0; text-align:center; }


### PR DESCRIPTION
## Summary
- Introduce light color variables to replace dark theme defaults
- Adjust header border and nav link highlight for light theme
- Tweak neutral text color for empty state

## Testing
- `pip install pytest-django`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b64f9427d0832cb04418aac26be988