### PR TITLE
Make community names on post feed clickable

### DIFF
--- a/templates/core/partials/post_row.html
+++ b/templates/core/partials/post_row.html
@@ -10,7 +10,8 @@
     </a>
     {% endif %}
     <div class="post-meta">
-      r/{{ post.community.slug }} · {% if post.author %}
+      <a href="{% url 'community' post.community.slug %}">r/{{ post.community.slug }}</a> ·
+      {% if post.author %}
       <a href="{% url 'user_overview' post.author.username %}">{{ post.author.username }}</a>
       {% else %}[deleted]{% endif %} · {{ post.created_at|timesince }} ago
     </div>


### PR DESCRIPTION
## Summary
- Make home feed community slugs link to their community pages

## Testing
- `PYTHONPATH=. pytest` *(fails: Requested setting INSTALLED_APPS, but settings are not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68b8e549b16c832caa3bacd8989e358e