### PR TITLE
Add communities index and sorting filters

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -23,6 +23,8 @@ urlpatterns = [
     path("terms/", TemplateView.as_view(template_name="legal/terms.html"), name="terms"),
     path("privacy/", TemplateView.as_view(template_name="legal/privacy.html"), name="privacy"),
     path("rules/", TemplateView.as_view(template_name="legal/rules.html"), name="rules"),
+    path("r", core.communities_index, name="communities_index"),
+    path("r/<slug:slug>", core.community, name="community"),
     path("", include("core.urls")),
 ]
 

--- a/core/tests_communities_index.py
+++ b/core/tests_communities_index.py
@@ -1,0 +1,13 @@
+from django.test import TestCase
+from django.urls import reverse
+
+
+class CommunitiesIndexTests(TestCase):
+    def test_lists_communities(self):
+        resp = self.client.get(reverse("communities_index"))
+        for name in ["News", "Brisbane", "Politics", "Social"]:
+            self.assertContains(resp, name)
+
+    def test_header_sort_highlight(self):
+        resp = self.client.get(reverse("communities_index"), {"sort": "new"})
+        self.assertContains(resp, 'href="?sort=new" aria-current="page"')

--- a/core/tests_feed_time_filters.py
+++ b/core/tests_feed_time_filters.py
@@ -66,7 +66,7 @@ class FeedRangeMixin:
 
 class FeedRangeFilterHTMXTests(FeedRangeMixin, TestCase):
     def _ids(self, t):
-        params = {"tab": "top"}
+        params = {"sort": "top"}
         if t is not None:
             params["t"] = t
         resp = self.client.get(reverse("feed_list"), params, HTTP_HX_REQUEST="true")
@@ -110,11 +110,42 @@ class FeedRangeFilterHTMXTests(FeedRangeMixin, TestCase):
 
 class FeedRangeFilterHomeTests(FeedRangeMixin, TestCase):
     def _ids(self, t):
-        params = {"tab": "top"}
+        params = {"sort": "top"}
         if t is not None:
             params["t"] = t
         resp = self.client.get(reverse("home"), params)
         return [p.pk for p in resp.context["page"].object_list]
+
+    def test_24h_filter(self):
+        ids = self._ids("24h")
+        self.assertEqual(ids, [self.day_post.pk])
+        self.assertNotIn(self.week_post.pk, ids)
+
+    def test_7d_filter(self):
+        ids = self._ids("7d")
+        self.assertSetEqual(set(ids), {self.day_post.pk, self.week_post.pk})
+
+    def test_all_filter(self):
+        ids = self._ids("all")
+        self.assertSetEqual(
+            set(ids),
+            {
+                self.day_post.pk,
+                self.week_post.pk,
+                self.month_post.pk,
+                self.year_post.pk,
+                self.old_post.pk,
+            },
+        )
+
+
+class CommunityRangeFilterTests(FeedRangeMixin, TestCase):
+    def _ids(self, t):
+        params = {"sort": "top"}
+        if t is not None:
+            params["t"] = t
+        resp = self.client.get(reverse("community", args=[self.community.slug]), params)
+        return [p.pk for p in resp.context["posts"]]
 
     def test_24h_filter(self):
         ids = self._ids("24h")

--- a/core/urls.py
+++ b/core/urls.py
@@ -38,7 +38,6 @@ urlpatterns = [
     path("c/new/", core_views.create_community, name="community_create"),
 
     # Community pages (slug-based, /r/<slug>/…)
-    path("r/<slug:slug>", core_views.community, name="community"),
     path("r/<slug:slug>/wiki", core_views.community_wiki, name="community_wiki"),
 
     # Post detail (nested under community, with id + slug)

--- a/core/views.py
+++ b/core/views.py
@@ -468,14 +468,6 @@ def regenerate_recovery_codes(request):
     return redirect("recovery_codes")
 
 
-# Mapping of feed tabs to their ordering in the database.  Each ordering
-# includes ``-id`` as the final column to guarantee deterministic results.
-FEED_ORDER = {
-    "hot": ["-hot_rank", "-created_at", "-id"],
-    "new": ["-created_at", "-id"],
-    "top": ["-score", "-created_at", "-id"],
-}
-
 SORT_TABS = [
     ("hot", "HOT"),
     ("new", "NEW"),
@@ -635,14 +627,11 @@ def post_submit(request):
     return render(request, "core/post_submit.html", {"form": form})
 
 
-def community(request, slug):
-    """Display posts for a specific community."""
-    try:
-        community = Community.objects.get(slug=slug)
-    except Community.DoesNotExist:
-        return redirect("/")
+@require_GET
+def communities_index(request):
+    """List available communities."""
     sort = request.GET.get("sort", "hot")
-    if sort not in FEED_ORDER:
+    if sort not in TAB_ORDER:
         sort = "hot"
 
     t = request.GET.get("t")
@@ -652,7 +641,41 @@ def community(request, slug):
     if sort == "top" and t is None:
         t = "all"
 
-    order = FEED_ORDER[sort]
+    communities = [
+        {"slug": "news", "name": "News"},
+        {"slug": "brisbane", "name": "Brisbane"},
+        {"slug": "politics", "name": "Politics"},
+        {"slug": "social", "name": "Social"},
+    ]
+
+    qs = ""
+    if sort != "hot":
+        qs = f"?sort={sort}"
+        if sort == "top" and t and t != "all":
+            qs += f"&t={t}"
+
+    ctx = {"communities": communities, "qs": qs, "sort": sort, "t": t}
+    return render(request, "core/communities_index.html", ctx)
+
+
+def community(request, slug):
+    """Display posts for a specific community."""
+    try:
+        community = Community.objects.get(slug=slug)
+    except Community.DoesNotExist:
+        return redirect("/")
+    sort = request.GET.get("sort", "hot")
+    if sort not in TAB_ORDER:
+        sort = "hot"
+
+    t = request.GET.get("t")
+    allowed = {"24h", "7d", "all"}
+    if sort != "top" or t not in allowed:
+        t = None
+    if sort == "top" and t is None:
+        t = "all"
+
+    order = TAB_ORDER[sort]
     page = int(request.GET.get("page", "1") or 1)
 
     qs = community.posts.select_related("author").order_by(*order)

--- a/templates/core/base.html
+++ b/templates/core/base.html
@@ -10,9 +10,12 @@
 </head>
 <body>
   <header class="header-bar" data-testid="header-bar">
-    <a class="header-logo" href="{% url 'home' %}">
-      <img class="site-logo" src="{% static 'img/Surejanlogo.png' %}" alt="SureJan">
-    </a>
+    <div class="nav-left">
+      <a class="header-logo" href="{% url 'home' %}">
+        <img class="site-logo" src="{% static 'img/Surejanlogo.png' %}" alt="SureJan">
+      </a>
+      <a class="communities-link" href="{% url 'communities_index' %}">Communities ▾</a>
+    </div>
     <nav id="sort-tabs" class="nav-tabs" aria-label="Sort">
       <a href="?sort=hot"{% if request.GET.sort|default:'hot' == 'hot' %} aria-current="page"{% endif %}>Hot</a>
       <a href="?sort=new"{% if request.GET.sort == 'new' %} aria-current="page"{% endif %}>New</a>

--- a/templates/core/communities_index.html
+++ b/templates/core/communities_index.html
@@ -1,0 +1,10 @@
+{% extends "core/base.html" %}
+{% block content %}
+<div class="shell">
+  <ul>
+    {% for c in communities %}
+      <li><a href="/r/{{ c.slug }}{{ qs }}">{{ c.name }}</a></li>
+    {% endfor %}
+  </ul>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Add global header link to `/r` with communities dropdown and center sort tabs
- Serve a hard-coded community directory and wire `/r/<slug>` routes at root
- Support `sort` and time range filters across home and community feeds

## Testing
- `pytest`
- `pytest core/tests_feed_time_filters.py core/tests_communities_index.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6626c5eec832cb48c0f87d258087b