### PR TITLE
Simplify static settings and enforce logo styling

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -239,20 +239,9 @@ STATICFILES_DIRS = [BASE_DIR / "static"]
 # Detect build phase for collectstatic
 IS_BUILD = os.getenv("DJANGO_COLLECTSTATIC") == "1"
 
-if os.getenv("DJANGO_TESTS", "1") in ("1", "true", "True"):
-    STORAGES = {
-        "staticfiles": {
-            "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
-        }
-    }
-else:
-    STORAGES = {
-        "staticfiles": {
-            "BACKEND": "whitenoise.storage.CompressedManifestStaticFilesStorage",
-        }
-    }
+STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
 
-STATICFILES_STORAGE = STORAGES["staticfiles"]["BACKEND"]
+STORAGES = {"staticfiles": {"BACKEND": STATICFILES_STORAGE}}
 
 # Temporary guard to avoid 500s from missing manifest entries while iterating.
 # REMOVE once favicon/static references are correct and collectstatic is clean.

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -105,5 +105,7 @@ html,body{background:var(--color-bg); color:var(--color-text); font-family:var(-
 .header-right{ justify-self:end; display:flex; align-items:center; gap:12px; }
 
 /* Logo size authority (wins last) */
-.header-logo img{ max-height:none !important; height:auto !important; }
-.site-logo{ height:48px !important; width:auto; display:block; }
+.header-logo img{max-height:none !important;height:auto !important;opacity:1 !important;visibility:visible !important;filter:none !important}
+.site-logo{height:48px !important;width:auto;display:block}
+/* remove after you confirm */
+.site-logo{filter: brightness(1.2) contrast(1.05)}


### PR DESCRIPTION
## Summary
- ensure WhiteNoise manifest storage uses project static directory
- harden logo CSS to override clamps and improve visibility

## Testing
- `DJANGO_COLLECTSTATIC=1 python manage.py findstatic img/logo.png -v 3`
- `DJANGO_COLLECTSTATIC=1 python manage.py collectstatic --noinput`
- `DJANGO_COLLECTSTATIC=1 pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b6b6709ab8832c959d5694b89fe825