### PR TITLE
Use URL reversing for community links

### DIFF
--- a/templates/core/partials/post_deleted_stub.html
+++ b/templates/core/partials/post_deleted_stub.html
@@ -11,7 +11,7 @@
         {% endif %}
       </em>
     </h2>
-    <div class="post-meta">in r/{{ post.community.slug }}</div>
+    <div class="post-meta">in <a href="{% url 'community' post.community.slug %}">r/{{ post.community.slug }}</a></div>
   </div>
 </article>
 

--- a/templates/partials/feed_card.html
+++ b/templates/partials/feed_card.html
@@ -21,7 +21,7 @@
     </a>
   {% endif %}
   <div class="post-meta">
-    r/{{ post.community.slug }} · {{ post.author.username }} · {{ post.created_at|timesince }} ago
+    <a href="{% url 'community' post.community.slug %}">r/{{ post.community.slug }}</a> · {{ post.author.username }} · {{ post.created_at|timesince }} ago
   </div>
   <h3 class="post-title"><a href="{{ detail_url }}">{{ post.title }}</a></h3>
   {% if post.is_deleted %}<span class="state-badge">deleted</span>{% endif %}


### PR DESCRIPTION
## Summary
- Link communities in feed cards using Django URL reversing
- Link communities in deleted post stubs via `{% url 'community' %}`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b8efe278b0832caaa7ee03acf2c440