### PR TITLE
Validate vote values for post and comment voting

### DIFF
--- a/core/tests/test_routes.py
+++ b/core/tests/test_routes.py
@@ -2,7 +2,7 @@ from django.contrib.auth import get_user_model
 from django.test import TestCase
 from django.urls import reverse
 
-from core.models import Community, Post
+from core.models import Comment, Community, Post
 
 
 class RouteTests(TestCase):
@@ -17,6 +17,9 @@ class RouteTests(TestCase):
             author=self.user,
             post_type="text",
             title="Hello",
+        )
+        self.comment = Comment.objects.create(
+            post=self.post, author=self.user, body="Hi", path="0001"
         )
 
     def test_home(self):
@@ -67,3 +70,15 @@ class RouteTests(TestCase):
         url = reverse("vote_post", args=[self.post.pk])
         resp = self.client.post(f"{url}?v=1")
         self.assertRedirects(resp, self.post.get_absolute_url())
+
+    def test_vote_post_invalid_value_returns_400(self):
+        self.client.login(username="tester", password="pwd")
+        url = reverse("vote_post", args=[self.post.pk])
+        resp = self.client.post(f"{url}?v=2", HTTP_HX_REQUEST="true")
+        self.assertEqual(resp.status_code, 400)
+
+    def test_vote_comment_invalid_value_returns_400(self):
+        self.client.login(username="tester", password="pwd")
+        url = reverse("vote_comment", args=[self.comment.pk])
+        resp = self.client.post(f"{url}?v=0", HTTP_HX_REQUEST="true")
+        self.assertEqual(resp.status_code, 400)

--- a/core/views.py
+++ b/core/views.py
@@ -1299,10 +1299,18 @@ def comment_delete(request, pk):
 @login_required
 @require_POST
 def vote_post(request, pk):
-    v = int(request.GET.get("v", "0") or 0)
+    try:
+        v = int(request.GET.get("v", "0"))
+    except (TypeError, ValueError):
+        return HttpResponseBadRequest("Invalid vote")
+    if v not in (-1, 1):
+        return HttpResponseBadRequest("Invalid vote")
     post = get_object_or_404(Post, pk=pk)
     from .votes import apply_vote
-    apply_vote(request.user, "post", post.pk, v)
+    try:
+        apply_vote(request.user, "post", post.pk, v)
+    except ValueError:
+        return HttpResponseBadRequest("Invalid vote")
     try:
         post.refresh_from_db(fields=["score"])
     except Exception:
@@ -1316,10 +1324,18 @@ def vote_post(request, pk):
 @login_required
 @require_POST
 def vote_comment(request, pk):
-    v = int(request.GET.get("v", "0") or 0)
+    try:
+        v = int(request.GET.get("v", "0"))
+    except (TypeError, ValueError):
+        return HttpResponseBadRequest("Invalid vote")
+    if v not in (-1, 1):
+        return HttpResponseBadRequest("Invalid vote")
     cmt = get_object_or_404(Comment, pk=pk)
     from .votes import apply_vote
-    apply_vote(request.user, "comment", cmt.pk, v)
+    try:
+        apply_vote(request.user, "comment", cmt.pk, v)
+    except ValueError:
+        return HttpResponseBadRequest("Invalid vote")
     try:
         cmt.refresh_from_db(fields=["score"])
     except Exception:


### PR DESCRIPTION
## Summary
- reject invalid vote values for posts and comments before applying votes
- return HTTP 400 when vote validation fails
- test post and comment vote endpoints with invalid values

## Testing
- `pytest core/tests/test_routes.py` *(fails: RuntimeError: S3 media env not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68b91a98e54c832caf7dcd7fbadc7ea2