### PR TITLE
refactor: add V3 layout shell

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -107,3 +107,21 @@ html,body{background:var(--color-bg); color:var(--color-text); font-family:var(-
 /* final authority for header logo size */
 .site-logo { max-height: 48px; height: auto; width: auto; object-fit: contain; display: block; }
 
+
+/* V3 layout -------------------------------------------------- */
+.header-bar{min-height:128px;}
+.page{display:flex;}
+.left-communities{width:200px;}
+.shell-1024{flex:1;max-width:1024px;margin:0 auto;padding:0 var(--space-6);}
+.grid-3{display:grid;grid-template-columns:minmax(0,1fr) 24px var(--sidebar-width);align-items:start;}
+.feed-col{grid-column:1;}
+.gutter-24{grid-column:2;}
+.right-sidebar{grid-column:3;}
+@media (max-width:1023px){
+  .page{flex-direction:column;}
+  .left-communities{order:2;width:auto;}
+  .shell-1024{max-width:none;padding:0 var(--space-4);}
+  .grid-3{grid-template-columns:1fr;}
+  .gutter-24{display:none;}
+  .right-sidebar{display:none;}
+}

--- a/static/img/logo.svg
+++ b/static/img/logo.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 24" fill="none">
+  <text x="0" y="18" font-size="18" font-family="sans-serif">SureJan</text>
+</svg>

--- a/templates/core/base.html
+++ b/templates/core/base.html
@@ -9,27 +9,24 @@
   {% block head %}{% endblock %}
 </head>
 <body>
-  <header class="header-bar">
-    <details class="communities-dropdown">
-      <summary class="communities-toggle header-logo" aria-haspopup="true">
-        <img class="site-logo" src="{% static 'img/logo.png' %}" alt="SureJan">
-      </summary>
-      <ul class="dropdown-menu" aria-label="Communities">
-        <li><a href="/r/news/">NEWS</a></li>
-        <li><a href="/r/brisbane/">BRISBANE</a></li>
-        <li><a href="/r/politics/">POLITICS</a></li>
-        <li><a href="/r/social/">SOCIAL</a></li>
-      </ul>
-    </details>
-    {% block header_center %}{% endblock %}
-    {% block header_right %}{% endblock %}
-  </header>
-  {% block content %}{% endblock %}
-  <footer class="footer">
-    <a href="{% url 'terms' %}">Terms</a> ·
-    <a href="{% url 'privacy' %}">Privacy</a> ·
-    <a href="{% url 'rules' %}">Rules</a>
-  </footer>
+  {% include "core/partials/header.html" %}
+  <div class="page">
+    <aside class="left-communities">
+      {% block left_communities %}{% endblock %}
+    </aside>
+    <main class="shell-1024">
+      <div class="grid-3">
+        <div class="feed-col">
+          {% block content %}{% endblock %}
+        </div>
+        <div class="gutter-24"></div>
+        <div class="right-sidebar">
+          {% block right_sidebar %}{% endblock %}
+        </div>
+      </div>
+    </main>
+  </div>
+  {% include "core/partials/footer.html" %}
   {% block scripts %}{% endblock %}
 </body>
 </html>

--- a/templates/core/partials/footer.html
+++ b/templates/core/partials/footer.html
@@ -1,0 +1,5 @@
+<footer class="footer">
+  <a href="{% url 'terms' %}">Terms</a> ·
+  <a href="{% url 'privacy' %}">Privacy</a> ·
+  <a href="{% url 'rules' %}">Rules</a>
+</footer>

--- a/templates/core/partials/header.html
+++ b/templates/core/partials/header.html
@@ -1,0 +1,26 @@
+{% load static %}
+<header class="header-bar" data-testid="header-bar">
+  <div class="header-left">
+    <details class="communities-dropdown">
+      <summary class="communities-toggle header-logo" aria-haspopup="true">
+        <img class="site-logo" src="{% static 'img/logo.svg' %}" alt="SureJan">
+      </summary>
+      <ul class="dropdown-menu" aria-label="Communities">
+        <li><a href="/r/news/">NEWS</a></li>
+        <li><a href="/r/brisbane/">BRISBANE</a></li>
+        <li><a href="/r/politics/">POLITICS</a></li>
+        <li><a href="/r/social/">SOCIAL</a></li>
+      </ul>
+    </details>
+  </div>
+  <nav id="sort-tabs" class="header-center" aria-label="Sort">
+    {% block header_center %}
+    <a href="?sort=hot" aria-current="page">Hot</a>
+    <a href="?sort=new">New</a>
+    <a href="?sort=top">Top</a>
+    {% endblock %}
+  </nav>
+  <div class="header-right">
+    {% block header_right %}{% endblock %}
+  </div>
+</header>


### PR DESCRIPTION
## Summary
- replace base layout body with V3 page shell that includes new header and footer partials
- add header and footer partials and new logo SVG asset
- append V3 layout CSS for page grid and responsive behavior

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'core')*

------
https://chatgpt.com/codex/tasks/task_e_68b7b3050b50832ca0e61120f765ac13