### PR TITLE
Add dev requirements and install in bootstrap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: bootstrap migrate seed recompute test astro
 
 bootstrap:
-	pip install -r requirements.txt
+	pip install -r requirements.txt -r requirements-dev.txt
 
 migrate:
 	python manage.py makemigrations && python manage.py migrate
@@ -10,7 +10,7 @@ seed:
 	python manage.py seed_demo
 
 recompute:
-        python manage.py recompute_ranks
+	python manage.py recompute_ranks
 
 test:
 	python manage.py test

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+pytest==8.4.1
+freezegun==1.5.5


### PR DESCRIPTION
## Summary
- add requirements-dev.txt with pinned pytest and freezegun
- update bootstrap target to install regular and dev requirements

## Testing
- `AWS_STORAGE_BUCKET_NAME=a AWS_ACCESS_KEY_ID=b AWS_SECRET_ACCESS_KEY=c AWS_S3_ENDPOINT_URL=d MEDIA_URL=http://example.com pytest tests/test_smoke_v2.py -q` (fails: The file 'css/app.css' could not be found)
- `AWS_STORAGE_BUCKET_NAME=a AWS_ACCESS_KEY_ID=b AWS_SECRET_ACCESS_KEY=c AWS_S3_ENDPOINT_URL=d MEDIA_URL=http://example.com/ python manage.py test core.tests.test_astro` (fails: The file 'css/app.css' could not be found)


------
https://chatgpt.com/codex/tasks/task_e_68b915f5e8f0832cbf428812ac97e7f1