### PR TITLE
Wire header logo and clamp size

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -20,7 +20,8 @@ header.header-bar{
   padding: var(--space-3) var(--space-6);
 }
 
-.site-logo{max-height:28px;width:auto;display:block}
+.site-logo{height:32px;width:auto;display:block}
+.header-logo{display:flex;align-items:center}
 
 .nav-links a{ padding:4px 8px; border-radius:6px; text-decoration:none; }
 .nav-links a[aria-current="page"]{ background:rgba(0,0,0,.06); }

--- a/templates/core/base.html
+++ b/templates/core/base.html
@@ -12,7 +12,7 @@
   <header class="header-bar" data-testid="header-bar">
     <div class="nav-left">
       <a class="header-logo" href="{% url 'home' %}">
-        <img class="site-logo" src="{% static 'img/Surejanlogo.png' %}" alt="SureJan">
+        <img class="site-logo" src="{% static 'img/logo.png' %}" alt="SureJan">
       </a>
       <div class="communities-dropdown">
         <button class="communities-toggle" type="button" aria-haspopup="true" aria-expanded="false">Communities ▾</button>


### PR DESCRIPTION
## Summary
- Render new header logo linking to home with static path
- Clamp logo height to 32px and center link content

## Testing
- `DJANGO_COLLECTSTATIC=1 pytest -q`
- `DJANGO_COLLECTSTATIC=1 python manage.py collectstatic --noinput`
- `curl -s -o /dev/null -w "%{http_code}" http://localhost:8000/static/img/logo.png`

------
https://chatgpt.com/codex/tasks/task_e_68b692ce9f0c832c83ccfed7478ae71d