### PR TITLE
Expand and make header logo responsive

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -194,16 +194,21 @@ body.layout-root {
 /* Ensure left column doesn't wrap the footer on short pages */
 .left-communities { align-self: flex-start; }
 
-/* Header logo size (forces upscaling if the source is small) */
+/* FINAL header logo sizing (desktop/tablet/phone) */
 .header-bar .site-logo{
-  height: 64px;        /* or 86px if you want ~80% bigger than 48 */
-  max-height: none;    /* don't clamp it back down */
+  height: 86px;          /* desktop ~80% bigger than 48 */
+  max-height: none;
   width: auto;
   object-fit: contain;
   display: block;
 }
 
-/* Keep it tidy on phones */
-@media (max-width: 768px){
-  .header-bar .site-logo{ height: 32px; }
+/* tablet */
+@media (max-width: 1024px){
+  .header-bar .site-logo{ height: 64px; }
+}
+
+/* phone */
+@media (max-width: 640px){
+  .header-bar .site-logo{ height: 40px; }
 }


### PR DESCRIPTION
## Summary
- enlarge site logo and add responsive sizes for desktop, tablet, and phone
- remove previous logo sizing rules to let new styles cascade

## Testing
- `DJANGO_DEBUG=1 pytest >/tmp/pytest.log 2>&1; tail -n 20 /tmp/pytest.log` *(fails: RuntimeError: S3 media env not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68b813f514e0832ca996de467d3d73d6