### PR TITLE
Use precomputed comment count in templates

### DIFF
--- a/templates/core/partials/post_row.html
+++ b/templates/core/partials/post_row.html
@@ -39,7 +39,7 @@
           <button type="submit" aria-label="Downvote">▼</button>
         </form>
       </div>
-      <a href="{{ post.get_absolute_url }}#comments">{{ post.comments.count }} comments</a>
+      <a href="{{ post.get_absolute_url }}#comments">{{ post.comment_count }} comments</a>
     </div>
   {% endwith %}
 </article>

--- a/templates/partials/feed_card.html
+++ b/templates/partials/feed_card.html
@@ -49,7 +49,7 @@
         <button type="submit" aria-label="Downvote">▼</button>
       </form>
     </div>
-    <a href="{{ detail_url }}#comments">{{ post.comments.count }} comments</a>
+    <a href="{{ detail_url }}#comments">{{ post.comment_count }} comments</a>
     {% if post.astro_score %}
     <details class="astro-why">
       <summary class="chip {{ post.astro_score.score|astro_band }}">Astro {{ post.astro_score.score }}</summary>


### PR DESCRIPTION
## Summary
- switch post comment display to use `comment_count` instead of querying `post.comments`

## Testing
- `PYTHONPATH=. pytest` *(fails: The file 'css/app.css' could not be found and other environment issues)*

------
https://chatgpt.com/codex/tasks/task_e_68b91b7eccb0832c96c6fd334e9e62cd