### PR TITLE
Use get_absolute_url for feed post cards

### DIFF
--- a/core/tests/test_links.py
+++ b/core/tests/test_links.py
@@ -1,7 +1,11 @@
 from django.contrib.auth import get_user_model
 from django.core.cache import cache
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.template.loader import render_to_string
 from django.test import TestCase
 from django.urls import reverse
+from io import BytesIO
+from PIL import Image
 
 from ..models import Comment, Community, Post
 
@@ -51,3 +55,35 @@ class CommentLinkTests(TestCase):
             user_url = reverse("user_overview", args=[comment.author.username])
             self.assertEqual(user_url, f"/u/{comment.author.username}/")
             self.assertContains(resp, f'href="{user_url}"')
+
+
+class PostLinkTests(TestCase):
+    def setUp(self):
+        cache.clear()
+        U = get_user_model()
+        self.user = U.objects.create_user("alice", password="pwd")
+        self.community = Community.objects.create(
+            slug="t", name="Test", title="Test", created_by=self.user
+        )
+        buf = BytesIO()
+        Image.new("RGB", (1, 1)).save(buf, format="PNG")
+        img = SimpleUploadedFile("a.png", buf.getvalue(), content_type="image/png")
+        self.post = Post.objects.create(
+            community=self.community,
+            author=self.user,
+            post_type="image",
+            title="Hello",
+            image=img,
+        )
+
+    def test_feed_card_uses_absolute_url(self):
+        url = self.post.get_absolute_url()
+        html = render_to_string("partials/feed_card.html", {"post": self.post})
+        self.assertEqual(html.count(f'href="{url}"'), 2)
+        self.assertIn(f'href="{url}#comments"', html)
+
+    def test_post_row_uses_absolute_url(self):
+        url = self.post.get_absolute_url()
+        html = render_to_string("core/partials/post_row.html", {"post": self.post})
+        self.assertEqual(html.count(f'href="{url}"'), 2)
+        self.assertIn(f'href="{url}#comments"', html)

--- a/templates/core/partials/post_row.html
+++ b/templates/core/partials/post_row.html
@@ -1,26 +1,28 @@
 <article class="post-card" data-testid="post-card">
-  {% if post.image_thumb or post.image %}
-  <a href="{{ post.get_absolute_url }}" class="thumb">
-    {% if post.image_thumb %}
-    <img src="{{ post.image_thumb.url }}" alt="" width="120" height="120" loading="lazy" decoding="async">
-    {% else %}
-    <img src="{{ post.image.url }}" alt="" width="120" height="120" loading="lazy" decoding="async">
+  {% with detail_url=post.get_absolute_url %}
+    {% if post.image_thumb or post.image %}
+    <a href="{{ detail_url }}" class="thumb">
+      {% if post.image_thumb %}
+      <img src="{{ post.image_thumb.url }}" alt="" width="120" height="120" loading="lazy" decoding="async">
+      {% else %}
+      <img src="{{ post.image.url }}" alt="" width="120" height="120" loading="lazy" decoding="async">
+      {% endif %}
+    </a>
     {% endif %}
-  </a>
-  {% endif %}
-  <div class="post-meta">
-    r/{{ post.community.slug }} · {{ post.author.username }} · {{ post.created_at|timesince }} ago
-  </div>
-  <h3 class="post-title"><a href="{{ post.get_absolute_url }}">{{ post.title }}</a></h3>
-  {% if post.body %}
-  <p class="post-excerpt">{{ post.body|truncatechars:180 }}</p>
-  {% endif %}
-  <div class="post-actions">
-    <div class="vote">
-      <button class="up" hx-post="{% url 'vote_post' post.pk %}?v=1" hx-target="#score-{{ post.pk }}" hx-swap="outerHTML" aria-label="Upvote">▲</button>
-      <span id="score-{{ post.pk }}" class="score">{{ post.score }}</span>
-      <button class="down" hx-post="{% url 'vote_post' post.pk %}?v=-1" hx-target="#score-{{ post.pk }}" hx-swap="outerHTML" aria-label="Downvote">▼</button>
+    <div class="post-meta">
+      r/{{ post.community.slug }} · {{ post.author.username }} · {{ post.created_at|timesince }} ago
     </div>
-    <a href="{{ post.get_absolute_url }}#comments">{{ post.comment_count }} comments</a>
-  </div>
+    <h3 class="post-title"><a href="{{ detail_url }}">{{ post.title }}</a></h3>
+    {% if post.body %}
+    <p class="post-excerpt">{{ post.body|truncatechars:180 }}</p>
+    {% endif %}
+    <div class="post-actions">
+      <div class="vote">
+        <button class="up" hx-post="{% url 'vote_post' post.pk %}?v=1" hx-target="#score-{{ post.pk }}" hx-swap="outerHTML" aria-label="Upvote">▲</button>
+        <span id="score-{{ post.pk }}" class="score">{{ post.score }}</span>
+        <button class="down" hx-post="{% url 'vote_post' post.pk %}?v=-1" hx-target="#score-{{ post.pk }}" hx-swap="outerHTML" aria-label="Downvote">▼</button>
+      </div>
+      <a href="{{ detail_url }}#comments">{{ post.comment_count }} comments</a>
+    </div>
+  {% endwith %}
 </article>

--- a/templates/partials/feed_card.html
+++ b/templates/partials/feed_card.html
@@ -1,7 +1,6 @@
 {% load url_domain astro_filters %}
 <article class="post-card" data-testid="post-card">
-{% with detail_url=post.get_absolute_url|default:None %}
-  {% if not detail_url %}{% url 'post_detail_id' post.pk as detail_url %}{% endif %}
+{% with detail_url=post.get_absolute_url %}
   {% if post.image_thumb or post.image %}
     <a href="{{ detail_url }}" class="thumb" aria-label="Open post">
       {% if post.image_thumb %}
@@ -18,11 +17,10 @@
       {% endif %}
     </a>
   {% endif %}
-{% endwith %}
   <div class="post-meta">
     r/{{ post.community.slug }} · {{ post.author.username }} · {{ post.created_at|timesince }} ago
   </div>
-  <h3 class="post-title"><a href="{{ post.get_absolute_url }}">{{ post.title }}</a></h3>
+  <h3 class="post-title"><a href="{{ detail_url }}">{{ post.title }}</a></h3>
   {% if post.is_deleted %}<span class="state-badge">deleted</span>{% endif %}
   {% if post.is_draft %}<span class="state-badge">draft</span>{% endif %}
   {% if post.body %}
@@ -34,7 +32,7 @@
       <span id="score-{{ post.pk }}" class="score">{{ post.score }}</span>
       <button class="down" hx-post="{% url 'vote_post' post.pk %}?v=-1" hx-target="#score-{{ post.pk }}" hx-swap="outerHTML" aria-label="Downvote">▼</button>
     </div>
-    <a href="{{ post.get_absolute_url }}#comments">{{ post.comment_count }} comments</a>
+    <a href="{{ detail_url }}#comments">{{ post.comment_count }} comments</a>
     {% if post.astro_score %}
     <details class="astro-why">
       <summary class="chip {{ post.astro_score.score|astro_band }}">Astro {{ post.astro_score.score }}</summary>
@@ -46,4 +44,5 @@
     </details>
     {% endif %}
   </div>
+{% endwith %}
 </article>


### PR DESCRIPTION
## Summary
- unify post detail link generation in feed_card and post_row templates via `get_absolute_url`
- add tests ensuring feed cards and list rows use consistent detail URLs

## Testing
- `pytest` *(fails: django.core.exceptions.ImproperlyConfigured: Requested setting INSTALLED_APPS, but settings are not configured)*
- `DJANGO_COLLECTSTATIC=1 python manage.py test` *(fails: ValueError: The file 'css/app.css' could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8c34d406c832c8ad27850558f2110