### PR TITLE
Refactor submit form layout

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -131,3 +131,7 @@ html,body{background:var(--color-bg); color:var(--color-text); font-family:var(-
 .comm-list a{display:block;padding:var(--space-2) 0;text-decoration:none;color:inherit;}
 .sidebar-cta{background:var(--color-surface);padding:var(--space-5);border-radius:var(--radius-lg);margin-top:var(--space-6);}
 .sidebar-link{display:block;margin-top:var(--space-3);text-decoration:none;color:inherit;}
+
+/* Form styles -------------------------------------------------- */
+.form-row{display:flex;flex-direction:column;gap:var(--space-2);margin-bottom:var(--space-4);}
+.form-helper{margin-bottom:var(--space-4);color:#666;font-size:0.875rem;}

--- a/templates/core/submit.html
+++ b/templates/core/submit.html
@@ -5,20 +5,25 @@
 <div class="submit-wrapper">
   <a href="{% url 'home' %}">← Back to feed</a>
   <h1>Submit Post</h1>
-  <form id="post-form" method="post" enctype="multipart/form-data" hx-boost="false" data-testid="submit-form">
+  <p class="form-helper">Title is required. Include body <strong>or</strong> media.</p>
+  <form method="post" enctype="multipart/form-data" hx-boost="false" class="submit-form" data-testid="submit-form">
     {% csrf_token %}
     <div id="form-errors" aria-live="assertive">{{ form.non_field_errors }}</div>
     <div class="form-row">
-      {{ form.post_type.label_tag }} {{ form.post_type }}
-      {{ form.post_type.errors }}
+      {{ form.community.label_tag }} {{ form.community }}
+      {{ form.community.errors }}
     </div>
-    {{ form.community.as_hidden }}
-    {{ form.community.errors }}
     <div class="form-row">
       {{ form.title.label_tag }} {{ form.title }}
       {{ form.title.errors }}
     </div>
-    <div class="form-row" id="body-row">
+    <div class="form-row">
+      {{ form.link.label_tag }} {{ form.link }}
+      {{ form.link.errors }}
+      {{ form.images.label_tag }} {{ form.images }}
+      {{ form.images.errors }}
+    </div>
+    <div class="form-row">
       {{ form.body.label_tag }}
       <div class="editor-container prose">
         {% include "core/partials/editor_toolbar.html" %}
@@ -26,16 +31,8 @@
       </div>
       {{ form.body.errors }}
     </div>
-    <div class="form-row" id="link-row" style="display:none">
-      {{ form.link.label_tag }} {{ form.link }}
-      {{ form.link.errors }}
-    </div>
-    <div class="form-row" id="images-row" style="display:none">
-      {{ form.images.label_tag }} {{ form.images }}
-      {{ form.images.errors }}
-    </div>
     <div class="form-actions">
-      <button type="submit" class="button primary" id="post-btn" disabled>Post</button>
+      <button type="submit" class="button primary">Post</button>
       <a href="{% url 'home' %}" class="button secondary">Cancel</a>
     </div>
   </form>
@@ -46,31 +43,4 @@
 {% block scripts %}
 {{ block.super }}
 <script src="{% static 'js/editor.js' %}" defer></script>
-<script>
-function validatePost(){
-  const type=document.querySelector('input[name="post_type"]:checked').value;
-  const title=document.getElementById('id_title').value.trim();
-  const body=document.getElementById('id_body').value.trim();
-  const link=document.getElementById('id_link').value.trim();
-  const images=document.getElementById('id_images').files;
-  let valid=false;
-  if(type==='text'){valid=title&&body;}
-  else if(type==='link'){valid=title&&link;}
-  else if(type==='images'){valid=title&&images.length>0;}
-  document.getElementById('post-btn').disabled=!valid;
-}
-function updateType(){
-  const type=document.querySelector('input[name="post_type"]:checked').value;
-  document.getElementById('body-row').style.display=type==='text'||type==='images'?"":"none";
-  document.getElementById('link-row').style.display=type==='link'?"":"none";
-  document.getElementById('images-row').style.display=type==='images'?"":"none";
-  validatePost();
-}
-updateType();
-['id_title','id_body','id_link','id_images'].forEach(id=>{
-  const el=document.getElementById(id);
-  if(el) el.addEventListener('input',validatePost);
-});
-document.querySelectorAll('input[name="post_type"]').forEach(r=>r.addEventListener('change',updateType));
-</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Simplify submit form to new community/title/media/body layout and remove post type radios
- Add helper text and optional form-row styles

## Testing
- `python manage.py test` *(fails: failures=5, errors=4)*

------
https://chatgpt.com/codex/tasks/task_e_68b7b56d1870832c997d55fc24e8c41b