### PR TITLE
Hide comment composer for guests

### DIFF
--- a/templates/core/partials/reply_form.html
+++ b/templates/core/partials/reply_form.html
@@ -1,4 +1,8 @@
-<form hx-post="{% url 'comment_reply' post.pk %}" hx-target="#comment-tree" hx-swap="beforeend" method="post">
+{% if request.user.is_authenticated %}
+<form hx-post="{% url 'comment_reply' post.pk %}"
+      hx-target="#comment-tree"
+      hx-swap="beforeend"
+      method="post">
   {% csrf_token %}
   <textarea name="body" rows="3" required></textarea>
   <input type="hidden" name="parent_id" value="{{ parent_id }}">
@@ -7,3 +11,6 @@
     <button type="submit">Comment</button>
   </div>
 </form>
+{% else %}
+<p class="muted">Log in to comment.</p>
+{% endif %}

--- a/templates/core/post_detail.html
+++ b/templates/core/post_detail.html
@@ -89,16 +89,23 @@
     <input type="search" name="q" placeholder="search comments" value="{{ request.GET.q }}">
   </form>
 
-  <div class="comment-composer">
-    <form hx-post="{% url 'comment_reply' post.pk %}" hx-target="#comment-tree" hx-swap="beforeend" method="post">
-      {% csrf_token %}
-      <textarea name="body" rows="4" required></textarea>
-      <div class="form-actions">
-        <button type="reset">Cancel</button>
-        <button type="submit">Comment</button>
-      </div>
-    </form>
-  </div>
+    {% if request.user.is_authenticated %}
+    <div class="comment-composer">
+      <form hx-post="{% url 'comment_reply' post.pk %}"
+            hx-target="#comment-tree"
+            hx-swap="beforeend"
+            method="post">
+        {% csrf_token %}
+        <textarea name="body" rows="4" required></textarea>
+        <div class="form-actions">
+          <button type="reset">Cancel</button>
+          <button type="submit">Comment</button>
+        </div>
+      </form>
+    </div>
+    {% else %}
+    <p class="muted">Log in to comment.</p>
+    {% endif %}
 
   <div id="comment-tree">
     {% for c in comments %}


### PR DESCRIPTION
## Summary
- Hide top-level comment composer and reply forms from unauthenticated users

## Testing
- `pytest` *(fails: The file 'css/app.css' could not be found with <whitenoise.storage.CompressedManifestStaticFilesStorage>)*

------
https://chatgpt.com/codex/tasks/task_e_68b8fd05c8a4832cb5754efc75e370d7