### PR TITLE
feat: move logo to header

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -147,4 +147,3 @@ html,body{background:var(--color-bg); color:var(--color-text); font-family:var(-
   text-decoration: none;
 }
 .nav-tabs { display:flex; justify-content:center; gap:32px; }
-.sidebar-logo { display:block; margin:0 0 16px; }

--- a/templates/core/partials/header.html
+++ b/templates/core/partials/header.html
@@ -1,7 +1,11 @@
 {% load static %}
 <header class="header-bar" data-testid="header-bar">
   <div class="header-inner">
-    <div class="hdr-left"></div>
+    <div class="hdr-left">
+      <a class="header-logo" href="{% url 'home' %}">
+        <img class="site-logo" src="{% static 'logo.png' %}" alt="SureJan">
+      </a>
+    </div>
     <nav id="sort-tabs" class="hdr-center nav-tabs" aria-label="Global sort">
       {% block header_center %}
       <a href="/?sort=hot"{% if request.GET.sort|default:'hot' == 'hot' %} aria-current="page"{% endif %}>Hot</a>

--- a/templates/core/partials/left_communities.html
+++ b/templates/core/partials/left_communities.html
@@ -1,7 +1,3 @@
-{% load static %}
-<a class="sidebar-logo" href="{% url 'home' %}">
-  <img class="site-logo" src="{% static 'logo.png' %}" alt="SureJan">
-</a>
 <h2 class="side-title">Communities</h2>
 <nav class="comm-list" aria-label="Communities">
   <a href="{% url 'community' 'news' %}">News</a>


### PR DESCRIPTION
## Summary
- move site logo into header and link it to home
- remove logo from communities sidebar
- drop unused sidebar logo CSS

## Testing
- `DJANGO_COLLECTSTATIC=1 python manage.py collectstatic --noinput`
- `DJANGO_COLLECTSTATIC=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7e466d970832cba6cc2290a3f4c21