### PR TITLE
Move auth links from header to sidebar

### DIFF
--- a/templates/core/partials/header.html
+++ b/templates/core/partials/header.html
@@ -14,11 +14,7 @@
       {% endblock %}
     </nav>
     <div class="hdr-right">
-      {% if request.user.is_authenticated %}
-        <span class="account-name">{{ request.user.username }}</span>
-      {% else %}
-        <a href="{% url 'login' %}">Login</a> | <a href="{% url 'signup' %}">Signup</a>
-      {% endif %}
+      {% block header_right %}{% endblock %}
     </div>
   </div>
 </header>

--- a/templates/core/partials/right_sidebar.html
+++ b/templates/core/partials/right_sidebar.html
@@ -1,12 +1,4 @@
-<div class="account-block">
-  <p class="side-title">Account</p>
-  {% if user.is_authenticated %}
-    <p>{{ user.username }}</p>
-  {% else %}
-    <a class="sidebar-link" href="{% url 'login' %}">Login</a>
-    <a class="sidebar-link" href="{% url 'signup' %}">Signup</a>
-  {% endif %}
-</div>
+{% include "partials/user_box.html" %}
 <div class="sidebar-cta" data-testid="sidebar-cta">
   <a class="btn btn-primary" href="{% url 'post_submit' %}" data-testid="sidebar-submit">Submit Post</a>
   <p class="muted"><a class="sidebar-link" href="{% url 'transparency_methods' %}" data-testid="sidebar-astro">Anti-Astroturf</a></p>


### PR DESCRIPTION
## Summary
- Remove login/signup links from header and leave hdr-right empty
- Consolidate account controls in right sidebar via shared user_box partial

## Testing
- `python manage.py collectstatic --noinput`
- `flyctl deploy -a surejan --remote-only` *(fails: command not found)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7f1386634832c8ed38d35e8b80722