### PR TITLE
Remove unpkg from CSP and update external script tests

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -117,7 +117,7 @@ if not DEBUG:
     CONTENT_SECURITY_POLICY = {
         "DIRECTIVES": {
             "default-src": ("'self'",),
-            "script-src": ("'self'", "https://unpkg.com"),
+            "script-src": ("'self'",),
             "style-src": ("'self'", "'unsafe-inline'"),
             "img-src": ("'self'", "https:", "data:"),
             "connect-src": ("'self'",),

--- a/tests/test_smoke_v2.py
+++ b/tests/test_smoke_v2.py
@@ -80,7 +80,7 @@ def test_signup_submit_sort_and_commands(client):
     # astro_recompute should exit 0
     call_command('astro_recompute')
 
-    # ensure only allowed third-party JS (HTMX) before consent
+    # ensure no external third-party JS before consent
     html = client.get('/').content.decode()
     external_scripts = re.findall(r'src="(http[^"]+)"', html)
-    assert external_scripts == ["https://unpkg.com/htmx.org@1.9.12"]
+    assert external_scripts == []


### PR DESCRIPTION
## Summary
- remove `https://unpkg.com` from CSP `script-src`
- adjust smoke test to expect no external scripts on homepage

## Testing
- `DJANGO_COLLECTSTATIC=1 DJANGO_ALLOWED_HOSTS=* pytest` *(fails: 10 failed, 24 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b92706eec4832c93fda59968fb776c