### PR TITLE
Consolidate community URLs under /r prefix

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -4,7 +4,7 @@ from django.conf.urls.static import static as serve_static
 from django.contrib import admin
 from django.contrib.auth.views import LogoutView
 from django.urls import path, include
-from django.views.generic import TemplateView
+from django.views.generic import TemplateView, RedirectView
 from django.http import HttpResponse
 
 from core import views as core
@@ -24,7 +24,11 @@ urlpatterns = [
     path("privacy/", TemplateView.as_view(template_name="legal/privacy.html"), name="privacy"),
     path("rules/", TemplateView.as_view(template_name="legal/rules.html"), name="rules"),
     path("r", core.communities_index, name="communities_index"),
-    path("c/<slug:slug>/", core.community, name="community"),
+    path("r/<slug:slug>/", core.community, name="community"),
+    path(
+        "c/<slug:slug>/",
+        RedirectView.as_view(pattern_name="community", permanent=True),
+    ),
     path("", include("core.urls")),
 ]
 

--- a/core/tests/test_routes.py
+++ b/core/tests/test_routes.py
@@ -27,6 +27,14 @@ class RouteTests(TestCase):
         resp = self.client.get(reverse("community", args=[self.community.slug]))
         self.assertEqual(resp.status_code, 200)
 
+    def test_c_prefix_redirects(self):
+        resp = self.client.get(f"/c/{self.community.slug}/")
+        self.assertRedirects(
+            resp,
+            reverse("community", args=[self.community.slug]),
+            status_code=301,
+        )
+
     def test_post_detail_id(self):
         resp = self.client.get(reverse("post_detail_id", args=[self.post.pk]))
         self.assertEqual(resp.status_code, 200)

--- a/templates/core/partials/comment_row.html
+++ b/templates/core/partials/comment_row.html
@@ -2,7 +2,7 @@
 <div class="comment-row">
   <p>{{ comment.body }}</p>
   <small>
-    in <a href="{% url 'community' comment.post.community.slug %}">/c/{{ comment.post.community.slug }}/</a>
+    in <a href="{% url 'community' comment.post.community.slug %}">r/{{ comment.post.community.slug }}</a>
     on <a href="{% url 'post_detail' comment.post.community.slug comment.post.pk comment.post.slug %}">{{ comment.post.title }}</a>
     · <time datetime="{{ comment.created_at|date:'c' }}" data-ts="{{ comment.created_at|date:'U' }}" title="{{ comment.created_at|date:'Y-m-d H:i' }}">{{ comment.created_at|timesince }} ago</time>
   </small>


### PR DESCRIPTION
## Summary
- Serve community pages at `/r/<slug>/` and redirect legacy `/c/<slug>/`
- Update templates to show `r/slug` notation
- Add regression test for `/c/<slug>/` redirect

## Testing
- `python manage.py test` *(fails: ValueError: The file 'css/app.css' could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8c18cc478832cb7dca7661f761c93