### PR TITLE
Return score span for HTMX votes

### DIFF
--- a/core/tests/test_routes.py
+++ b/core/tests/test_routes.py
@@ -51,3 +51,19 @@ class RouteTests(TestCase):
     def test_methods(self):
         resp = self.client.get(reverse("transparency_methods"))
         self.assertEqual(resp.status_code, 200)
+
+    def test_vote_post_htmx_returns_span(self):
+        self.client.login(username="tester", password="pwd")
+        url = reverse("vote_post", args=[self.post.pk])
+        resp = self.client.post(f"{url}?v=1", HTTP_HX_REQUEST="true")
+        self.assertEqual(resp.status_code, 200)
+        self.assertHTMLEqual(
+            resp.content.decode(),
+            f'<span id="post-score-{self.post.pk}" class="score">1</span>',
+        )
+
+    def test_vote_post_non_htmx_redirects(self):
+        self.client.login(username="tester", password="pwd")
+        url = reverse("vote_post", args=[self.post.pk])
+        resp = self.client.post(f"{url}?v=1")
+        self.assertRedirects(resp, self.post.get_absolute_url())

--- a/core/views.py
+++ b/core/views.py
@@ -1320,8 +1320,11 @@ def vote_post(request, pk):
     except ValueError:
         return HttpResponseBadRequest("Invalid vote")
 
-    score = Post.objects.get(pk=pk).score
-    return HttpResponse(f"<span id='post-score-{pk}'>{score}</span>")
+    post = Post.objects.get(pk=pk)
+    html = f'<span id="post-score-{post.pk}" class="score">{post.score}</span>'
+    if request.headers.get("HX-Request") == "true":
+        return HttpResponse(html, content_type="text/html")
+    return redirect(post.get_absolute_url())
 
 
 @login_required


### PR DESCRIPTION
## Summary
- return inline score `<span>` from `vote_post` when HTMX header is present
- redirect to post detail for non-HTMX requests
- add tests covering both HTMX and non-HTMX vote flows

## Testing
- `DJANGO_COLLECTSTATIC=1 python manage.py test` *(fails: failures=6, errors=28)*

------
https://chatgpt.com/codex/tasks/task_e_68b907630bb0832c8ab78db96fb89635