### PR TITLE
Add safe embed helper and image carousel

### DIFF
--- a/core/tests/test_post_detail_media.py
+++ b/core/tests/test_post_detail_media.py
@@ -15,7 +15,7 @@ class PostDetailMediaTests(TestCase):
             slug="test", name="Test", title="Test", created_by=self.user
         )
 
-    @patch("core.views.fetch_oembed")
+    @patch("core.utils.embeds.fetch_oembed")
     def test_youtube_embed_has_placeholder(self, mock_oembed):
         mock_oembed.return_value = {
             "type": "embed",
@@ -35,7 +35,7 @@ class PostDetailMediaTests(TestCase):
         self.assertContains(resp, 'data-src="https://www.youtube-nocookie.com/embed/abc"')
         self.assertContains(resp, 'href="https://www.youtube.com/watch?v=abc"')
 
-    @patch("core.views.fetch_oembed")
+    @patch("core.utils.embeds.fetch_oembed")
     def test_rumble_embed_has_placeholder(self, mock_oembed):
         mock_oembed.return_value = {
             "type": "embed",

--- a/core/utils/embeds.py
+++ b/core/utils/embeds.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import re
+from urllib.parse import urlparse
+
+from django.conf import settings
+from django.utils.html import escape
+
+from core.oembed import fetch_oembed
+
+
+def build_embed_html(url: str) -> str:
+    """Return safe embed placeholder HTML or a link card for ``url``.
+
+    Supports YouTube, Rumble, and Twitter/X embeds rendered behind a click-to-
+    play consent gate. Unrecognized providers fall back to a simple link card.
+    """
+    if not url:
+        return ""
+
+    parsed = urlparse(url)
+    domain = parsed.netloc.lower()
+
+    try:
+        data = fetch_oembed(url)
+    except Exception:
+        data = {}
+
+    if data.get("type") != "embed":
+        return (
+            f'<div class="link-card"><a href="{escape(url)}" '
+            f'rel="noopener nofollow">{escape(parsed.netloc)}</a></div>'
+        )
+
+    thumb = data.get("thumbnail_url", "")
+    html = data.get("html", "")
+
+    src = ""
+    if "youtube" in domain:
+        vid = None
+        for pattern in [r"v=([\w-]{11})", r"be/([\w-]{11})", r"embed/([\w-]{11})"]:
+            m = re.search(pattern, url)
+            if m:
+                vid = m.group(1)
+                break
+        if not vid:
+            m = re.search(r"embed/([\w-]{11})", html)
+            if m:
+                vid = m.group(1)
+        if not vid:
+            return (
+                f'<div class="link-card"><a href="{escape(url)}" '
+                f'rel="noopener nofollow">{escape(parsed.netloc)}</a></div>'
+            )
+        if not thumb:
+            thumb = f"https://i.ytimg.com/vi/{vid}/hqdefault.jpg"
+        src = f"https://www.youtube-nocookie.com/embed/{vid}"
+    elif "rumble.com" in domain:
+        m = re.search(r'src="([^"]+)"', html)
+        if not m:
+            return (
+                f'<div class="link-card"><a href="{escape(url)}" '
+                f'rel="noopener nofollow">{escape(parsed.netloc)}</a></div>'
+            )
+        src = m.group(1)
+    elif "twitter.com" in domain or "x.com" in domain:
+        if not getattr(settings, "ENABLE_TWITTER_EMBEDS", False):
+            return (
+                f'<div class="link-card"><a href="{escape(url)}" '
+                f'rel="noopener nofollow">{escape(parsed.netloc)}</a></div>'
+            )
+        m = re.search(r"status/(\d+)", url)
+        if not m:
+            return (
+                f'<div class="link-card"><a href="{escape(url)}" '
+                f'rel="noopener nofollow">{escape(parsed.netloc)}</a></div>'
+            )
+        src = f"https://platform.twitter.com/embed/Tweet.html?id={m.group(1)}"
+    else:
+        return (
+            f'<div class="link-card"><a href="{escape(url)}" '
+            f'rel="noopener nofollow">{escape(parsed.netloc)}</a></div>'
+        )
+
+    thumb_html = (
+        f'<img src="{escape(thumb)}" alt="" loading="lazy" decoding="async" '
+        'referrerpolicy="no-referrer" '
+        'style="width:100%;height:100%;object-fit:cover;">'
+        if thumb
+        else ""
+    )
+
+    return (
+        f'<div class="post-embed" data-src="{escape(src)}" '
+        'style="position:relative;padding-top:56.25%;overflow:hidden;">'
+        f'<a href="{escape(url)}" rel="noopener nofollow" '
+        'style="position:absolute;top:0;left:0;width:100%;height:100%;display:block;">'
+        f'{thumb_html}</a></div>'
+    )

--- a/core/views.py
+++ b/core/views.py
@@ -50,6 +50,7 @@ from .pagination import PAGE_SIZE
 from .services.astro import compute_post_signals, compute_user_post_summary
 from .services.feed import TAB_ORDER, RANGE_MAP, feed_queryset
 from .oembed import fetch_oembed
+from .utils.embeds import build_embed_html
 
 
 def _is_banned(user):
@@ -726,13 +727,13 @@ def post_detail(request, community, pk, slug):
     )
     comments = post.comments.select_related("author").order_by("path")
     form = CommentForm()
-    embed, _ = _build_embed(post.content_url)
+    embed_html = build_embed_html(post.content_url)
     images = list(post.image_links.all())
     context = {
         "post": post,
         "comments": comments,
         "form": form,
-        "embed": embed,
+        "embed_html": embed_html,
         "images": images,
     }
     return render(request, "core/post_detail.html", context)
@@ -744,13 +745,13 @@ def post_detail_id(request, pk):
     post = get_object_or_404(Post.objects.prefetch_related("image_links"), pk=pk)
     comments = post.comments.select_related("author").order_by("path")
     form = CommentForm()
-    embed, _ = _build_embed(post.content_url)
+    embed_html = build_embed_html(post.content_url)
     images = list(post.image_links.all())
     context = {
         "post": post,
         "comments": comments,
         "form": form,
-        "embed": embed,
+        "embed_html": embed_html,
         "images": images,
     }
     return render(request, "core/post_detail.html", context)

--- a/templates/core/post_detail.html
+++ b/templates/core/post_detail.html
@@ -37,22 +37,14 @@
           {% if post.heading %}
             <h2 class="post-heading">{{ post.heading }}</h2>
           {% endif %}
-          {% if embed %}
-            <div class="post-embed" data-src="{{ embed.src }}" style="position:relative;padding-top:56.25%;overflow:hidden;">
-              <a href="{{ embed.url }}" rel="noopener nofollow" style="position:absolute;top:0;left:0;width:100%;height:100%;display:block;">
-                <img src="{{ embed.thumb }}" alt="" loading="lazy" decoding="async" referrerpolicy="no-referrer" style="width:100%;height:100%;object-fit:cover;">
-              </a>
-            </div>
-          {% elif post.image %}
-            <img src="{{ post.image.url }}" alt="" class="post-image" loading="lazy" decoding="async" referrerpolicy="no-referrer">
+          {% if post.content_url %}
+            {{ embed_html|safe }}
           {% elif images %}
             {% include "partials/post_images.html" with images=images %}
+          {% elif post.image %}
+            <img src="{{ post.image.url }}" alt="" class="post-image" loading="lazy" decoding="async" referrerpolicy="no-referrer">
           {% elif post.embed_html %}
             <div class="post-embed">{{ post.embed_html|safe }}</div>
-          {% elif post.content_url %}
-            <div class="link-card">
-              <a href="{{ post.content_url }}" rel="noopener nofollow">{{ post.link_domain }}</a>
-            </div>
           {% endif %}
           {% if post.body %}
             <div class="post-caption prose">
@@ -104,6 +96,7 @@
 
 {% block scripts %}
 {{ block.super }}
+<script src="{% static 'js/embeds.js' %}" defer></script>
 <script src="{% static 'js/editor.js' %}" defer></script>
 <script src="{% static 'js/comments.js' %}" defer></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add `build_embed_html` utility for consent-gated embeds with YouTube-nocookie, Rumble, and X
- render link embeds with helper in post detail template and support image carousel
- load client script for click-to-play embeds

## Testing
- `MEDIA_URL=/media/ AWS_STORAGE_BUCKET_NAME=bucket AWS_ACCESS_KEY_ID=key AWS_SECRET_ACCESS_KEY=secret AWS_S3_ENDPOINT_URL=http://s3.local python manage.py test` *(fails: failures=4, errors=4)*

------
https://chatgpt.com/codex/tasks/task_e_68b66ac81c38832c8e79ff98cb22d9af