### PR TITLE
feat: add responsive image previews

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -229,36 +229,6 @@ body.layout-root {
   font-size:0.875rem;
 }
 
-/* Media elements */
-.post-gallery{
-  display:grid;
-  grid-template-columns:1fr;
-  gap:var(--space-3);
-  margin-top:var(--space-4);
-}
-.post-media img{
-  width:100%;
-  border-radius:var(--radius-md);
-  display:block;
-}
-.post-embed{
-  position:relative;
-  width:100%;
-  overflow:hidden;
-  border-radius:var(--radius-md);
-}
-.aspect-16-9{
-  position:relative;
-  padding-top:56.25%;
-}
-.aspect-16-9 .embed-inner{
-  position:absolute;
-  top:0;
-  left:0;
-  width:100%;
-  height:100%;
-}
-
 /* Post actions */
 .post-actions{
   display:flex;
@@ -296,14 +266,40 @@ body.layout-root {
   gap:var(--space-3);
 }
 
-/* Responsive gallery */
-@media (min-width:768px){
-  .post-gallery{ grid-template-columns:repeat(2,1fr); }
+/* Feed card thumbnail */
+.post-card .thumb{
+  display:block;
+  border-radius:12px;
+  overflow:hidden;
+  background:#f2f2f2;
+}
+.post-card .thumb img{
+  display:block;
+  width:100%;
+  height:auto;
+  aspect-ratio:16/9;      /* prevents layout shift */
+  object-fit:cover;        /* fill the frame */
 }
 
+/* Post detail media */
 .post-media{ margin:16px 0; }
-.post-media img{ display:block; max-width:100%; height:auto; border-radius:12px; }
+.post-media img{
+  display:block;
+  max-width:100%;
+  height:auto;
+  border-radius:12px;
+}
+@media (min-width:1024px){
+  .post-media img{ max-height:80vh; } /* don’t get too tall */
+}
 
+/* Simple 2-up gallery on larger screens */
+.post-gallery{ display:grid; grid-template-columns:1fr; gap:12px; }
+@media (min-width:768px){
+  .post-gallery{ grid-template-columns:1fr 1fr; }
+}
+
+/* 16:9 embed frame */
 .aspect-16-9{ position:relative; padding-top:56.25%; overflow:hidden; border-radius:12px; background:#000; }
 .aspect-16-9 .embed-inner{ position:absolute; inset:0; }
 .aspect-16-9 iframe, .aspect-16-9 video{ width:100%; height:100%; display:block; }

--- a/templates/partials/feed_card.html
+++ b/templates/partials/feed_card.html
@@ -1,14 +1,24 @@
 {% load url_domain astro_filters %}
 <article class="post-card" data-testid="post-card">
+{% with detail_url=post.get_absolute_url|default:None %}
+  {% if not detail_url %}{% url 'post_detail_id' post.pk as detail_url %}{% endif %}
   {% if post.image_thumb or post.image %}
-  <a href="{{ post.get_absolute_url }}" class="thumb">
-    {% if post.image_thumb %}
-    <img src="{{ post.image_thumb.url }}" alt="" width="120" height="120" loading="lazy" decoding="async">
-    {% else %}
-    <img src="{{ post.image.url }}" alt="" width="120" height="120" loading="lazy" decoding="async">
-    {% endif %}
-  </a>
+    <a href="{{ detail_url }}" class="thumb" aria-label="Open post">
+      {% if post.image_thumb %}
+        <img
+          src="{{ post.image_thumb.url }}"
+          alt="{{ post.title }}"
+          loading="lazy" decoding="async"
+          width="640" height="360">
+      {% else %}
+        <img
+          src="{{ post.image.url }}"
+          alt="{{ post.title }}"
+          loading="lazy" decoding="async">
+      {% endif %}
+    </a>
   {% endif %}
+{% endwith %}
   <div class="post-meta">
     r/{{ post.community.slug }} · {{ post.author.username }} · {{ post.created_at|timesince }} ago
   </div>


### PR DESCRIPTION
## Summary
- show image thumbnails on feed cards with fallback URL resolution
- ensure post images scale responsively and thumbnails keep 16:9 aspect

## Testing
- `DJANGO_COLLECTSTATIC=1 python manage.py collectstatic --noinput`
- `DJANGO_COLLECTSTATIC=1 pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8bf5dced4832cbbcdae99bc30d443