### PR TITLE
docs: record new testing policy and update V2 spec

### DIFF
--- a/docs/Testing-Policy.md
+++ b/docs/Testing-Policy.md
@@ -1,0 +1,7 @@
+Change control: If testing policy changes, update this file in the same PR.
+
+# Testing Policy (V2)
+- We **do not use UI smoke tests** (route/selector/logo/empty-state smokes).
+- CI may run `pytest` with **0 tests** and still pass.
+- Verification for UI flows is **manual** or via targeted unit/integration tests added case-by-case.
+- Future E2E (Playwright/Cypress) can be added post-V2 if needed.

--- a/docs/V2-onepager.md
+++ b/docs/V2-onepager.md
@@ -88,19 +88,11 @@ Fly: `release_command: python manage.py migrate --noinput`. Static via WhiteNois
 - AstroShield chips + slowmode thresholds work; `/methods` published.
 - Mod tools (Remove/Lock/Slowmode/Domain-throttle) function.
 - CSP enforced; consent gating; rate limits enforced.
-- Staging + Prod live; smoke tests pass; deps pinned.
+- Staging + Prod live; acceptance checks are manual (no UI smoke tests); deps pinned.
 - **500 registered users** milestone.
 
-## 15) Acceptance & Smoke Tests (minimum)
-1. Signup → header shows username.  
-2. Submit Text, Link (YouTube nocookie), Images(3) → appear in feed.  
-3. Sort tabs render; `/?sort=top` (no `t`) works; `t=24h|7d|all` all work.  
-4. Rate-limit thresholds return **429** with friendly copy.  
-5. AstroShield fixture score=75 → red chip + 60s slowmode; ≥85 → 120s + listed in `/mod/astro`.  
-6. Mod actions visibly affect UI/ranking.  
-7. CSP: no third-party JS before consent.  
-8. `/secret-admin/` reachable (allowed IPs).  
-9. HTMX pagination: `/?page=2` valid; no duplicate IDs.
+## 15) Acceptance
+Acceptance checks are manual (no UI smoke tests). Targeted unit/integration tests only as needed.
 
 ## 16) Milestones (merge order)
 1) Models/migrations + seed 4 communities · 2) Routes/base views · 3) Feed cards  


### PR DESCRIPTION
## Summary
- document V2 testing policy with no UI smoke tests and optional future E2E
- note manual acceptance checks in V2 one-pager

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'core')*

------
https://chatgpt.com/codex/tasks/task_e_68b6a1ba94f4832c88d5f8debaa03ca9