### PR TITLE
Use thumbnail for feed images

### DIFF
--- a/templates/partials/feed_card.html
+++ b/templates/partials/feed_card.html
@@ -1,22 +1,17 @@
 {% load url_domain astro_filters %}
 <article class="post-card" data-testid="post-card">
 {% with detail_url=post.get_absolute_url %}
-  {% if post.image_thumb or post.image %}
+  {% with thumb=post.image_thumb|default:post.image %}
+    {% if thumb %}
     <a href="{{ detail_url }}" class="thumb" aria-label="Open post">
-      {% if post.image_thumb %}
-        <img
-          src="{{ post.image_thumb.url }}"
-          alt="{{ post.title }}"
-          loading="lazy" decoding="async"
-          width="640" height="360">
-      {% else %}
-        <img
-          src="{{ post.image.url }}"
-          alt="{{ post.title }}"
-          loading="lazy" decoding="async">
-      {% endif %}
+      <img
+        src="{{ thumb.url }}"
+        alt="{{ post.title }}"
+        loading="lazy" decoding="async"
+        width="640" height="360">
     </a>
-  {% endif %}
+    {% endif %}
+  {% endwith %}
   <div class="post-meta">
     r/{{ post.community.slug }} · {{ post.author.username }} · {{ post.created_at|timesince }} ago
   </div>


### PR DESCRIPTION
## Summary
- Prefer post.image_thumb over post.image in feed cards so feeds show consistent previews

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'core')*
- `python manage.py test` *(fails: The file 'css/app.css' could not be found with whitenoise storage)*
- `python manage.py backfill_thumbs` *(fails: no such table: core_post)*

------
https://chatgpt.com/codex/tasks/task_e_68b8c5249efc832ca28133b519ee0504