### PR TITLE
Lock V3 layout and clean sidebars

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -135,3 +135,32 @@ html,body{background:var(--color-bg); color:var(--color-text); font-family:var(-
 /* Form styles -------------------------------------------------- */
 .form-row{display:flex;flex-direction:column;gap:var(--space-2);margin-bottom:var(--space-4);}
 .form-helper{margin-bottom:var(--space-4);color:#666;font-size:0.875rem;}
+/* --- V3 layout lock (append; ~50 LOC) --- */
+
+/* Header: 128px band with 3 zones */
+.header-bar{height:128px;display:flex;align-items:center;background:#fff;border-bottom:1px solid #e5e7eb}
+.header-inner{max-width:1440px;margin:0 auto;display:grid;grid-template-columns:1fr 1fr 1fr;gap:24px;align-items:center;padding:0 24px}
+.hdr-left{justify-self:start}.hdr-center{justify-self:center}.hdr-right{justify-self:end}
+.site-logo{max-height:48px;height:auto;width:auto;display:block}
+
+/* Page: left communities (200–240) + main shell */
+.page{display:grid;grid-template-columns:minmax(200px,240px) 1fr}
+.left-communities{border-right:1px solid #eee;padding:24px 12px}
+.side-title{margin:0 0 8px;font-weight:600}
+.comm-list a{display:block;padding:6px 4px;text-decoration:none}
+
+/* Main shell: fixed 1024 grid inside */
+.shell-1024{max-width:1024px;margin:0 auto;padding:24px 12px}
+.grid-3{display:grid;grid-template-columns:700px 24px 300px;align-items:start}
+.feed-col{min-width:0}.gutter-24{min-width:24px}.right-sidebar{min-width:0}
+
+/* Sidebar widgets */
+.sidebar-cta{border:1px solid #e5e7eb;border-radius:12px;padding:16px;background:#fff;margin:16px 0;text-align:center}
+
+/* Mobile */
+@media (max-width:768px){
+  .page{display:block}
+  .shell-1024{max-width:100%}
+  .grid-3{grid-template-columns:1fr}
+  .right-sidebar{margin-top:24px}
+}

--- a/templates/core/base.html
+++ b/templates/core/base.html
@@ -11,20 +11,18 @@
 <body>
   {% include "core/partials/header.html" %}
   <div class="page">
-    <aside class="left-communities">
+    <aside class="left-communities" aria-label="Communities">
       {% include "core/partials/left_communities.html" %}
-      {% block left_communities %}{% endblock %}
     </aside>
-    <main class="shell-1024">
+    <main class="shell-1024" role="main">
       <div class="grid-3">
-        <div class="feed-col">
+        <section class="feed-col">
           {% block content %}{% endblock %}
-        </div>
-        <div class="gutter-24"></div>
-        <div class="right-sidebar">
+        </section>
+        <div class="gutter-24" aria-hidden="true"></div>
+        <aside class="right-sidebar">
           {% include "core/partials/right_sidebar.html" %}
-          {% block right_sidebar %}{% endblock %}
-        </div>
+        </aside>
       </div>
     </main>
   </div>

--- a/templates/core/community.html
+++ b/templates/core/community.html
@@ -1,32 +1,23 @@
 {% extends "core/base.html" %}
 {% block content %}
-<div class="shell">
-  <div class="layout-grid">
-    <main class="feed-col">
-      <h1>{{ community.title }}</h1>
-      <p>{{ community.description }}</p>
-      {% if request.user.is_authenticated %}
-        <p><a class="button" href="{% url 'post_submit' %}" hx-boost="false">Submit</a></p>
-      {% endif %}
-      {% include "partials/sort_tabs.html" with active_sort=sort community_slug=community_slug sort_tabs=sort_tabs %}
-      {% if sort == 'top' %}
-      <div class="sort">
-        <div class="btn-group" role="group" aria-label="Select time range">
-          <a href="{% url 'community' community_slug %}?sort=top&t=24h" class="{% if t == '24h' %}active{% endif %}">Last 24h</a>
-          <a href="{% url 'community' community_slug %}?sort=top&t=7d" class="{% if t == '7d' %}active{% endif %}">Last 7d</a>
-          <a href="{% url 'community' community_slug %}?sort=top" class="{% if t == 'all' %}active{% endif %}">All</a>
-        </div>
-      </div>
-      {% endif %}
-      <div class="feed">
-        <div id="feed-list">
-          {% include "core/partials/post_list.html" with posts=posts next_page=next_page sort_query=sort_query %}
-        </div>
-      </div>
-    </main>
-    <aside class="sidebar-col">
-      {% include "core/partials/sidebar.html" %}
-    </aside>
+<h1>{{ community.title }}</h1>
+<p>{{ community.description }}</p>
+{% if request.user.is_authenticated %}
+  <p><a class="button" href="{% url 'post_submit' %}" hx-boost="false">Submit</a></p>
+{% endif %}
+{% include "partials/sort_tabs.html" with active_sort=sort community_slug=community_slug sort_tabs=sort_tabs %}
+{% if sort == 'top' %}
+<div class="sort">
+  <div class="btn-group" role="group" aria-label="Select time range">
+    <a href="{% url 'community' community_slug %}?sort=top&t=24h" class="{% if t == '24h' %}active{% endif %}">Last 24h</a>
+    <a href="{% url 'community' community_slug %}?sort=top&t=7d" class="{% if t == '7d' %}active{% endif %}">Last 7d</a>
+    <a href="{% url 'community' community_slug %}?sort=top" class="{% if t == 'all' %}active{% endif %}">All</a>
+  </div>
+</div>
+{% endif %}
+<div class="feed">
+  <div id="feed-list">
+    {% include "core/partials/post_list.html" with posts=posts next_page=next_page sort_query=sort_query %}
   </div>
 </div>
 {% endblock %}

--- a/templates/core/home.html
+++ b/templates/core/home.html
@@ -1,25 +1,13 @@
 {% extends "core/base.html" %}
 {% block header_center %}
-<nav id="sort-tabs" class="header-center" aria-label="Sort">
   <a href="?sort=hot"{% if request.GET.sort|default:'hot' == 'hot' %} aria-current="page"{% endif %}>Hot</a>
   <a href="?sort=new"{% if request.GET.sort == 'new' %} aria-current="page"{% endif %}>New</a>
   <a href="?sort=top{% if request.GET.t %}&t={{ request.GET.t }}{% endif %}"{% if request.GET.sort == 'top' %} aria-current="page"{% endif %}>Top</a>
-</nav>
 {% endblock %}
 {% block content %}
-<div class="shell">
-  <div class="layout-grid">
-    <main class="feed-col">
-      <section aria-labelledby="feed-heading">
-        <h1 id="feed-heading" class="sr-only">Feed</h1>
-
-        {% include "core/partials/post_list.html" with posts=posts next_page=next_page sort_query=sort_query %}
-      </section>
-    </main>
-    <aside class="sidebar-col">
-      {% include "core/partials/sidebar.html" %}
-    </aside>
-  </div>
-</div>
+<section aria-labelledby="feed-heading">
+  <h1 id="feed-heading" class="sr-only">Feed</h1>
+  {% include "core/partials/post_list.html" with posts=posts next_page=next_page sort_query=sort_query %}
+</section>
 {% endblock %}
 

--- a/templates/core/partials/header.html
+++ b/templates/core/partials/header.html
@@ -1,26 +1,18 @@
 {% load static %}
 <header class="header-bar" data-testid="header-bar">
-  <div class="header-left">
-    <details class="communities-dropdown">
-      <summary class="communities-toggle header-logo" aria-haspopup="true">
-        <img class="site-logo" src="{% static 'img/logo.svg' %}" alt="SureJan">
-      </summary>
-      <ul class="dropdown-menu" aria-label="Communities">
-        <li><a href="/r/news/">NEWS</a></li>
-        <li><a href="/r/brisbane/">BRISBANE</a></li>
-        <li><a href="/r/politics/">POLITICS</a></li>
-        <li><a href="/r/social/">SOCIAL</a></li>
-      </ul>
-    </details>
-  </div>
-  <nav id="sort-tabs" class="header-center" aria-label="Sort">
-    {% block header_center %}
-    <a href="?sort=hot" aria-current="page">Hot</a>
-    <a href="?sort=new">New</a>
-    <a href="?sort=top">Top</a>
-    {% endblock %}
-  </nav>
-  <div class="header-right">
-    {% block header_right %}{% endblock %}
+  <div class="header-inner">
+    <div class="hdr-left">
+      <a href="/" class="header-logo"><img class="site-logo" src="{% static 'img/logo.svg' %}" alt="SureJan"></a>
+    </div>
+    <nav class="hdr-center" id="sort-tabs" aria-label="Sort">
+      {% block header_center %}
+      <a href="?sort=hot" aria-current="page">Hot</a>
+      <a href="?sort=new">New</a>
+      <a href="?sort=top">Top</a>
+      {% endblock %}
+    </nav>
+    <div class="hdr-right">
+      {% block header_right %}{% endblock %}
+    </div>
   </div>
 </header>

--- a/templates/core/partials/left_communities.html
+++ b/templates/core/partials/left_communities.html
@@ -1,7 +1,7 @@
 <h2 class="side-title">Communities</h2>
-<div class="comm-list">
-  <a href="/r/news/">/r/news/</a>
-  <a href="/r/brisbane/">/r/brisbane/</a>
-  <a href="/r/politics/">/r/politics/</a>
-  <a href="/r/social/">/r/social/</a>
-</div>
+<nav class="comm-list" aria-label="Communities">
+  <a href="/r/news/">News</a>
+  <a href="/r/brisbane/">Brisbane</a>
+  <a href="/r/politics/">Politics</a>
+  <a href="/r/social/">Social</a>
+</nav>


### PR DESCRIPTION
## Summary
- Implement V3 page frame and grid with a single right sidebar include
- Replace slugged community list with readable labels
- Restructure header to 3-zone layout with consistent hooks

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'core')*


------
https://chatgpt.com/codex/tasks/task_e_68b7bee31698832c9f8520a14cfde639