### PR TITLE
Fix communities dropdown positioning to prevent blink

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -36,10 +36,12 @@ html,body{background:var(--color-bg); color:var(--color-text); font-family:var(-
 .communities-dropdown .dropdown-menu{
   display:none;
   position:absolute;
+  top: calc(100% + var(--space-2));
+  left: 0;
+  z-index: 1000;
   background:var(--color-surface);
   border:1px solid var(--color-border);
   border-radius:var(--radius-md);
-  margin-top:var(--space-2);
   padding:var(--space-2) 0;
   min-width:140px;
 }


### PR DESCRIPTION
## Summary
- fix dropdown positioning for community menu
- confirm header bar and parents don't hide overflow

## Testing
- `pip install pytest-django`
- `DJANGO_COLLECTSTATIC=1 python manage.py collectstatic --noinput`
- `DJANGO_COLLECTSTATIC=1 pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b6c8495f64832c80c56f6b3d2fd9a2