### PR TITLE
Handle multiple comments in comment partial

### DIFF
--- a/templates/core/partials/comment.html
+++ b/templates/core/partials/comment.html
@@ -1,2 +1,12 @@
-{% url 'post_detail' comment.post.community.slug comment.post.pk comment.post.slug as post_url %}
-{% include "core/partials/comment_item.html" %}
+{% if comments != '' %}
+  {% for c in comments %}
+    {% if not c.parent_id %}
+      {% include "core/partials/comment_item.html" with comment=c %}
+    {% endif %}
+  {% empty %}
+    <p>No comments yet.</p>
+  {% endfor %}
+{% else %}
+  {% include "core/partials/comment_item.html" %}
+{% endif %}
+


### PR DESCRIPTION
## Summary
- Render lists of comments when a `comments` context variable is provided
- Fallback to single comment rendering for `comment_create` and similar views

## Testing
- `python manage.py collectstatic --noinput`
- `AWS_STORAGE_BUCKET_NAME=foo AWS_ACCESS_KEY_ID=foo AWS_SECRET_ACCESS_KEY=foo AWS_S3_ENDPOINT_URL=http://example.com MEDIA_URL=http://example.com pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8b81e6814832c8d43380da89ecd91