### PR TITLE
Add Vote target integrity constraints

### DIFF
--- a/core/migrations/0024_vote_constraints.py
+++ b/core/migrations/0024_vote_constraints.py
@@ -1,0 +1,54 @@
+from django.conf import settings
+from django.db import migrations, models
+from django.db.models import Q
+
+
+def cleanup_votes(apps, schema_editor):
+    """Remove votes without a clear post or comment target."""
+
+    Vote = apps.get_model("core", "Vote")
+    Vote.objects.filter(
+        Q(target_type__isnull=True)
+        | ~Q(target_type__in=["post", "comment"])
+        | Q(target_id__isnull=True)
+    ).delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("core", "0023_community_name_ci_unique"),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.RunPython(cleanup_votes, migrations.RunPython.noop),
+        migrations.RemoveConstraint(
+            model_name="vote",
+            name="uniq_vote_target_user",
+        ),
+        migrations.AddConstraint(
+            model_name="vote",
+            constraint=models.CheckConstraint(
+                check=Q(target_type__in=["post", "comment"]),
+                name="vote_valid_target_type",
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name="vote",
+            constraint=models.UniqueConstraint(
+                fields=["user", "target_id"],
+                condition=Q(target_type="post"),
+                name="uniq_vote_post_user",
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name="vote",
+            constraint=models.UniqueConstraint(
+                fields=["user", "target_id"],
+                condition=Q(target_type="comment"),
+                name="uniq_vote_comment_user",
+            ),
+        ),
+    ]
+

--- a/core/models.py
+++ b/core/models.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 from django.db import models
-from django.db.models import F
+from django.db.models import F, Q
 from django.db.models.functions import Lower
 from django.db.models.signals import post_save, post_delete, pre_save
 from django.dispatch import receiver
@@ -287,10 +287,20 @@ class Vote(models.Model):
 
     class Meta:
         constraints = [
+            models.CheckConstraint(
+                check=Q(target_type__in=["post", "comment"]),
+                name="vote_valid_target_type",
+            ),
             models.UniqueConstraint(
-                fields=["user", "target_type", "target_id"],
-                name="uniq_vote_target_user",
-            )
+                fields=["user", "target_id"],
+                condition=Q(target_type="post"),
+                name="uniq_vote_post_user",
+            ),
+            models.UniqueConstraint(
+                fields=["user", "target_id"],
+                condition=Q(target_type="comment"),
+                name="uniq_vote_comment_user",
+            ),
         ]
 
 


### PR DESCRIPTION
## Summary
- ensure votes reference either a post or a comment and remove any invalid entries
- enforce per-user uniqueness for post and comment votes

## Testing
- `DJANGO_COLLECTSTATIC=1 pytest` *(fails: missing static files and invalid endpoint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b937d05184832cb331ac2ee3c2acb0