### PR TITLE
Link authors to profile in feed

### DIFF
--- a/core/tests/test_links.py
+++ b/core/tests/test_links.py
@@ -87,3 +87,8 @@ class PostLinkTests(TestCase):
         html = render_to_string("core/partials/post_row.html", {"post": self.post})
         self.assertEqual(html.count(f'href="{url}"'), 2)
         self.assertIn(f'href="{url}#comments"', html)
+
+    def test_post_row_links_author(self):
+        user_url = reverse("user_overview", args=[self.user.username])
+        html = render_to_string("core/partials/post_row.html", {"post": self.post})
+        self.assertIn(f'href="{user_url}"', html)

--- a/templates/core/partials/post_row.html
+++ b/templates/core/partials/post_row.html
@@ -10,7 +10,9 @@
     </a>
     {% endif %}
     <div class="post-meta">
-      r/{{ post.community.slug }} · {{ post.author.username }} · {{ post.created_at|timesince }} ago
+      r/{{ post.community.slug }} · {% if post.author %}
+      <a href="{% url 'user_overview' post.author.username %}">{{ post.author.username }}</a>
+      {% else %}[deleted]{% endif %} · {{ post.created_at|timesince }} ago
     </div>
     <h3 class="post-title"><a href="{{ detail_url }}">{{ post.title }}</a></h3>
     {% if post.body %}


### PR DESCRIPTION
## Summary
- Make author name in feed link to their profile with `[deleted]` fallback
- Cover author link in post row with a regression test

## Testing
- `pytest`
- `python manage.py test core.tests.test_links` *(fails: An error occurred (403) when calling the PutObject operation: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b8de54aa80832cb468030412aa47d9