### PR TITLE
refactor: standardize post card templates

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -10,6 +10,7 @@ from django.core.exceptions import ValidationError
 from django.core.files.base import ContentFile
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
+from django.urls import reverse
 from datetime import timedelta
 from django.utils import timezone
 from django.utils.text import slugify
@@ -150,6 +151,9 @@ class Post(models.Model):
     @property
     def slug(self):
         return slugify(self.title)
+
+    def get_absolute_url(self):
+        return reverse("post_detail", args=[self.community.slug, self.pk, self.slug])
 
     class Meta:
         indexes = [

--- a/templates/core/partials/post_row.html
+++ b/templates/core/partials/post_row.html
@@ -1,6 +1,6 @@
 <article class="post-card" data-testid="post-card">
   {% if post.image_thumb or post.image %}
-  <a href="{% url 'post_detail' post.community.slug post.pk post.slug %}" class="thumb">
+  <a href="{{ post.get_absolute_url }}" class="thumb">
     {% if post.image_thumb %}
     <img src="{{ post.image_thumb.url }}" alt="" width="120" height="120" loading="lazy" decoding="async">
     {% else %}
@@ -9,20 +9,18 @@
   </a>
   {% endif %}
   <div class="post-meta">
-    <a href="{% url 'community' post.community.slug %}">r/{{ post.community.slug }}</a>
-    •
-    <a href="{% url 'user_overview' post.author.username %}">{{ post.author.username }}</a>
-    •
-    <time datetime="{{ post.created_at|date:'c' }}">{{ post.created_at|timesince }}</time>
+    r/{{ post.community.slug }} · {{ post.author.username }} · {{ post.created_at|timesince }} ago
   </div>
-  <h2 class="post-title line-clamp"><a href="{% url 'post_detail' post.community.slug post.pk post.slug %}">{{ post.title }}</a></h2>
+  <h3 class="post-title"><a href="{{ post.get_absolute_url }}">{{ post.title }}</a></h3>
+  {% if post.body %}
+  <p class="post-excerpt">{{ post.body|truncatechars:180 }}</p>
+  {% endif %}
   <div class="post-actions">
     <div class="vote">
       <button class="up" hx-post="{% url 'vote_post' post.pk %}?v=1" hx-target="#score-{{ post.pk }}" hx-swap="outerHTML" aria-label="Upvote">▲</button>
       <span id="score-{{ post.pk }}" class="score">{{ post.score }}</span>
       <button class="down" hx-post="{% url 'vote_post' post.pk %}?v=-1" hx-target="#score-{{ post.pk }}" hx-swap="outerHTML" aria-label="Downvote">▼</button>
     </div>
-    <a href="{% url 'post_detail' post.community.slug post.pk post.slug %}#comments">{{ post.comment_count }} comments</a>
+    <a href="{{ post.get_absolute_url }}#comments">{{ post.comment_count }} comments</a>
   </div>
 </article>
-

--- a/templates/partials/feed_card.html
+++ b/templates/partials/feed_card.html
@@ -1,7 +1,7 @@
 {% load url_domain astro_filters %}
-<article class="post-card" id="post-{{ post.pk }}" data-testid="post-card"{% if load_more_url %} hx-get="{{ load_more_url }}" hx-trigger="revealed" hx-swap="outerHTML" hx-target="this" hx-push-url="true"{% endif %}>
+<article class="post-card" data-testid="post-card">
   {% if post.image_thumb or post.image %}
-  <a href="{% url 'post_detail' post.community.slug post.pk post.slug %}" class="thumb">
+  <a href="{{ post.get_absolute_url }}" class="thumb">
     {% if post.image_thumb %}
     <img src="{{ post.image_thumb.url }}" alt="" width="120" height="120" loading="lazy" decoding="async">
     {% else %}
@@ -10,22 +10,21 @@
   </a>
   {% endif %}
   <div class="post-meta">
-    <a href="{% url 'community' post.community.slug %}">r/{{ post.community.slug }}</a>
-    •
-    <a href="{% url 'user_overview' post.author.username %}">{{ post.author.username }}</a>
-    •
-    <time datetime="{{ post.created_at|date:'c' }}">{{ post.created_at|timesince }}</time>
+    r/{{ post.community.slug }} · {{ post.author.username }} · {{ post.created_at|timesince }} ago
   </div>
-  <h2 class="post-title line-clamp"><a href="{% url 'post_detail' post.community.slug post.pk post.slug %}">{{ post.title }}</a></h2>
+  <h3 class="post-title"><a href="{{ post.get_absolute_url }}">{{ post.title }}</a></h3>
   {% if post.is_deleted %}<span class="state-badge">deleted</span>{% endif %}
   {% if post.is_draft %}<span class="state-badge">draft</span>{% endif %}
+  {% if post.body %}
+  <p class="post-excerpt">{{ post.body|truncatechars:180 }}</p>
+  {% endif %}
   <div class="post-actions">
     <div class="vote">
       <button class="up" hx-post="{% url 'vote_post' post.pk %}?v=1" hx-target="#score-{{ post.pk }}" hx-swap="outerHTML" aria-label="Upvote">▲</button>
       <span id="score-{{ post.pk }}" class="score">{{ post.score }}</span>
       <button class="down" hx-post="{% url 'vote_post' post.pk %}?v=-1" hx-target="#score-{{ post.pk }}" hx-swap="outerHTML" aria-label="Downvote">▼</button>
     </div>
-    <a href="{% url 'post_detail' post.community.slug post.pk post.slug %}#comments">{{ post.comment_count }} comments</a>
+    <a href="{{ post.get_absolute_url }}#comments">{{ post.comment_count }} comments</a>
     {% if post.astro_score %}
     <details class="astro-why">
       <summary class="chip {{ post.astro_score.score|astro_band }}">Astro {{ post.astro_score.score }}</summary>


### PR DESCRIPTION
## Summary
- update feed card and post row to V3 markup
- show plain meta line and optional excerpt
- add `get_absolute_url` to Post for simplified links

## Testing
- `AWS_STORAGE_BUCKET_NAME=x AWS_ACCESS_KEY_ID=x AWS_SECRET_ACCESS_KEY=x AWS_S3_ENDPOINT_URL=http://x MEDIA_URL=http://x pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7b7d50cb4832c8770a5f77b89dd3f