### PR TITLE
Increase header logo size

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -117,7 +117,7 @@ html,body{background:var(--color-bg); color:var(--color-text); font-family:var(-
 /* Header: 128px band with 3 zones */
 .header-inner{max-width:1440px;margin:0 auto;display:grid;grid-template-columns:1fr 1fr 1fr;gap:24px;align-items:center;padding:0 24px}
 .hdr-left{justify-self:start}.hdr-center{justify-self:center}.hdr-right{justify-self:end}
-.site-logo{max-height:48px;height:auto;width:auto;object-fit:contain;display:block}
+.site-logo{max-height:64px;height:auto;width:auto;object-fit:contain;display:block}
 
 /* Page: left communities (200–240) + main shell */
 .page{display:grid;grid-template-columns:minmax(200px,240px) 1fr}


### PR DESCRIPTION
## Summary
- increase header logo max-height to 64px

## Testing
- `AWS_STORAGE_BUCKET_NAME=dummy AWS_ACCESS_KEY_ID=dummy AWS_SECRET_ACCESS_KEY=dummy AWS_S3_ENDPOINT_URL=http://example.com MEDIA_URL=http://example.com/ python manage.py test` *(fails: The file 'css/app.css' could not be found with <whitenoise.storage.CompressedManifestStaticFilesStorage>)*

------
https://chatgpt.com/codex/tasks/task_e_68b7f587f99c832caa3ed4edd826dc83