### PR TITLE
Simplify community page title and empty posts messaging

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -71,6 +71,7 @@ html,body{background:var(--color-bg); color:var(--color-text); font-family:var(-
   margin-bottom:var(--space-5);
 }
 .empty-state{ color:#666666; padding:var(--space-6) 0; text-align:center; }
+.empty-community{ color:#666666; padding:var(--space-6) 0; text-align:center; }
 
 /* Two-column layout -------------------------------------------------- */
 .layout-grid{ display:flex; flex-direction:column; gap:var(--space-6); }

--- a/templates/core/community.html
+++ b/templates/core/community.html
@@ -9,14 +9,11 @@
 {% endblock %}
 
 {% block content %}
-  {# Title: prefer explicit display fields, then slug; no prefixes #}
-  <h1 class="page-title">
-    {{ community.title|default:community.name|default:community.slug }}
-  </h1>
+  <h1>{{ community.name }}</h1>
 
-  {% if posts and posts|length %}
-    {% include "core/partials/post_list.html" with posts=posts %}
-  {% else %}
-    <div class="empty-state" data-testid="empty-state">No posts yet.</div>
+  {% include "core/partials/post_list.html" with posts=posts %}
+
+  {% if not posts %}
+    <div class="empty-community">No posts here</div>
   {% endif %}
 {% endblock %}

--- a/templates/core/partials/post_list.html
+++ b/templates/core/partials/post_list.html
@@ -1,5 +1,3 @@
 {% for post in posts %}
   {% include "core/partials/post_row.html" with post=post %}
-{% empty %}
-  <div class="empty-state" data-testid="empty-state">No posts yet.</div>
 {% endfor %}


### PR DESCRIPTION
## Summary
- Show community name directly in community page header
- Display 'No posts here' when a community has no posts
- Add styling for `.empty-community`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'core')*


------
https://chatgpt.com/codex/tasks/task_e_68b7d6243ee8832cadbe6fd7f07c44ec