### PR TITLE
Enforce HTTPS for image links and thumbnails

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -242,8 +242,14 @@ class PostImageLink(models.Model):
     url = models.URLField()
 
     def save(self, *args, **kwargs):
+        # Enforce a maximum of five images per post
         if not self.pk and self.post.image_links.count() >= 5:
             raise ValidationError("Maximum of 5 images per post")
+
+        # Upgrade insecure HTTP URLs to HTTPS before saving
+        if self.url and self.url.startswith("http://"):
+            self.url = "https://" + self.url[len("http://") :]
+
         super().save(*args, **kwargs)
 
 

--- a/core/tests/test_post_detail_media.py
+++ b/core/tests/test_post_detail_media.py
@@ -34,6 +34,9 @@ class PostDetailMediaTests(TestCase):
         )
         self.assertContains(resp, 'data-src="https://www.youtube-nocookie.com/embed/abc"')
         self.assertContains(resp, 'href="https://www.youtube.com/watch?v=abc"')
+        self.assertContains(
+            resp, 'src="https://img.youtube.com/vi/abc/hqdefault.jpg"'
+        )
 
     @patch("core.utils.embeds.fetch_oembed")
     def test_rumble_embed_has_placeholder(self, mock_oembed):
@@ -54,6 +57,7 @@ class PostDetailMediaTests(TestCase):
         )
         self.assertContains(resp, 'data-src="https://rumble.com/embed/vxyz/?pub=4"')
         self.assertContains(resp, 'href="https://rumble.com/vxyz-test.html"')
+        self.assertContains(resp, 'src="https://thumb.jpg"')
 
     def test_image_slideshow_renders(self):
         post = Post.objects.create(
@@ -69,3 +73,4 @@ class PostDetailMediaTests(TestCase):
         )
         self.assertContains(resp, 'class="post-images"')
         self.assertContains(resp, 'href="#img1"')
+        self.assertContains(resp, 'src="https://example.com/0.jpg"')

--- a/core/tests/test_post_image_link.py
+++ b/core/tests/test_post_image_link.py
@@ -28,3 +28,10 @@ class PostImageLinkTests(TestCase):
             PostImageLink.objects.create(
                 post=self.post, url="http://example.com/6.jpg"
             )
+
+    def test_http_url_upgraded_to_https(self):
+        link = PostImageLink.objects.create(
+            post=self.post, url="http://example.com/img.jpg"
+        )
+        link.refresh_from_db()
+        self.assertEqual(link.url, "https://example.com/img.jpg")

--- a/core/utils/embeds.py
+++ b/core/utils/embeds.py
@@ -33,6 +33,9 @@ def build_embed_html(url: str) -> str:
         )
 
     thumb = data.get("thumbnail_url", "")
+    # Prefer secure thumbnails when available
+    if thumb.startswith("http://"):
+        thumb = "https://" + thumb[len("http://") :]
     html = data.get("html", "")
 
     src = ""


### PR DESCRIPTION
## Summary
- upgrade PostImageLink URLs from http to https on save
- force https for embed thumbnails
- update media tests for https expectations and add regression test for URL upgrade

## Testing
- `python manage.py test core.tests.test_post_detail_media core.tests.test_post_image_link` *(fails: The file 'css/app.css' could not be found with <whitenoise.storage.CompressedManifestStaticFilesStorage>)*

------
https://chatgpt.com/codex/tasks/task_e_68b7d1654d70832c8a9c8881b701a320