### PR TITLE
Add community and account sidebars

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -125,3 +125,9 @@ html,body{background:var(--color-bg); color:var(--color-text); font-family:var(-
   .gutter-24{display:none;}
   .right-sidebar{display:none;}
 }
+
+/* Sidebar basics -------------------------------------------------- */
+.side-title{font-weight:600;margin-bottom:var(--space-3);}
+.comm-list a{display:block;padding:var(--space-2) 0;text-decoration:none;color:inherit;}
+.sidebar-cta{background:var(--color-surface);padding:var(--space-5);border-radius:var(--radius-lg);margin-top:var(--space-6);}
+.sidebar-link{display:block;margin-top:var(--space-3);text-decoration:none;color:inherit;}

--- a/templates/core/base.html
+++ b/templates/core/base.html
@@ -12,6 +12,7 @@
   {% include "core/partials/header.html" %}
   <div class="page">
     <aside class="left-communities">
+      {% include "core/partials/left_communities.html" %}
       {% block left_communities %}{% endblock %}
     </aside>
     <main class="shell-1024">
@@ -21,6 +22,7 @@
         </div>
         <div class="gutter-24"></div>
         <div class="right-sidebar">
+          {% include "core/partials/right_sidebar.html" %}
           {% block right_sidebar %}{% endblock %}
         </div>
       </div>

--- a/templates/core/partials/left_communities.html
+++ b/templates/core/partials/left_communities.html
@@ -1,0 +1,7 @@
+<h2 class="side-title">Communities</h2>
+<div class="comm-list">
+  <a href="/r/news/">/r/news/</a>
+  <a href="/r/brisbane/">/r/brisbane/</a>
+  <a href="/r/politics/">/r/politics/</a>
+  <a href="/r/social/">/r/social/</a>
+</div>

--- a/templates/core/partials/right_sidebar.html
+++ b/templates/core/partials/right_sidebar.html
@@ -1,0 +1,13 @@
+<div class="account-block">
+  <p class="side-title">Account</p>
+  {% if user.is_authenticated %}
+    <p>{{ user.username }}</p>
+  {% else %}
+    <a class="sidebar-link" href="{% url 'login' %}">Login</a>
+    <a class="sidebar-link" href="{% url 'signup' %}">Signup</a>
+  {% endif %}
+</div>
+<div class="sidebar-cta" data-testid="sidebar-cta">
+  <a class="btn btn-primary" href="{% url 'post_submit' %}" data-testid="sidebar-submit">Submit Post</a>
+  <p class="muted"><a class="sidebar-link" href="{% url 'transparency_methods' %}" data-testid="sidebar-astro">Anti-Astroturf</a></p>
+</div>


### PR DESCRIPTION
## Summary
- add left sidebar listing communities
- add right sidebar with account/login links and submit CTA
- style new sidebars and include in base template

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'core')*

------
https://chatgpt.com/codex/tasks/task_e_68b7b480a664832cb33b08bbdbb85987