### PR TITLE
Clean community headers

### DIFF
--- a/templates/core/community.html
+++ b/templates/core/community.html
@@ -9,7 +9,10 @@
 {% endblock %}
 
 {% block content %}
-  <h1 class="page-title">r/{{ community.name|default:community.slug }}</h1>
+  {# Title: prefer explicit display fields, then slug; no prefixes #}
+  <h1 class="page-title">
+    {{ community.title|default:community.name|default:community.slug }}
+  </h1>
 
   {% if posts and posts|length %}
     {% include "core/partials/post_list.html" with posts=posts %}

--- a/templates/core/home.html
+++ b/templates/core/home.html
@@ -6,7 +6,8 @@
 {% endblock %}
 {% block content %}
 <section aria-labelledby="feed-heading">
-  <h1 id="feed-heading" class="sr-only">Feed</h1>
+  {# optional: replace a “Feed” title #}
+  <h1 id="feed-heading" class="sr-only">Home</h1>
   {% include "core/partials/post_list.html" with posts=posts next_page=next_page sort_query=sort_query %}
 </section>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Remove `r/` prefixes from community headers
- Rename home page heading to `Home`

## Testing
- `python manage.py collectstatic --noinput`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7cf98ead0832c917c66247244dee7