### PR TITLE
Add logo hover communities dropdown

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -102,3 +102,29 @@ html,body{background:var(--color-bg); color:var(--color-text); font-family:var(-
 /* final authority for header logo size */
 .site-logo { max-height: 48px; height: auto; width: auto; object-fit: contain; display: block; }
 
+/* --- Communities dropdown on logo hover (CSS-only) --- */
+.brand { position: relative; display: inline-block; }
+.brand-menu {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  display: none;
+  margin: 6px 0 0 0;
+  padding: 6px 0;
+  list-style: none;
+  min-width: 160px;
+  background: #fff;
+  border: 1px solid rgba(0,0,0,0.1);
+  box-shadow: 0 6px 18px rgba(0,0,0,0.08);
+  z-index: 1000;
+}
+.brand:hover .brand-menu,
+.brand:focus-within .brand-menu { display: block; }
+.brand-menu li { margin: 0; }
+.brand-menu a {
+  display: block;
+  padding: 8px 12px;
+  text-decoration: none;
+}
+.brand-menu a:hover { text-decoration: underline; }
+

--- a/templates/core/base.html
+++ b/templates/core/base.html
@@ -10,9 +10,17 @@
 </head>
 <body>
   <header class="header-bar">
-    <a class="header-logo" href="{% url 'home' %}">
-      <img class="site-logo" src="{% static 'img/logo.png' %}" alt="SureJan">
-    </a>
+    <div class="brand">
+      <a class="header-logo" href="{% url 'home' %}">
+        <img class="site-logo" src="{% static 'img/logo.png' %}" alt="SureJan">
+      </a>
+      <ul class="brand-menu" aria-label="Communities">
+        <li><a href="/r/news/">NEWS</a></li>
+        <li><a href="/r/brisbane/">BRISBANE</a></li>
+        <li><a href="/r/politics/">POLITICS</a></li>
+        <li><a href="/r/social/">SOCIAL</a></li>
+      </ul>
+    </div>
     {% block header_center %}{% endblock %}
     {% block header_right %}{% endblock %}
   </header>


### PR DESCRIPTION
## Summary
- Wrap header logo in `.brand` container and add `brand-menu` with community links
- Add CSS-only dropdown styles to reveal menu on logo hover or focus

## Testing
- `DJANGO_COLLECTSTATIC=1 python manage.py collectstatic --noinput`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b6c20d41ec832cba2a5801daac3c73