### PR TITLE
Add shared sidebar and responsive two-column layout

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -1,9 +1,13 @@
 @import "tokens.css";
 
+/* Light theme variables */
 :root{
   --color-bg:#ffffff;
   --color-surface:#f5f5f5;
   --color-text:#111111;
+  --color-border:#e0e0e0;
+  --feed-width:700px;
+  --sidebar-width:300px;
 }
 
 html,body{background:var(--color-bg); color:var(--color-text); font-family:var(--font-sans);}
@@ -11,7 +15,7 @@ html,body{background:var(--color-bg); color:var(--color-text); font-family:var(-
 header.header-bar{
   position:sticky; top:0; z-index:1000;
   background:var(--color-surface);
-  border-bottom:1px solid #e0e0e0;
+  border-bottom:1px solid var(--color-border);
   display:flex; align-items:center; gap:var(--space-4);
   padding: var(--space-3) var(--space-6);
 }
@@ -29,3 +33,14 @@ header.header-bar{
   margin-bottom:var(--space-5);
 }
 .empty-state{ color:#666666; padding:var(--space-6) 0; text-align:center; }
+
+/* Two-column layout -------------------------------------------------- */
+.layout-grid{ display:flex; flex-direction:column; gap:var(--space-6); }
+.feed-col{ width:100%; }
+.sidebar-col{ width:100%; }
+
+@media (min-width:1024px){
+  .layout-grid{ flex-direction:row; align-items:flex-start; justify-content:center; }
+  .feed-col{ flex:0 0 var(--feed-width); }
+  .sidebar-col{ flex:0 0 var(--sidebar-width); }
+}

--- a/templates/core/community.html
+++ b/templates/core/community.html
@@ -24,9 +24,8 @@
         </div>
       </div>
     </main>
-    <div class="gutter" aria-hidden="true"></div>
     <aside class="sidebar-col">
-      {% include "core/partials/sidebar_minimal.html" %}
+      {% include "core/partials/sidebar.html" %}
     </aside>
   </div>
 </div>

--- a/templates/core/home.html
+++ b/templates/core/home.html
@@ -30,9 +30,8 @@
         {% endif %}
       </section>
     </main>
-    <div class="gutter" aria-hidden="true"></div>
     <aside class="sidebar-col">
-      {% include "core/partials/sidebar_minimal.html" %}
+      {% include "core/partials/sidebar.html" %}
     </aside>
   </div>
 </div>

--- a/templates/core/partials/sidebar.html
+++ b/templates/core/partials/sidebar.html
@@ -1,0 +1,4 @@
+<div class="sidebar-cta" data-testid="sidebar-cta">
+  <a class="btn btn-primary" href="{% url 'post_submit' %}" data-testid="sidebar-submit">Submit Post</a>
+  <p class="muted"><a href="{% url 'transparency_methods' %}" data-testid="sidebar-astro">Anti-Astroturf</a></p>
+</div>

--- a/tests/test_routes_and_selectors.py
+++ b/tests/test_routes_and_selectors.py
@@ -1,4 +1,6 @@
 import pytest
+from django.contrib.auth import get_user_model
+from core.models import Community
 
 @pytest.mark.django_db
 def test_home_route_renders(client):
@@ -25,6 +27,22 @@ def test_required_selectors_on_home(client):
     html = client.get("/").content.decode()
     assert 'data-testid="header-bar"' in html
     assert ('data-testid="post-card"' in html) or ('data-testid="empty-state"' in html)
+
+
+@pytest.mark.django_db
+def test_sidebar_links_home(client):
+    html = client.get("/").content.decode()
+    assert 'data-testid="sidebar-submit"' in html
+    assert 'data-testid="sidebar-astro"' in html
+
+
+@pytest.mark.django_db
+def test_sidebar_links_community(client):
+    user = get_user_model().objects.create_user(username="u", password="pw")
+    Community.objects.create(slug="test", name="Test", title="Test", created_by=user)
+    html = client.get("/r/test").content.decode()
+    assert 'data-testid="sidebar-submit"' in html
+    assert 'data-testid="sidebar-astro"' in html
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Summary
- Introduce shared sidebar partial with Submit Post and Anti-Astroturf links
- Implement responsive two-column layout for home and community pages with light theme styles
- Test presence of sidebar links on home and community pages

## Testing
- `MEDIA_URL=/media/ AWS_STORAGE_BUCKET_NAME=bucket AWS_ACCESS_KEY_ID=foo AWS_SECRET_ACCESS_KEY=bar AWS_S3_ENDPOINT_URL=http://example.com pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b664352cd8832c9af0c2a37daf8f69