### PR TITLE
Center sort tabs and resize logo

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -12,7 +12,8 @@
 
 html,body{background:var(--color-bg); color:var(--color-text); font-family:var(--font-sans);}
 
-header.header-bar{
+/* Header -------------------------------------------------------------- */
+.header-bar{
   position:sticky; top:0; z-index:1000;
   background:var(--color-surface);
   border-bottom:1px solid var(--color-border);
@@ -81,3 +82,24 @@ header.header-bar{
 .header-logo{display:flex;align-items:center}
 /* neutralize old caps if they exist */
 .header-logo img{max-height:none;height:auto}
+
+/* Header grid: left | center | right */
+.header-bar{
+  display:grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items:center;
+  gap:12px;
+}
+
+/* Left: logo (48px) */
+.site-logo{ height:48px; width:auto; display:block; }
+.header-logo img{ max-height:none; height:auto; } /* neutralize any old clamps */
+.header-left{ display:flex; align-items:center; gap:12px; }
+
+/* Center: tabs truly centered */
+.header-center{ justify-self:center; display:flex; gap:16px; }
+.header-center a{ text-decoration:none; padding:4px 8px; border-radius:6px; }
+.header-center a[aria-current="page"]{ background:rgba(0,0,0,0.06); }
+
+/* Right area stays aligned to end */
+.header-right{ justify-self:end; display:flex; align-items:center; gap:12px; }

--- a/templates/core/base.html
+++ b/templates/core/base.html
@@ -10,11 +10,22 @@
 </head>
 <body>
   <header class="header-bar" data-testid="header-bar">
-    <a class="header-logo" href="{% url 'home' %}">
-      <img class="site-logo" src="{% static 'img/logo.png' %}" alt="SureJan">
-    </a>
-    {% block header_center %}{% endblock %}
-    {% block header_right %}{% endblock %}
+    <div class="header-left">
+      <a class="header-logo" href="{% url 'home' %}">
+        <img class="site-logo" src="{% static 'img/logo.png' %}" alt="SureJan">
+      </a>
+      {% comment %} Optional: <a class="nav-communities" href="/r">Communities ▾</a> {% endcomment %}
+    </div>
+
+    <nav id="sort-tabs" class="header-center" aria-label="Sort">
+      <a href="?sort=hot"{% if request.GET.sort|default:'hot' == 'hot' %} aria-current="page"{% endif %}>Hot</a>
+      <a href="?sort=new"{% if request.GET.sort == 'new' %} aria-current="page"{% endif %}>New</a>
+      <a href="?sort=top{% if request.GET.t %}&t={{ request.GET.t }}{% endif %}"{% if request.GET.sort == 'top' %} aria-current="page"{% endif %}>Top</a>
+    </nav>
+
+    <div class="header-right">
+      {% block header_right %}{% endblock %}
+    </div>
   </header>
   {% block content %}{% endblock %}
   <footer class="footer">


### PR DESCRIPTION
## Summary
- restructure header markup with logo on the left, centered sort tabs, and right-side auth block
- style header as CSS grid, size logo to 48px, and center Hot/New/Top tabs

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'core')*

------
https://chatgpt.com/codex/tasks/task_e_68b6b07e83e0832c948856ea5a6b0435