### PR TITLE
Implement sticky site-wide footer

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -147,3 +147,47 @@ html,body{background:var(--color-bg); color:var(--color-text); font-family:var(-
   text-decoration: none;
 }
 .nav-tabs { display:flex; justify-content:center; gap:32px; }
+
+/* Sticky footer layout */
+html, body { height: 100%; }
+body.layout-root {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+.layout-main { flex: 1 0 auto; }
+
+/* Footer */
+.site-footer {
+  margin-top: auto;         /* push to bottom */
+  width: 100%;
+  border-top: 1px solid var(--border, #e5e7eb);
+  background: var(--footer-bg, #fff);
+}
+.site-footer .footer-shell {
+  max-width: 1024px;
+  margin: 0 auto;
+  padding: 16px 12px;
+}
+.site-footer .footer-links {
+  margin: 0;
+  color: var(--muted, #6b7280);
+  font-size: 14px;
+}
+.site-footer .footer-links a {
+  text-decoration: none;
+}
+
+/* Prevent footer from inheriting grid/aside styling */
+.page .site-footer, .left-communities .site-footer { 
+  /* never nest footers inside grid columns */
+  all: unset; /* reset if accidentally nested */
+}
+
+/* If 'all: unset' is too aggressive for your stack, instead ensure the footer is not inside .page */
+
+/* Optional: ensure .page grid doesn’t overlap the footer */
+.page { position: relative; }
+
+/* Ensure left column doesn't wrap the footer on short pages */
+.left-communities { align-self: flex-start; }

--- a/templates/core/base.html
+++ b/templates/core/base.html
@@ -8,45 +8,26 @@
   <link rel="stylesheet" href="{% static 'css/app.css' %}">
   {% block head %}{% endblock %}
 </head>
-<body>
-  <!-- Header -->
-  <header class="header-bar" data-testid="header-bar">
-    <div class="nav-left">
-      <!-- Logo = Home -->
-      <a class="header-logo" href="{% url 'home' %}">
-        <img class="site-logo" src="{% static 'logo.png' %}" alt="SureJan">
-      </a>
-    </div>
-
-    <!-- Centered sort tabs -->
-    <nav id="sort-tabs" class="nav-tabs" aria-label="Sort">
-      <a href="?sort=hot"{% if request.GET.sort|default:'hot' == 'hot' %} aria-current="page"{% endif %}>Hot</a>
-      <a href="?sort=new"{% if request.GET.sort == 'new' %} aria-current="page"{% endif %}>New</a>
-      <a href="?sort=top"{% if request.GET.sort == 'top' %} aria-current="page"{% endif %}>Top</a>
-    </nav>
-
-    <div class="nav-right"><!-- reserved for auth/user links --></div>
-  </header>
-
-  <!-- Page body -->
-  <div class="page">
-    <aside class="left-communities" aria-label="Communities">
-      {% include "core/partials/left_communities.html" %}
-    </aside>
-
-    <main class="shell-1024" role="main">
-      <div class="grid-3">
-        <section class="feed-col">
-          {% block content %}{% endblock %}
-        </section>
-        <div class="gutter-24" aria-hidden="true"></div>
-        <aside class="right-sidebar">
-          {% include "core/partials/right_sidebar.html" %}
-        </aside>
+<body class="layout-root">
+  {% include "core/partials/header.html" %}
+  <main id="app-main" class="layout-main" role="main">
+    <div class="page">
+      <aside class="left-communities" aria-label="Communities">
+        {% include "core/partials/left_communities.html" %}
+      </aside>
+      <div class="shell-1024">
+        <div class="grid-3">
+          <section class="feed-col">
+            {% block content %}{% endblock %}
+          </section>
+          <div class="gutter-24" aria-hidden="true"></div>
+          <aside class="right-sidebar">
+            {% include "core/partials/right_sidebar.html" %}
+          </aside>
+        </div>
       </div>
-    </main>
-  </div>
-
+    </div>
+  </main>
   {% include "core/partials/footer.html" %}
   {% block scripts %}{% endblock %}
 </body>

--- a/templates/core/partials/footer.html
+++ b/templates/core/partials/footer.html
@@ -1,5 +1,9 @@
-<footer class="footer">
-  <a href="{% url 'terms' %}">Terms</a> ·
-  <a href="{% url 'privacy' %}">Privacy</a> ·
-  <a href="{% url 'mission' %}">About</a>
+<footer class="site-footer" role="contentinfo">
+  <div class="footer-shell">
+    <p class="footer-links">
+      <a href="{% url 'terms' %}">Terms</a> ·
+      <a href="{% url 'privacy' %}">Privacy</a> ·
+      <a href="{% url 'mission' %}">About</a>
+    </p>
+  </div>
 </footer>


### PR DESCRIPTION
## Summary
- Refactor base template to use flex layout and keep footer outside the grid
- Replace footer partial with full-width footer markup
- Add CSS rules for sticky footer layout and isolation from page grid

## Testing
- `DJANGO_COLLECTSTATIC=1 python manage.py collectstatic --noinput`
- `DJANGO_COLLECTSTATIC=1 pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7edea21ec832ca4c7672502291c42