### PR TITLE
Constrain bleach and mistune versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 asgiref==3.9.1
 requests==2.32.3
-bleach>=6
+bleach>=6,<7
 django-storages[boto3]>=1.14,<2
 dj-database-url==3.0.1
 Django==5.2.5
@@ -17,4 +17,4 @@ sqlparse==0.5.3
 typing_extensions==4.14.1
 tzdata==2025.2
 whitenoise==6.6.0
-mistune>=3
+mistune>=3,<4


### PR DESCRIPTION
## Summary
- pin `bleach` to version 6.x and `mistune` to 3.x to avoid future incompatibilities

## Testing
- `DJANGO_COLLECTSTATIC=1 PYTHONPATH=. pytest -q` *(fails: tests/test_smoke_v2.py::test_signup_submit_sort_and_commands)*

------
https://chatgpt.com/codex/tasks/task_e_68b9179998cc832cb5dc90770f0adcc7