### PR TITLE
Add hourly AstroShield score recomputation and scheduler note

### DIFF
--- a/core/management/commands/astro_recompute.py
+++ b/core/management/commands/astro_recompute.py
@@ -1,0 +1,24 @@
+from django.core.management.base import BaseCommand
+from django.contrib.auth import get_user_model
+from django.core.cache import cache
+
+from core.utils.astro import compute_astro_score
+
+
+User = get_user_model()
+
+
+class Command(BaseCommand):
+    help = "Recompute AstroShield scores; cache astro_score:* and astro_band:* for 60 minutes."
+
+    def handle(self, *args, **opts):
+        n = 0
+        qs = User.objects.filter(is_active=True).only("id", "date_joined")
+        for user in qs.iterator():
+            score, band = compute_astro_score(user)
+            cache.set(f"astro_score:{user.id}", score, 3600)
+            cache.set(f"astro_band:{user.id}", band, 3600)
+            n += 1
+        self.stdout.write(
+            self.style.SUCCESS(f"AstroShield recompute complete ({n} users)")
+        )

--- a/core/utils/astro.py
+++ b/core/utils/astro.py
@@ -1,0 +1,31 @@
+from django.utils import timezone
+
+
+def compute_astro_score(user) -> tuple[int, str]:
+    """
+    Return (score 0..100, band 'green'|'amber'|'red').
+    Minimal heuristics, no DB writes.
+    """
+    now = timezone.now()
+    age_days = (now - getattr(user, "date_joined", now)).days
+    score = 0
+
+    # Simple signals (replace/extend later without API change)
+    if age_days < 3:  # very new account
+        score += 25
+    recent_vote_rate = getattr(user, "recent_vote_rate", 0)  # optional external calc
+    if recent_vote_rate > 40:
+        score += 40
+    elif recent_vote_rate > 20:
+        score += 25
+    recent_posts = getattr(user, "recent_posts_count", 0)
+    if recent_posts > 10:
+        score += 20
+    if getattr(user, "discuss_ratio_low", False):
+        score += 10
+    if getattr(user, "domain_repeat_high", False):
+        score += 10
+
+    score = max(0, min(100, score))
+    band = "green" if score < 40 else ("amber" if score < 70 else "red")
+    return score, band

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -31,3 +31,8 @@ flyctl logs -a surejan | Select-String -Pattern "ERROR|Traceback|favicon|collect
 * `/r/news/` → "Submit" visible (logged-in), post appears in feed.
 * Vote/comment work; anonymous users get redirected to login for writes.
 * `/secret-admin/` → admin login loads (only from allowlisted IPs if set).
+
+### AstroShield scheduler (minimal)
+Run hourly (cron or CI runner):
+flyctl ssh console -a surejan -C "python manage.py astro_recompute"
+


### PR DESCRIPTION
## Summary
- add compute_astro_score utility for minimal AstroShield heuristics
- add astro_recompute management command to cache user scores for 1 hour
- document hourly AstroShield scheduler in deploy notes

## Testing
- `python manage.py astro_recompute`
- `python - <<'PY' ...` (TTL 3600)
- `python manage.py test` *(fails: test_new_order, test_24h_filter, test_7d_filter)*

------
https://chatgpt.com/codex/tasks/task_e_68b65d66f378832c9ebfb155b6860050