### PR TITLE
Fix header logo path and size

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -76,10 +76,8 @@ header.header-bar{
   .sidebar-col{ flex:0 0 var(--sidebar-width); }
 }
 
+
+.site-logo{height:48px;width:auto;display:block}
 .header-logo{display:flex;align-items:center}
-
-/* kill any previous logo clamps */
-.header-logo img { max-height: none !important; height: auto !important; }
-
-/* final size */
-.site-logo { height: 128px !important; width: auto; display: block; }
+/* neutralize old caps if they exist */
+.header-logo img{max-height:none;height:auto}

--- a/static/img/logo.svg
+++ b/static/img/logo.svg
@@ -1,4 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="160" height="32" viewBox="0 0 160 32">
-  <rect width="160" height="32" rx="6" fill="#141418"/>
-  <text x="10" y="22" fill="#e9e9ee" font-family="system-ui,Segoe UI,Roboto,Helvetica,Arial" font-size="16">SureJan</text>
-</svg>


### PR DESCRIPTION
## Summary
- Clamp site logo height and neutralize previous caps
- Prune unused logo assets so only static/img/logo.png remains

## Testing
- `git grep -n "SureJanLogo"`
- `git grep -n "img/logo.png" templates`
- `curl -I https://surejan.fly.dev/static/img/logo.png` *(403)*)
- `pytest` *(fails: RuntimeError: S3 media env not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68b6ad9779c8832c8d86e757981a6f3b