### PR TITLE
Fix comment voting with CSRF-protected forms

### DIFF
--- a/templates/core/partials/comment_row.html
+++ b/templates/core/partials/comment_row.html
@@ -4,7 +4,6 @@
     <span class="dot">•</span>
     <time datetime="{{ comment.created_at|date:'c' }}">{{ comment.created_at|timesince }} ago</time>
     <span class="dot">•</span>
-    <span id="cscore-{{ comment.pk }}" class="score">{{ comment.score }}</span>
     {% if comment.astro_band %}
       <span class="astro-chip {{ comment.astro_band }}" title="Astro severity">
         {{ comment.astro_severity|default:0|floatformat:0 }}
@@ -17,16 +16,24 @@
   </div>
 
   <div class="comment-actions">
-    <button class="up"
-            hx-post="{% url 'vote_comment' comment.pk %}?v=1"
-            hx-target="#cscore-{{ comment.pk }}"
-            hx-swap="outerHTML"
-            aria-label="Upvote">▲</button>
-    <button class="down"
-            hx-post="{% url 'vote_comment' comment.pk %}?v=-1"
-            hx-target="#cscore-{{ comment.pk }}"
-            hx-swap="outerHTML"
-            aria-label="Downvote">▼</button>
+    <form hx-post="{% url 'vote_comment' comment.pk %}?v=1"
+          hx-target="#cscore-{{ comment.pk }}"
+          hx-swap="outerHTML"
+          method="post" class="inline">
+      {% csrf_token %}
+      <button type="submit" aria-label="Upvote">▲</button>
+    </form>
+
+    <span id="cscore-{{ comment.pk }}" class="score">{{ comment.score }}</span>
+
+    <form hx-post="{% url 'vote_comment' comment.pk %}?v=-1"
+          hx-target="#cscore-{{ comment.pk }}"
+          hx-swap="outerHTML"
+          method="post" class="inline">
+      {% csrf_token %}
+      <button type="submit" aria-label="Downvote">▼</button>
+    </form>
+
     <a class="reply"
        hx-get="{% url 'comment_reply_form' comment.pk %}"
        hx-target="#c{{ comment.pk }} .reply-target"


### PR DESCRIPTION
## Summary
- Wrap comment up/down vote buttons in small forms with CSRF tokens so Django accepts the POST
- Move comment score between the forms for easier updates

## Testing
- `python manage.py shell -c "..."` (comment vote returns status 200 and updated score)
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b90ad5551c832c819cd9c4e3b33915