### PR TITLE
Use c/ prefix for community links

### DIFF
--- a/templates/core/communities_index.html
+++ b/templates/core/communities_index.html
@@ -3,7 +3,7 @@
 <div class="shell">
   <ul>
     {% for c in communities %}
-      <li><a href="{% url 'community' c.slug %}{{ qs }}">{{ c.name }}</a></li>
+      <li><a href="{% url 'community' c.slug %}{{ qs }}">c/{{ c.slug }}</a></li>
     {% endfor %}
   </ul>
 </div>

--- a/templates/core/partials/left_communities.html
+++ b/templates/core/partials/left_communities.html
@@ -1,7 +1,7 @@
 <h2 class="side-title">Communities</h2>
 <nav class="comm-list" aria-label="Communities">
-  <a href="{% url 'community' 'news' %}">News</a>
-  <a href="{% url 'community' 'brisbane' %}">Brisbane</a>
-  <a href="{% url 'community' 'politics' %}">Politics</a>
-  <a href="{% url 'community' 'social' %}">Social</a>
+  <a href="{% url 'community' 'news' %}">c/news</a>
+  <a href="{% url 'community' 'brisbane' %}">c/brisbane</a>
+  <a href="{% url 'community' 'politics' %}">c/politics</a>
+  <a href="{% url 'community' 'social' %}">c/social</a>
 </nav>

--- a/templates/core/partials/post_deleted_stub.html
+++ b/templates/core/partials/post_deleted_stub.html
@@ -11,7 +11,7 @@
         {% endif %}
       </em>
     </h2>
-    <div class="post-meta">in <a href="{% url 'community' post.community.slug %}">r/{{ post.community.slug }}</a></div>
+    <div class="post-meta">in <a href="{% url 'community' post.community.slug %}">c/{{ post.community.slug }}</a></div>
   </div>
 </article>
 

--- a/templates/core/partials/post_row.html
+++ b/templates/core/partials/post_row.html
@@ -10,7 +10,7 @@
     </a>
     {% endif %}
     <div class="post-meta">
-      <a href="{% url 'community' post.community.slug %}">r/{{ post.community.slug }}</a> ·
+      <a href="{% url 'community' post.community.slug %}">c/{{ post.community.slug }}</a> ·
       {% if post.author %}
       <a href="{% url 'user_overview' post.author.username %}">{{ post.author.username }}</a>
       {% else %}[deleted]{% endif %} · {{ post.created_at|timesince }} ago

--- a/templates/core/post_detail.html
+++ b/templates/core/post_detail.html
@@ -12,7 +12,7 @@
     <h1>{{ post.title }}</h1>
     <div class="meta">
       by <a href="{% url 'user_overview' post.author.username %}">{{ post.author.username }}</a>
-      in <a href="{% url 'community' post.community.slug %}">r/{{ post.community.slug }}</a>
+      in <a href="{% url 'community' post.community.slug %}">c/{{ post.community.slug }}</a>
       • <time datetime="{{ post.created_at|date:'c' }}">{{ post.created_at|timesince }} ago</time>
     </div>
   </header>


### PR DESCRIPTION
## Summary
- show communities as `c/<slug>` in post listings and details
- switch deleted-post, community index, and sidebar to `c/<slug>` labels

## Testing
- `python manage.py test` *(fails: ValueError: The file 'css/app.css' could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8f4e83b30832c866ae8f4930f99af