### PR TITLE
Use dynamic community URLs in sidebar

### DIFF
--- a/templates/core/partials/left_communities.html
+++ b/templates/core/partials/left_communities.html
@@ -1,7 +1,7 @@
 <h2 class="side-title">Communities</h2>
 <nav class="comm-list" aria-label="Communities">
-  <a href="/r/news/">News</a>
-  <a href="/r/brisbane/">Brisbane</a>
-  <a href="/r/politics/">Politics</a>
-  <a href="/r/social/">Social</a>
+  <a href="{% url 'community' slug='news' %}">News</a>
+  <a href="{% url 'community' slug='brisbane' %}">Brisbane</a>
+  <a href="{% url 'community' slug='politics' %}">Politics</a>
+  <a href="{% url 'community' slug='social' %}">Social</a>
 </nav>


### PR DESCRIPTION
## Summary
- Replace hard-coded community links with Django URL tags using slugs

## Testing
- `DJANGO_COLLECTSTATIC=1 pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7c87b69dc832ca2cd4beccfda2703