### PR TITLE
Render nested comments with depth-based styling

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -726,7 +726,11 @@ def post_detail(request, community, pk, slug):
     if c_sort not in {"best", "top", "new", "controversial"}:
         c_sort = "best"
 
-    comments = post.comments.select_related("author")
+    comments = (
+        post.comments.filter(parent__isnull=True)
+        .select_related("author")
+        .prefetch_related("children__author")
+    )
     if q:
         comments = comments.filter(body__icontains=q)
 
@@ -788,7 +792,11 @@ def post_detail_id(request, pk):
     if c_sort not in {"best", "top", "new", "controversial"}:
         c_sort = "best"
 
-    comments = post.comments.select_related("author")
+    comments = (
+        post.comments.filter(parent__isnull=True)
+        .select_related("author")
+        .prefetch_related("children__author")
+    )
     if q:
         comments = comments.filter(body__icontains=q)
 

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -340,3 +340,27 @@ body.layout-root {
 
 /* If your vote buttons are inside <form>, keep forms inline */
 .post-actions .vote form{ display: inline; margin: 0; }
+
+/* Comment tree */
+.comment{ position:relative; padding:10px 0 10px calc(16px * var(--depth, 0)); }
+.comment-children{ margin-top:6px; }
+
+/* vertical guide for nested levels */
+.comment::before{
+  content:"";
+  position:absolute;
+  left: calc(16px * max(var(--depth, 0) - 0.5, 0));
+  top:0; bottom:0; width:1px;
+  background: var(--color-border, #e5e7eb);
+  opacity:.6;
+}
+.comment[style*="--depth: 0"]::before{ display:none; }
+
+/* Meta + actions */
+.comment-meta{ display:flex; align-items:center; gap:8px; flex-wrap:wrap; font-size:13px; color:#666; }
+.comment-meta .author{ font-weight:600; color:inherit; text-decoration:none; }
+.comment-meta .dot{ opacity:.6; }
+.comment-actions{ display:flex; align-items:center; gap:8px; margin-top:6px; }
+.comment .score{ min-width:1.5ch; text-align:center; }
+.astro-chip{ min-width:28px; height:18px; padding:0 6px; border-radius:9px; font-size:11px; line-height:18px; color:#fff; font-weight:600; }
+.astro-chip.green{ background:#16a34a; } .astro-chip.amber{ background:#f59e0b; } .astro-chip.red{ background:#dc2626; }

--- a/templates/core/partials/comment_row.html
+++ b/templates/core/partials/comment_row.html
@@ -1,10 +1,47 @@
-{% comment %}Row for displaying a single comment in user profile views{% endcomment %}
-<div class="comment-row">
-  <p>{{ comment.body }}</p>
-  <small>
-    in <a href="{% url 'community' comment.post.community.slug %}">r/{{ comment.post.community.slug }}</a>
-    on <a href="{% url 'post_detail' comment.post.community.slug comment.post.pk comment.post.slug %}">{{ comment.post.title }}</a>
-    · <time datetime="{{ comment.created_at|date:'c' }}" data-ts="{{ comment.created_at|date:'U' }}" title="{{ comment.created_at|date:'Y-m-d H:i' }}">{{ comment.created_at|timesince }} ago</time>
-  </small>
-</div>
+<article class="comment" id="c{{ comment.pk }}" style="--depth: {{ depth|default:'0' }}">
+  <header class="comment-meta">
+    <a class="author" href="{% url 'user_overview' comment.author.username %}">{{ comment.author.username }}</a>
+    <span class="dot">•</span>
+    <time datetime="{{ comment.created_at|date:'c' }}">{{ comment.created_at|timesince }} ago</time>
+    <span class="dot">•</span>
+    <span id="cscore-{{ comment.pk }}" class="score">{{ comment.score }}</span>
+    {% if comment.astro_band %}
+      <span class="astro-chip {{ comment.astro_band }}" title="Astro severity">
+        {{ comment.astro_severity|default:0|floatformat:0 }}
+      </span>
+    {% endif %}
+  </header>
 
+  <div class="comment-body">
+    {% if comment.body_html %}{{ comment.body_html|safe }}{% else %}{{ comment.body|linebreaks }}{% endif %}
+  </div>
+
+  <div class="comment-actions">
+    <button class="up"
+            hx-post="{% url 'vote_comment' comment.pk %}?v=1"
+            hx-target="#cscore-{{ comment.pk }}"
+            hx-swap="outerHTML"
+            aria-label="Upvote">▲</button>
+    <button class="down"
+            hx-post="{% url 'vote_comment' comment.pk %}?v=-1"
+            hx-target="#cscore-{{ comment.pk }}"
+            hx-swap="outerHTML"
+            aria-label="Downvote">▼</button>
+    <a class="reply"
+       hx-get="{% url 'comment_reply_form' comment.pk %}"
+       hx-target="#c{{ comment.pk }} .reply-target"
+       hx-swap="innerHTML">Reply</a>
+  </div>
+
+  <div class="reply-target"></div>
+
+  {% with kids=children|default:comment.children.all %}
+    {% if kids %}
+      <div class="comment-children">
+        {% for child in kids %}
+          {% include "core/partials/comment_row.html" with comment=child depth=depth|add:1 only %}
+        {% endfor %}
+      </div>
+    {% endif %}
+  {% endwith %}
+</article>

--- a/templates/core/post_detail.html
+++ b/templates/core/post_detail.html
@@ -101,7 +101,11 @@
   </div>
 
   <div id="comment-tree">
-    {% include "core/partials/comment.html" with post=post comments=comments only %}
+    {% for c in comments %}
+      {% include "core/partials/comment_row.html" with comment=c depth=0 only %}
+    {% empty %}
+      <p class="muted">No comments yet.</p>
+    {% endfor %}
   </div>
 </section>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Replace comment tree rendering with recursive partial for Reddit-style nested comments
- Fetch only top-level comments and prefetch children in post detail view
- Style comment tree with depth-based indentation and vertical guides

## Testing
- `AWS_STORAGE_BUCKET_NAME=foo AWS_ACCESS_KEY_ID=bar AWS_SECRET_ACCESS_KEY=baz AWS_S3_ENDPOINT_URL=http://example.com MEDIA_URL=http://example.com/ pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b8ee9fcd40832cbe1ab24b529422ba