### PR TITLE
Enable HTMX via unpkg CDN

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -117,7 +117,7 @@ if not DEBUG:
     CONTENT_SECURITY_POLICY = {
         "DIRECTIVES": {
             "default-src": ("'self'",),
-            "script-src": ("'self'",),
+            "script-src": ("'self'", "https://unpkg.com"),
             "style-src": ("'self'", "'unsafe-inline'"),
             "img-src": ("'self'", "https:", "data:"),
             "connect-src": ("'self'",),

--- a/templates/core/base.html
+++ b/templates/core/base.html
@@ -30,5 +30,6 @@
   </main>
   {% include "core/partials/footer.html" %}
   {% block scripts %}{% endblock %}
+  <script src="https://unpkg.com/htmx.org@1.9.12" defer></script>
 </body>
 </html>

--- a/tests/test_smoke_v2.py
+++ b/tests/test_smoke_v2.py
@@ -7,6 +7,7 @@ import os
 from django.core.management import call_command
 from django.urls import reverse
 from django.core.cache import cache
+import re
 
 from core.models import Community, Post
 
@@ -79,6 +80,7 @@ def test_signup_submit_sort_and_commands(client):
     # astro_recompute should exit 0
     call_command('astro_recompute')
 
-    # ensure no third-party JS before consent
+    # ensure only allowed third-party JS (HTMX) before consent
     html = client.get('/').content.decode()
-    assert 'src="http' not in html
+    external_scripts = re.findall(r'src="(http[^"]+)"', html)
+    assert external_scripts == ["https://unpkg.com/htmx.org@1.9.12"]


### PR DESCRIPTION
## Summary
- Load HTMX from unpkg CDN in base template
- Allow unpkg in CSP for production and update test to expect HTMX script

## Testing
- `DJANGO_COLLECTSTATIC=1 pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b8ffafc5d8832cb8562532285d4f2d