### PR TITLE
Add moderation helpers and domain throttle

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,0 +1,18 @@
+name: smoke
+on: { push: { branches: [main] }, pull_request: {} }
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run smoke tests
+        env:
+          DJANGO_SETTINGS_MODULE: config.settings
+        run: pytest tests/test_smoke_v2.py -q

--- a/core/mod.py
+++ b/core/mod.py
@@ -1,0 +1,33 @@
+from datetime import timedelta
+from django.core.cache import cache
+
+THROTTLE_TTL = 7 * 24 * 60 * 60  # 7 days
+KEY_PREFIX = "domain-throttle:"
+
+def domain_weight(domain: str) -> float:
+    """Return weight for a given domain (0.5 if throttled)."""
+    if not domain:
+        return 1.0
+    return 0.5 if cache.get(f"{KEY_PREFIX}{domain.lower()}") else 1.0
+
+def set_domain_throttle(domain: str, enabled: bool) -> None:
+    """Toggle throttling for a domain and update existing posts."""
+    domain = domain.lower()
+    key = f"{KEY_PREFIX}{domain}"
+    if enabled:
+        cache.set(key, True, THROTTLE_TTL)
+        from .models import Post
+        Post.objects.filter(link_domain=domain).update(domain_weight=0.5)
+    else:
+        cache.delete(key)
+        from .models import Post
+        Post.objects.filter(link_domain=domain).update(domain_weight=1.0)
+
+def remove_post(post, by_user):
+    """Soft remove a post."""
+    post.soft_delete(by_user)
+
+def lock_post(post, locked: bool) -> None:
+    """Lock or unlock a post's comments."""
+    post.is_locked = locked
+    post.save(update_fields=["is_locked"])

--- a/core/models.py
+++ b/core/models.py
@@ -22,12 +22,12 @@ import os
 from .ranking import recompute_post_ranks
 
 
-MAX_BYTES = 5 * 1024 * 1024
+MAX_BYTES = 4 * 1024 * 1024
 
 
 def validate_image_file(f):
     if f.size > MAX_BYTES:
-        raise forms.ValidationError("Image too large (max 5MB).")
+        raise forms.ValidationError("Image too large (max 4MB).")
     try:
         Image.open(f).verify()
     except Exception:
@@ -170,6 +170,13 @@ class Post(models.Model):
 
         if self.content_url:
             self.link_domain = urlparse(self.content_url).netloc
+
+        # Apply domain throttling weight on every save
+        from .mod import domain_weight  # avoid circular import at module load
+        if self.link_domain:
+            self.domain_weight = domain_weight(self.link_domain)
+        else:
+            self.domain_weight = 1.0
 
         if self.image:
             resized = _resize_img(self.image)

--- a/core/services/feed.py
+++ b/core/services/feed.py
@@ -1,13 +1,14 @@
 from datetime import timedelta
 
 from django.utils import timezone
+from django.db.models import F
 
 from ..models import Post
 
 TAB_ORDER = {
-    "hot": ["-hot_rank", "-created_at", "-id"],
+    "hot": ["-weighted_hot", "-created_at", "-id"],
     "new": ["-created_at", "-id"],
-    "top": ["-score", "-created_at", "-id"],
+    "top": ["-weighted_score", "-created_at", "-id"],
 }
 
 RANGE_MAP = {
@@ -16,10 +17,14 @@ RANGE_MAP = {
 }
 
 
-def feed_queryset(tab: str, t: str):
+def feed_queryset(tab: str, t: str, base_qs=None):
     """Return a queryset for the given tab and time range."""
     order = TAB_ORDER.get(tab, TAB_ORDER["hot"])
-    qs = Post.objects.select_related("community", "author").order_by(*order)
+    qs = base_qs if base_qs is not None else Post.objects.select_related("community", "author")
+    qs = qs.annotate(
+        weighted_hot=F("hot_rank") * F("domain_weight"),
+        weighted_score=F("score") * F("domain_weight"),
+    ).order_by(*order)
     if tab == "top" and t and t != "all":
         delta = RANGE_MAP.get(t)
         if delta:

--- a/core/tests_mod_actions.py
+++ b/core/tests_mod_actions.py
@@ -1,0 +1,47 @@
+from django.contrib.auth import get_user_model
+from django.core.cache import cache
+from django.test import TestCase
+from django.urls import reverse
+
+from .models import Comment, Community, Post
+
+
+class ModActionTests(TestCase):
+    def setUp(self):
+        cache.clear()
+        U = get_user_model()
+        self.user = U.objects.create_user("alice", password="pwd")
+        self.staff = U.objects.create_user("mod", password="pwd", is_staff=True)
+        self.community = Community.objects.create(slug="t", name="Test", title="Test", created_by=self.user)
+
+    def test_moderator_remove_shows_message(self):
+        post = Post.objects.create(community=self.community, author=self.user, post_type="text", title="Hello")
+        self.client.login(username="mod", password="pwd")
+        resp = self.client.post(reverse("post_remove", args=[post.pk]), HTTP_HX_REQUEST="true")
+        self.assertIn(b"Removed by moderators.", resp.content)
+
+    def test_author_soft_delete_message(self):
+        post = Post.objects.create(community=self.community, author=self.user, post_type="text", title="Hi")
+        Comment.objects.create(post=post, author=self.user, body="c", path="0001")
+        post.comment_count = 1
+        post.save(update_fields=["comment_count"])
+        self.client.login(username="alice", password="pwd")
+        resp = self.client.post(reverse("post_delete_owner", args=[post.pk]), HTTP_HX_REQUEST="true")
+        self.assertIn(b"[deleted] by author", resp.content)
+
+    def test_delete_window_hint(self):
+        post = Post.objects.create(community=self.community, author=self.user, post_type="text", title="hint")
+        self.client.login(username="alice", password="pwd")
+        resp = self.client.get(reverse("post_detail", args=[self.community.slug, post.pk, post.slug]))
+        self.assertContains(resp, "Delete within 15 minutes")
+
+    def test_domain_throttle_affects_ranking(self):
+        p1 = Post.objects.create(community=self.community, author=self.user, post_type="text", title="p1", score=5, content_url="https://a.com")
+        p2 = Post.objects.create(community=self.community, author=self.user, post_type="text", title="p2", score=5, content_url="https://b.com")
+        Post.objects.filter(pk=p1.pk).update(hot_rank=10)
+        Post.objects.filter(pk=p2.pk).update(hot_rank=10)
+        self.client.login(username="mod", password="pwd")
+        self.client.post(reverse("post_domain_throttle", args=[p1.pk]), {"state": "1"})
+        resp = self.client.get(reverse("home"))
+        posts = resp.context["posts"]
+        self.assertEqual(posts[0].pk, p2.pk)

--- a/core/views.py
+++ b/core/views.py
@@ -51,6 +51,7 @@ from .services.astro import compute_post_signals, compute_user_post_summary
 from .services.feed import TAB_ORDER, RANGE_MAP, feed_queryset
 from .oembed import fetch_oembed
 from .utils.embeds import build_embed_html
+from . import mod
 
 
 def _is_banned(user):
@@ -681,15 +682,10 @@ def community(request, slug):
     if sort == "top" and t is None:
         t = "all"
 
-    order = TAB_ORDER[sort]
     page = int(request.GET.get("page", "1") or 1)
 
-    qs = community.posts.select_related("author").order_by(*order)
-    if sort == "top" and t and t != "all":
-        delta = RANGE_MAP.get(t)
-        if delta:
-            since = timezone.now() - delta
-            qs = qs.filter(created_at__gte=since)
+    base_qs = community.posts.select_related("author")
+    qs = feed_queryset(sort, t, base_qs=base_qs)
 
     offset = (page - 1) * PAGE_SIZE
     posts = list(qs[offset : offset + PAGE_SIZE + 1])
@@ -1126,7 +1122,7 @@ def post_remove(request, pk):
     if not request.user.is_staff:
         return HttpResponseForbidden("Forbidden")
     post = get_object_or_404(Post, pk=pk)
-    post.soft_delete(request.user)
+    mod.remove_post(post, request.user)
     if request.headers.get("HX-Request") == "true":
         html = render_to_string("core/partials/post_deleted_stub.html", {"post": post})
         return HttpResponse(html)
@@ -1147,8 +1143,7 @@ def post_lock(request, pk):
         return HttpResponseForbidden("Forbidden")
     post = get_object_or_404(Post, pk=pk)
     state = request.POST.get("state")
-    post.is_locked = state == "1"
-    post.save(update_fields=["is_locked"])
+    mod.lock_post(post, state == "1")
     html = render_to_string("core/partials/mod_controls.html", {"post": post}, request=request)
     return HttpResponse(html)
 
@@ -1184,8 +1179,8 @@ def post_domain_throttle(request, pk):
     state = request.POST.get("state")
     if state not in {"0", "1"}:
         return HttpResponseBadRequest("Invalid value")
-    post.domain_weight = 0.5 if state == "1" else 1.0
-    post.save(update_fields=["domain_weight"])
+    mod.set_domain_throttle(post.link_domain, state == "1")
+    post.refresh_from_db()
     html = render_to_string("core/partials/mod_controls.html", {"post": post}, request=request)
     return HttpResponse(html)
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -14,6 +14,12 @@ The `ASTROTURF_WATCH` environment variable (default `1`) controls all
 astroturf-detection features. Set `ASTROTURF_WATCH=0` to hide engagement
 chips and block transparency pages; related endpoints will return 404.
 
+### Moderation
+
+Staff can remove posts without deleting them, lock conversations, or
+throttle a link's domain. Throttling cuts ranking weight in half for seven
+days and is useful for spammy sources.
+
 ```bash
 git add -A
 git commit -m "alpha: public signup + header auth + submit CTA + seeds"
@@ -33,6 +39,7 @@ flyctl logs -a surejan | Select-String -Pattern "ERROR|Traceback|favicon|collect
 * `/secret-admin/` → admin login loads (only from allowlisted IPs if set).
 
 ### AstroShield scheduler (minimal)
-Run hourly (cron or CI runner):
+Run hourly (cron or CI runner) to refresh `astro_score:*` and
+`astro_band:*` cache keys:
 flyctl ssh console -a surejan -C "python manage.py astro_recompute"
 

--- a/templates/core/partials/post_deleted_stub.html
+++ b/templates/core/partials/post_deleted_stub.html
@@ -2,7 +2,15 @@
 <article id="post-{{ post.pk }}" class="post-card" data-testid="post-card">
   <div class="vote"></div>
   <div class="post-body">
-    <h2><em>[deleted]</em></h2>
+    <h2>
+      <em>
+        {% if post.deleted_by and post.deleted_by.is_staff %}
+          Removed by moderators.
+        {% else %}
+          [deleted] by author.
+        {% endif %}
+      </em>
+    </h2>
     <div class="post-meta">in r/{{ post.community.slug }}</div>
   </div>
 </article>

--- a/templates/core/post_detail.html
+++ b/templates/core/post_detail.html
@@ -32,7 +32,7 @@
       {% endif %}
       <div class="post-content">
         {% if post.is_deleted %}
-          <p><em>[deleted by author]</em></p>
+          <p><em>{% if post.deleted_by and post.deleted_by.is_staff %}Removed by moderators.{% else %}[deleted] by author.{% endif %}</em></p>
         {% else %}
           {% if post.heading %}
             <h2 class="post-heading">{{ post.heading }}</h2>
@@ -69,6 +69,9 @@
               {% csrf_token %}
               <button type="submit" class="linklike">delete</button>
             </form>
+          {% endif %}
+          {% if request.user == post.author and post|can_author_delete:request.user %}
+            <span class="delete-window">Delete within 15 minutes…</span>
           {% endif %}
         {% endif %}
         {% if user.is_authenticated %}

--- a/tests/test_smoke_v2.py
+++ b/tests/test_smoke_v2.py
@@ -1,0 +1,84 @@
+import pytest
+from django.contrib.auth import get_user_model
+from django.core.files.uploadedfile import SimpleUploadedFile
+from io import BytesIO
+from PIL import Image
+import os
+from django.core.management import call_command
+from django.urls import reverse
+from django.core.cache import cache
+
+from core.models import Community, Post
+
+
+@pytest.mark.django_db
+def test_signup_submit_sort_and_commands(client):
+    # signup flow
+    r = client.get('/accounts/signup/')
+    a, b = client.session['signup_captcha_q']
+    r = client.post('/accounts/signup/', {
+        'username': 'alice',
+        'password': 'pw',
+        'captcha': a + b,
+    }, follow=True)
+    assert r.status_code == 200
+
+    user = get_user_model().objects.get(username='alice')
+    client.login(username='alice', password='pw')
+    com = Community.objects.create(slug='t', name='Test', title='Test', created_by=user)
+
+    # submit text
+    client.post(reverse('post_submit'), {
+        'community': com.id,
+        'post_type': 'text',
+        'title': 'T1',
+        'body': 'body',
+    }, follow=True)
+    # submit link
+    client.post(reverse('post_submit'), {
+        'community': com.id,
+        'post_type': 'link',
+        'title': 'L1',
+        'link': 'https://example.com',
+    }, follow=True)
+    # submit image
+    buf = BytesIO()
+    Image.new('RGB', (10, 10), 'white').save(buf, format='JPEG')
+    img = SimpleUploadedFile('a.jpg', buf.getvalue(), content_type='image/jpeg')
+    resp = client.post(reverse('post_submit'), {
+        'community': com.id,
+        'post_type': 'images',
+        'title': 'I1',
+        'body': 'caption',
+        'images': img,
+    }, follow=True)
+    assert Post.objects.filter(title='T1').exists()
+    assert Post.objects.filter(title='L1').exists()
+    assert resp.status_code == 200
+
+    # sort tab default t=all
+    resp = client.get('/?sort=top')
+    assert resp.context['t'] == 'all'
+
+    # 4MB rejection
+    cache.clear()
+    prev = Post.objects.count()
+    big_buf = BytesIO()
+    noise = Image.frombytes('RGB', (2000, 2000), os.urandom(2000 * 2000 * 3))
+    noise.save(big_buf, format='PNG')
+    big = SimpleUploadedFile('big.png', big_buf.getvalue(), content_type='image/png')
+    resp = client.post(reverse('post_submit'), {
+        'community': com.id,
+        'post_type': 'images',
+        'title': 'big',
+        'images': big,
+    })
+    assert resp.status_code == 200
+    assert Post.objects.count() == prev
+
+    # astro_recompute should exit 0
+    call_command('astro_recompute')
+
+    # ensure no third-party JS before consent
+    html = client.get('/').content.decode()
+    assert 'src="http' not in html


### PR DESCRIPTION
## Summary
- limit image uploads to 4MB and apply domain throttling weight on post save
- add moderation helper for removals, locking, and domain throttling with 7‑day expiry
- factor domain weight into feed ranking and show clearer delete messaging
- document moderation controls and astro recompute cadence
- add smoke workflow and tests for signup flow and moderation actions

## Testing
- `MEDIA_URL=/media/ AWS_STORAGE_BUCKET_NAME=foo AWS_ACCESS_KEY_ID=foo AWS_SECRET_ACCESS_KEY=bar AWS_S3_ENDPOINT_URL=http://example.com PYTHONPATH=. pytest tests/test_smoke_v2.py core/tests_mod_actions.py tests/test_routes_and_selectors.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b670469b58832cba2a668751db2c8d