### PR TITLE
Render uploaded media in post detail

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -300,3 +300,10 @@ body.layout-root {
 @media (min-width:768px){
   .post-gallery{ grid-template-columns:repeat(2,1fr); }
 }
+
+.post-media{ margin:16px 0; }
+.post-media img{ display:block; max-width:100%; height:auto; border-radius:12px; }
+
+.aspect-16-9{ position:relative; padding-top:56.25%; overflow:hidden; border-radius:12px; background:#000; }
+.aspect-16-9 .embed-inner{ position:absolute; inset:0; }
+.aspect-16-9 iframe, .aspect-16-9 video{ width:100%; height:100%; display:block; }

--- a/templates/core/post_detail.html
+++ b/templates/core/post_detail.html
@@ -17,17 +17,36 @@
     </div>
   </header>
 
-  <div class="post-media">
-    {% if images %}
-      {% for image in images %}
-        <img src="{{ image.url }}" alt="" class="post-image" loading="lazy" decoding="async">
-      {% endfor %}
-    {% elif post.image %}
-      <img src="{{ post.image.url }}" alt="" class="post-image" loading="lazy" decoding="async" referrerpolicy="no-referrer">
-    {% elif embed_html %}
-      <div class="post-embed">{{ embed_html|safe }}</div>
-    {% endif %}
+{% comment %} Media priority: gallery → upload → embed → link {% endcomment %}
+{% if images %}
+  <div class="post-gallery">
+    {% for link in images %}
+      <figure class="post-media">
+        <img
+          src="{{ link.url|default:link }}"
+          alt="{{ post.title }}"
+          loading="lazy" decoding="async" referrerpolicy="no-referrer"
+          onerror="this.onerror=null; this.closest('figure').remove()"
+        >
+      </figure>
+    {% endfor %}
   </div>
+{% elif post.image %}
+  <figure class="post-media">
+    <img
+      src="{{ post.image.url }}"
+      alt="{{ post.title }}"
+      loading="lazy" decoding="async" referrerpolicy="no-referrer"
+      onerror="this.onerror=null; this.closest('figure').remove()"
+    >
+  </figure>
+{% elif embed_html %}
+  <div class="post-embed aspect-16-9">
+    <div class="embed-inner">{{ embed_html|safe }}</div>
+  </div>
+{% elif post.content_url %}
+  <p class="link-card"><a href="{{ post.content_url }}" rel="noopener nofollow">{{ post.content_url }}</a></p>
+{% endif %}
 
   {% if post.body %}
   <div class="post-body prose">


### PR DESCRIPTION
## Summary
- Show gallery images, uploaded image, embeds or link in post detail with correct priority
- Ensure post media and embeds scale within layout

## Testing
- `python manage.py collectstatic --noinput`
- `pytest`
- `flyctl deploy -a surejan --remote-only` *(fails: command not found; install attempt could not reach fly.io)*

------
https://chatgpt.com/codex/tasks/task_e_68b8bc53d7f0832c93e1ae9aa9b439ff