### PR TITLE
Switch community URLs to /c/

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -24,7 +24,7 @@ urlpatterns = [
     path("privacy/", TemplateView.as_view(template_name="legal/privacy.html"), name="privacy"),
     path("rules/", TemplateView.as_view(template_name="legal/rules.html"), name="rules"),
     path("r", core.communities_index, name="communities_index"),
-    path("r/<slug:slug>", core.community, name="community"),
+    path("c/<slug:slug>/", core.community, name="community"),
     path("", include("core.urls")),
 ]
 

--- a/templates/core/communities_index.html
+++ b/templates/core/communities_index.html
@@ -3,7 +3,7 @@
 <div class="shell">
   <ul>
     {% for c in communities %}
-      <li><a href="/r/{{ c.slug }}{{ qs }}">{{ c.name }}</a></li>
+      <li><a href="{% url 'community' c.slug %}{{ qs }}">{{ c.name }}</a></li>
     {% endfor %}
   </ul>
 </div>

--- a/templates/core/partials/comment_row.html
+++ b/templates/core/partials/comment_row.html
@@ -2,7 +2,7 @@
 <div class="comment-row">
   <p>{{ comment.body }}</p>
   <small>
-    in <a href="{% url 'community' comment.post.community.slug %}">/r/{{ comment.post.community.slug }}/</a>
+    in <a href="{% url 'community' comment.post.community.slug %}">/c/{{ comment.post.community.slug }}/</a>
     on <a href="{% url 'post_detail' comment.post.community.slug comment.post.pk comment.post.slug %}">{{ comment.post.title }}</a>
     · <time datetime="{{ comment.created_at|date:'c' }}" data-ts="{{ comment.created_at|date:'U' }}" title="{{ comment.created_at|date:'Y-m-d H:i' }}">{{ comment.created_at|timesince }} ago</time>
   </small>


### PR DESCRIPTION
## Summary
- Change community path to `/c/<slug>/`
- Replace hardcoded community links with `{% url 'community' %}` and update display text

## Testing
- `python manage.py runserver`
- `python manage.py test --noinput --failfast` (fails: ValueError: The file 'css/app.css' could not be found)


------
https://chatgpt.com/codex/tasks/task_e_68b7d4ab8574832c992202580397db86