### PR TITLE
Increase header logo size to 128px

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -76,9 +76,10 @@ header.header-bar{
   .sidebar-col{ flex:0 0 var(--sidebar-width); }
 }
 
-codex/make-logo-2x-bigger-vuy1kx
-.site-logo{height:128px;width:128px;display:block}
-
-.site-logo{height:64px;width:auto;display:block}
-main
 .header-logo{display:flex;align-items:center}
+
+/* kill any previous logo clamps */
+.header-logo img { max-height: none !important; height: auto !important; }
+
+/* final size */
+.site-logo { height: 128px !important; width: auto; display: block; }

--- a/templates/core/base.html
+++ b/templates/core/base.html
@@ -11,7 +11,7 @@
 <body>
   <header class="header-bar" data-testid="header-bar">
     <a class="header-logo" href="{% url 'home' %}">
-      <img class="site-logo" src="{% static 'logo.png' %}" alt="SureJan">
+      <img class="site-logo" src="{% static 'img/logo.png' %}" alt="SureJan">
     </a>
     {% block header_center %}{% endblock %}
     {% block header_right %}{% endblock %}


### PR DESCRIPTION
## Summary
- Update base template logo path and markup
- Override header logo CSS clamps and enforce 128px height

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'core')*

------
https://chatgpt.com/codex/tasks/task_e_68b6a2b92288832c9d1f30bc5443f2b1