### PR TITLE
Fix post voting via HTMX

### DIFF
--- a/core/tests/test_routes.py
+++ b/core/tests/test_routes.py
@@ -58,7 +58,7 @@ class RouteTests(TestCase):
     def test_vote_post_htmx_returns_span(self):
         self.client.login(username="tester", password="pwd")
         url = reverse("vote_post", args=[self.post.pk])
-        resp = self.client.post(f"{url}?v=1", HTTP_HX_REQUEST="true")
+        resp = self.client.post(url, {"v": 1}, HTTP_HX_REQUEST="true")
         self.assertEqual(resp.status_code, 200)
         self.assertHTMLEqual(
             resp.content.decode(),
@@ -68,13 +68,13 @@ class RouteTests(TestCase):
     def test_vote_post_non_htmx_redirects(self):
         self.client.login(username="tester", password="pwd")
         url = reverse("vote_post", args=[self.post.pk])
-        resp = self.client.post(f"{url}?v=1")
+        resp = self.client.post(url, {"v": 1})
         self.assertRedirects(resp, self.post.get_absolute_url())
 
     def test_vote_post_invalid_value_returns_400(self):
         self.client.login(username="tester", password="pwd")
         url = reverse("vote_post", args=[self.post.pk])
-        resp = self.client.post(f"{url}?v=2", HTTP_HX_REQUEST="true")
+        resp = self.client.post(url, {"v": 2}, HTTP_HX_REQUEST="true")
         self.assertEqual(resp.status_code, 400)
 
     def test_vote_comment_invalid_value_returns_400(self):

--- a/core/views.py
+++ b/core/views.py
@@ -1300,7 +1300,8 @@ def comment_delete(request, pk):
 @require_POST
 def vote_post(request, pk):
     try:
-        v = int(request.GET.get("v", "0"))
+        raw = request.GET.get("v") or request.POST.get("v")
+        v = int(raw)
     except (TypeError, ValueError):
         return HttpResponseBadRequest("Invalid vote")
     if v not in (-1, 1):

--- a/templates/core/partials/post_row.html
+++ b/templates/core/partials/post_row.html
@@ -21,7 +21,8 @@
     {% endif %}
     <div class="post-actions">
       <div class="vote">
-        <form hx-post="{% url 'vote_post' post.pk %}?v=1"
+        <form hx-post="{% url 'vote_post' post.pk %}"
+              hx-vals='{"v":1}'
               hx-target="#post-score-{{ post.pk }}"
               hx-swap="outerHTML"
               method="post" class="inline">
@@ -31,7 +32,8 @@
 
         {% include "partials/score_span.html" with id="post-score-"|add:post.pk score=post.score %}
 
-        <form hx-post="{% url 'vote_post' post.pk %}?v=-1"
+        <form hx-post="{% url 'vote_post' post.pk %}"
+              hx-vals='{"v":-1}'
               hx-target="#post-score-{{ post.pk }}"
               hx-swap="outerHTML"
               method="post" class="inline">

--- a/templates/core/post_detail.html
+++ b/templates/core/post_detail.html
@@ -56,7 +56,8 @@
 
   <div class="post-actions">
     <div class="vote">
-      <form hx-post="{% url 'vote_post' post.pk %}?v=1"
+      <form hx-post="{% url 'vote_post' post.pk %}"
+            hx-vals='{"v":1}'
             hx-target="#post-score-{{ post.pk }}"
             hx-swap="outerHTML"
             method="post" class="inline">
@@ -66,7 +67,8 @@
 
       {% include "partials/score_span.html" with id="post-score-"|add:post.pk score=post.score %}
 
-      <form hx-post="{% url 'vote_post' post.pk %}?v=-1"
+      <form hx-post="{% url 'vote_post' post.pk %}"
+            hx-vals='{"v":-1}'
             hx-target="#post-score-{{ post.pk }}"
             hx-swap="outerHTML"
             method="post" class="inline">

--- a/templates/partials/feed_card.html
+++ b/templates/partials/feed_card.html
@@ -31,7 +31,8 @@
   {% endif %}
   <div class="post-actions">
     <div class="vote">
-      <form hx-post="{% url 'vote_post' post.pk %}?v=1"
+      <form hx-post="{% url 'vote_post' post.pk %}"
+            hx-vals='{"v":1}'
             hx-target="#post-score-{{ post.pk }}"
             hx-swap="outerHTML"
             method="post" class="inline">
@@ -41,7 +42,8 @@
 
       {% include "partials/score_span.html" with id="post-score-"|add:post.pk score=post.score %}
 
-      <form hx-post="{% url 'vote_post' post.pk %}?v=-1"
+      <form hx-post="{% url 'vote_post' post.pk %}"
+            hx-vals='{"v":-1}'
             hx-target="#post-score-{{ post.pk }}"
             hx-swap="outerHTML"
             method="post" class="inline">


### PR DESCRIPTION
## Summary
- Accept vote value from GET or POST in `vote_post`
- Send vote values via `hx-vals` in post templates
- Update routing tests for POST body values

## Testing
- `DJANGO_COLLECTSTATIC=1 python manage.py test core.tests.test_routes` *(fails: test_mod_astro expected 200, got 302)*

------
https://chatgpt.com/codex/tasks/task_e_68b9298a9734832cbff49d6c9439922f