### PR TITLE
style: unify header logo sizing

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -79,20 +79,6 @@ html,body{background:var(--color-bg); color:var(--color-text); font-family:var(-
 
 .header-logo{display:flex;align-items:center}
 
-/* Logo */
-.site-logo{
-  max-height:48px;
-  height:auto;
-  width:auto;
-  object-fit:contain;
-}
-
-@media (max-width:768px){
-  .site-logo{max-height:24px;}
-}
-
-/* neutralize old caps if they exist */
-.header-logo img{max-height:none;height:auto}
 
 /* Header grid: left | center | right */
 .header-bar{
@@ -112,4 +98,7 @@ html,body{background:var(--color-bg); color:var(--color-text); font-family:var(-
 
 /* Right area stays aligned to end */
 .header-right{ justify-self:end; display:flex; align-items:center; gap:12px; }
+
+/* final authority for header logo size */
+.site-logo { max-height: 48px; height: auto; width: auto; object-fit: contain; display: block; }
 


### PR DESCRIPTION
## Summary
- remove stray logo height rules
- cap .site-logo at max-height 48px with final rule

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'core')*

------
https://chatgpt.com/codex/tasks/task_e_68b6be4b0b38832c99891e89d1c54508