### PR TITLE
Add astro-turf severity bar to post actions

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -745,6 +745,27 @@ def post_detail(request, community, pk, slug):
     show_embed = bool(post.content_url) and not (has_gallery or has_upload)
     embed_html = build_embed_html(post.content_url) if show_embed else ""
 
+    severity = None
+    band = None
+    try:
+        severity = getattr(getattr(post, "astro_score", None), "severity", None)
+    except Exception:
+        severity = None
+    if severity is None:
+        try:
+            metrics = compute_post_signals(post.pk)
+            severity = metrics.get("severity")
+        except Exception:
+            severity = None
+
+    if isinstance(severity, (int, float)):
+        if severity < 40:
+            band = "green"
+        elif severity < 70:
+            band = "amber"
+        else:
+            band = "red"
+
     context = {
         "post": post,
         "comments": comments,
@@ -752,6 +773,8 @@ def post_detail(request, community, pk, slug):
         "images": images,
         "c_sort": c_sort,
         "q": q,
+        "severity": severity,
+        "severity_band": band,
     }
     return render(request, "core/post_detail.html", context)
 
@@ -784,6 +807,27 @@ def post_detail_id(request, pk):
     show_embed = bool(post.content_url) and not (has_gallery or has_upload)
     embed_html = build_embed_html(post.content_url) if show_embed else ""
 
+    severity = None
+    band = None
+    try:
+        severity = getattr(getattr(post, "astro_score", None), "severity", None)
+    except Exception:
+        severity = None
+    if severity is None:
+        try:
+            metrics = compute_post_signals(post.pk)
+            severity = metrics.get("severity")
+        except Exception:
+            severity = None
+
+    if isinstance(severity, (int, float)):
+        if severity < 40:
+            band = "green"
+        elif severity < 70:
+            band = "amber"
+        else:
+            band = "red"
+
     context = {
         "post": post,
         "comments": comments,
@@ -791,6 +835,8 @@ def post_detail_id(request, pk):
         "images": images,
         "c_sort": c_sort,
         "q": q,
+        "severity": severity,
+        "severity_band": band,
     }
     return render(request, "core/post_detail.html", context)
 

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -303,3 +303,16 @@ body.layout-root {
 .aspect-16-9{ position:relative; padding-top:56.25%; overflow:hidden; border-radius:12px; background:#000; }
 .aspect-16-9 .embed-inner{ position:absolute; inset:0; }
 .aspect-16-9 iframe, .aspect-16-9 video{ width:100%; height:100%; display:block; }
+
+.astro-meter{
+  display:flex; align-items:center; gap:8px; margin-left:12px;
+}
+.astro-chip{
+  min-width: 36px; height: 20px; padding: 0 8px;
+  border-radius: 10px; font-size: 12px; line-height: 20px;
+  color:#fff; text-align:center; font-weight:600;
+}
+.astro-chip.green{ background:#16a34a; }   /* green-600 */
+.astro-chip.amber{ background:#f59e0b; }   /* amber-500 */
+.astro-chip.red{   background:#dc2626; }   /* red-600 */
+.astro-label{ font-size:12px; color:#6b7280; }

--- a/templates/core/post_detail.html
+++ b/templates/core/post_detail.html
@@ -55,15 +55,26 @@
   {% endif %}
 
   <div class="post-actions">
-    <form hx-post="{% url 'vote_post' post.pk %}?v=1" hx-target="#post-score-{{ post.pk }}" hx-swap="outerHTML" method="post">
-      {% csrf_token %}
-      <button type="submit" aria-label="Upvote">▲</button>
-    </form>
-    <span id="post-score-{{ post.pk }}" class="score">{{ post.score }}</span>
-    <form hx-post="{% url 'vote_post' post.pk %}?v=-1" hx-target="#post-score-{{ post.pk }}" hx-swap="outerHTML" method="post">
-      {% csrf_token %}
-      <button type="submit" aria-label="Downvote">▼</button>
-    </form>
+    <div class="vote">
+      <form hx-post="{% url 'vote_post' post.pk %}?v=1" hx-target="#post-score-{{ post.pk }}" hx-swap="outerHTML" method="post">
+        {% csrf_token %}
+        <button type="submit" aria-label="Upvote">▲</button>
+      </form>
+      <span id="post-score-{{ post.pk }}" class="score">{{ post.score }}</span>
+      <form hx-post="{% url 'vote_post' post.pk %}?v=-1" hx-target="#post-score-{{ post.pk }}" hx-swap="outerHTML" method="post">
+        {% csrf_token %}
+        <button type="submit" aria-label="Downvote">▼</button>
+      </form>
+    </div>
+
+    {% if severity_band %}
+      <div class="astro-meter" title="Astro severity: {{ severity|floatformat:0 }}/100">
+        <div class="astro-chip {{ severity_band }}">
+          {{ severity|floatformat:0 }}
+        </div>
+        <span class="astro-label">Astro</span>
+      </div>
+    {% endif %}
   </div>
 </article>
 


### PR DESCRIPTION
## Summary
- show astro-turf severity meter on post detail actions row
- compute severity and band for posts using stored astro_score or computed signals
- add styling for severity chip

## Testing
- `pytest` *(fails: RuntimeError: S3 media env not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68b8d8356714832cab7bc5858436c927