### PR TITLE
Remove share and copy link actions

### DIFF
--- a/templates/core/post_detail.html
+++ b/templates/core/post_detail.html
@@ -64,8 +64,6 @@
       {% csrf_token %}
       <button type="submit" aria-label="Downvote">▼</button>
     </form>
-    <a href="{{ post_url }}" class="share-link">share</a>
-    <button type="button" class="copy-link" data-link="{{ post_url }}">copy link</button>
   </div>
 </article>
 


### PR DESCRIPTION
## Summary
- remove share and copy link options from post detail actions row

## Testing
- `DJANGO_COLLECTSTATIC=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8d6b5e4a8832c9c6581e6f87584a3