### PR TITLE
Include core tests in pytest configuration

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,5 @@
 [pytest]
 DJANGO_SETTINGS_MODULE = config.settings
-testpaths = tests
+testpaths =
+    tests
+    core/tests


### PR DESCRIPTION
## Summary
- run tests from core app by adding `core/tests` to pytest's search paths

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'core' and others)*

------
https://chatgpt.com/codex/tasks/task_e_68b917b893d8832ca2c2139609342c55