### PR TITLE
Adjust site logo sizing

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -119,6 +119,11 @@ html,body{background:var(--color-bg); color:var(--color-text); font-family:var(-
 .hdr-left{justify-self:start}.hdr-center{justify-self:center}.hdr-right{justify-self:end}
 .site-logo{max-height:64px;height:auto;width:auto;object-fit:contain;display:block}
 
+/* Keep it tidy on phones */
+@media (max-width: 768px){
+  .site-logo { max-height: 32px; }
+}
+
 /* Page: left communities (200–240) + main shell */
 .page{display:grid;grid-template-columns:minmax(200px,240px) 1fr}
 .left-communities{border-right:1px solid #eee;padding:24px 12px}


### PR DESCRIPTION
## Summary
- Allow header logo to scale up to 64px
- Cap logo at 32px on narrow screens

## Testing
- `DJANGO_COLLECTSTATIC=1 python manage.py test` *(fails: FAILED (failures=6, errors=28))*

------
https://chatgpt.com/codex/tasks/task_e_68b802273544832cac7f8ce6610ad31f