### PR TITLE
Add communities dropdown menu

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -25,6 +25,39 @@ header.header-bar{
 .nav-links a{ padding:4px 8px; border-radius:6px; text-decoration:none; }
 .nav-links a[aria-current="page"]{ background:rgba(0,0,0,.06); }
 
+/* Communities dropdown ------------------------------------------------ */
+.communities-dropdown{ position:relative; }
+.communities-toggle{
+  background:none;
+  border:none;
+  cursor:pointer;
+  font:inherit;
+  color:inherit;
+}
+.communities-dropdown .dropdown-menu{
+  display:none;
+  position:absolute;
+  background:var(--color-surface);
+  border:1px solid var(--color-border);
+  border-radius:var(--radius-md);
+  margin-top:var(--space-2);
+  padding:var(--space-2) 0;
+  min-width:140px;
+}
+.communities-dropdown .dropdown-menu a{
+  display:block;
+  padding:var(--space-2) var(--space-4);
+  text-decoration:none;
+  color:inherit;
+}
+.communities-dropdown .dropdown-menu a:hover{
+  background:rgba(0,0,0,.06);
+}
+.communities-dropdown.open .dropdown-menu,
+.communities-dropdown:hover .dropdown-menu{
+  display:block;
+}
+
 .sidebar-cta{ background:var(--color-surface); padding:var(--space-5); border-radius:var(--radius-lg); }
 .post-card{
   background:var(--color-surface);

--- a/static/js/dropdown.js
+++ b/static/js/dropdown.js
@@ -1,0 +1,19 @@
+document.addEventListener('DOMContentLoaded', function () {
+  var dropdown = document.querySelector('.communities-dropdown');
+  if (!dropdown) return;
+  var toggle = dropdown.querySelector('.communities-toggle');
+  function closeMenu() {
+    dropdown.classList.remove('open');
+    toggle.setAttribute('aria-expanded', 'false');
+  }
+  toggle.addEventListener('click', function (e) {
+    e.stopPropagation();
+    var isOpen = dropdown.classList.toggle('open');
+    toggle.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+  });
+  document.addEventListener('click', function (e) {
+    if (!dropdown.contains(e.target)) {
+      closeMenu();
+    }
+  });
+});

--- a/templates/core/base.html
+++ b/templates/core/base.html
@@ -14,7 +14,15 @@
       <a class="header-logo" href="{% url 'home' %}">
         <img class="site-logo" src="{% static 'img/Surejanlogo.png' %}" alt="SureJan">
       </a>
-      <a class="communities-link" href="{% url 'communities_index' %}">Communities ▾</a>
+      <div class="communities-dropdown">
+        <button class="communities-toggle" type="button" aria-haspopup="true" aria-expanded="false">Communities ▾</button>
+        <div class="dropdown-menu" role="menu">
+          <a href="/r/news">News</a>
+          <a href="/r/brisbane">Brisbane</a>
+          <a href="/r/politics">Politics</a>
+          <a href="/r/social">Social</a>
+        </div>
+      </div>
     </div>
     <nav id="sort-tabs" class="nav-tabs" aria-label="Sort">
       <a href="?sort=hot"{% if request.GET.sort|default:'hot' == 'hot' %} aria-current="page"{% endif %}>Hot</a>
@@ -39,6 +47,7 @@
     <a href="{% url 'privacy' %}">Privacy</a> ·
     <a href="{% url 'rules' %}">Rules</a>
   </footer>
+  <script src="{% static 'js/dropdown.js' %}"></script>
   {% block scripts %}{% endblock %}
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add Communities dropdown with links to News, Brisbane, Politics, and Social
- style dropdown and load toggle script

## Testing
- `python manage.py shell -c "from django.test import Client; from core.models import Community; print([Community.objects.count()]); c=Client(); slugs=['news','brisbane','politics','social']; print([c.get(f'/r/{s}').status_code for s in slugs])"`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b674ad0348832cabc03cc025291578