### PR TITLE
Use shared score span partial for votes

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -1316,7 +1316,10 @@ def vote_post(request, pk):
     except Exception:
         post.refresh_from_db()
     if request.headers.get("HX-Request") == "true":
-        html = f'<span id="post-score-{post.pk}" class="score">{post.score}</span>'
+        html = render_to_string(
+            "partials/score_span.html",
+            {"id": f"post-score-{post.pk}", "score": post.score},
+        )
         return HttpResponse(html, content_type="text/html")
     return redirect(post.get_absolute_url())
 
@@ -1341,7 +1344,10 @@ def vote_comment(request, pk):
     except Exception:
         cmt.refresh_from_db()
     if request.headers.get("HX-Request") == "true":
-        html = f'<span id="cscore-{cmt.pk}" class="score">{cmt.score}</span>'
+        html = render_to_string(
+            "partials/score_span.html",
+            {"id": f"cscore-{cmt.pk}", "score": cmt.score},
+        )
         return HttpResponse(html, content_type="text/html")
     return redirect(cmt.post.get_absolute_url())
 

--- a/templates/core/partials/comment_item.html
+++ b/templates/core/partials/comment_item.html
@@ -19,7 +19,7 @@
         <button type="submit" aria-label="Upvote">▲</button>
       </form>
 
-      <span id="cscore-{{ comment.pk }}" class="score">{{ comment.score }}</span>
+      {% include "core/partials/comment_score.html" %}
 
       <form hx-post="{% url 'vote_comment' comment.pk %}?v=-1"
             hx-target="#cscore-{{ comment.pk }}"

--- a/templates/core/partials/comment_row.html
+++ b/templates/core/partials/comment_row.html
@@ -24,7 +24,7 @@
       <button type="submit" aria-label="Upvote">▲</button>
     </form>
 
-    <span id="cscore-{{ comment.pk }}" class="score">{{ comment.score }}</span>
+    {% include "core/partials/comment_score.html" %}
 
     <form hx-post="{% url 'vote_comment' comment.pk %}?v=-1"
           hx-target="#cscore-{{ comment.pk }}"

--- a/templates/core/partials/comment_score.html
+++ b/templates/core/partials/comment_score.html
@@ -1,1 +1,1 @@
-<span id="cscore-{{ comment.pk }}" class="score">{{ comment.score }}</span>
+{% include "partials/score_span.html" with id="cscore-"|add:comment.pk score=comment.score %}

--- a/templates/core/partials/post_row.html
+++ b/templates/core/partials/post_row.html
@@ -29,7 +29,7 @@
           <button type="submit" aria-label="Upvote">▲</button>
         </form>
 
-        <span id="post-score-{{ post.pk }}" class="score">{{ post.score }}</span>
+        {% include "partials/score_span.html" with id="post-score-"|add:post.pk score=post.score %}
 
         <form hx-post="{% url 'vote_post' post.pk %}?v=-1"
               hx-target="#post-score-{{ post.pk }}"

--- a/templates/core/post_detail.html
+++ b/templates/core/post_detail.html
@@ -64,7 +64,7 @@
         <button type="submit" aria-label="Upvote">▲</button>
       </form>
 
-      <span id="post-score-{{ post.pk }}" class="score">{{ post.score }}</span>
+      {% include "partials/score_span.html" with id="post-score-"|add:post.pk score=post.score %}
 
       <form hx-post="{% url 'vote_post' post.pk %}?v=-1"
             hx-target="#post-score-{{ post.pk }}"

--- a/templates/partials/feed_card.html
+++ b/templates/partials/feed_card.html
@@ -39,7 +39,7 @@
         <button type="submit" aria-label="Upvote">▲</button>
       </form>
 
-      <span id="post-score-{{ post.pk }}" class="score">{{ post.score }}</span>
+      {% include "partials/score_span.html" with id="post-score-"|add:post.pk score=post.score %}
 
       <form hx-post="{% url 'vote_post' post.pk %}?v=-1"
             hx-target="#post-score-{{ post.pk }}"

--- a/templates/partials/score_span.html
+++ b/templates/partials/score_span.html
@@ -1,0 +1,1 @@
+<span id="{{ id }}" class="score">{{ score }}</span>


### PR DESCRIPTION
## Summary
- add reusable `score_span` partial
- render score partial in `vote_post` and `vote_comment`
- reuse score partial across post and comment templates

## Testing
- `WHITENOISE_USE_FINDERS=1 DJANGO_COLLECTSTATIC=1 python manage.py test --failfast` *(fails: Couldn't find 'href="?sort=new" aria-current="page"')*

------
https://chatgpt.com/codex/tasks/task_e_68b91d2ea4ec832cb2dedfada65d4fd8