### PR TITLE
Normalize score span IDs for posts and comments

### DIFF
--- a/core/tests/test_routes.py
+++ b/core/tests/test_routes.py
@@ -62,7 +62,7 @@ class RouteTests(TestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertHTMLEqual(
             resp.content.decode(),
-            f'<span id="post-{self.post.pk}-score" class="score">1</span>',
+            f'<span id="post-score-{self.post.pk}">1</span>',
         )
 
     def test_vote_post_non_htmx_returns_span(self):
@@ -72,7 +72,7 @@ class RouteTests(TestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertHTMLEqual(
             resp.content.decode(),
-            f'<span id="post-{self.post.pk}-score" class="score">1</span>',
+            f'<span id="post-score-{self.post.pk}">1</span>',
         )
 
     def test_vote_post_invalid_value_returns_400(self):
@@ -115,5 +115,5 @@ class RouteTests(TestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertHTMLEqual(
             resp.content.decode(),
-            f'<span id="cscore-{self.comment.pk}" class="score">1</span>',
+            f'<span id="comment-score-{self.comment.pk}">1</span>',
         )

--- a/templates/core/partials/comment_item.html
+++ b/templates/core/partials/comment_item.html
@@ -12,7 +12,7 @@
     {% endif %}
     <span class="vote">
       <form hx-post="{% url 'vote_comment' comment.pk %}?v=1"
-            hx-target="#cscore-{{ comment.pk }}"
+            hx-target="#comment-score-{{ comment.pk }}"
             hx-swap="outerHTML"
             method="post" class="inline">
         {% csrf_token %}
@@ -22,7 +22,7 @@
       {% include "core/partials/comment_score.html" %}
 
       <form hx-post="{% url 'vote_comment' comment.pk %}?v=-1"
-            hx-target="#cscore-{{ comment.pk }}"
+            hx-target="#comment-score-{{ comment.pk }}"
             hx-swap="outerHTML"
             method="post" class="inline">
         {% csrf_token %}

--- a/templates/core/partials/comment_row.html
+++ b/templates/core/partials/comment_row.html
@@ -17,17 +17,17 @@
 
     <div class="comment-actions">
       <form hx-post="{% url 'vote_comment' comment.pk %}?v=1"
-            hx-target="#cscore-{{ comment.pk }}"
+            hx-target="#comment-score-{{ comment.pk }}"
             hx-swap="outerHTML"
             method="post" class="inline">
         {% csrf_token %}
         <button type="submit" aria-label="Upvote">▲</button>
       </form>
 
-      <span id="cscore-{{ comment.pk }}" class="score">{{ comment.score }}</span>
+      <span id="comment-score-{{ comment.pk }}">{{ comment.score }}</span>
 
       <form hx-post="{% url 'vote_comment' comment.pk %}?v=-1"
-            hx-target="#cscore-{{ comment.pk }}"
+            hx-target="#comment-score-{{ comment.pk }}"
             hx-swap="outerHTML"
             method="post" class="inline">
         {% csrf_token %}

--- a/templates/core/partials/comment_score.html
+++ b/templates/core/partials/comment_score.html
@@ -1,1 +1,1 @@
-{% include "partials/score_span.html" with id="cscore-"|add:comment.pk score=comment.score %}
+<span id="comment-score-{{ comment.pk }}">{{ comment.score }}</span>

--- a/templates/core/partials/post_row.html
+++ b/templates/core/partials/post_row.html
@@ -24,7 +24,7 @@
         <button
           hx-post="{% url 'vote_post' post.pk %}"
           hx-vals='{"v":1}'
-          hx-target="#post-{{ post.pk }}-score"
+          hx-target="#post-score-{{ post.pk }}"
           hx-swap="outerHTML"
           aria-label="Upvote">▲</button>
 
@@ -33,7 +33,7 @@
         <button
           hx-post="{% url 'vote_post' post.pk %}"
           hx-vals='{"v":-1}'
-          hx-target="#post-{{ post.pk }}-score"
+          hx-target="#post-score-{{ post.pk }}"
           hx-swap="outerHTML"
           aria-label="Downvote">▼</button>
       </div>

--- a/templates/core/partials/post_score.html
+++ b/templates/core/partials/post_score.html
@@ -1,2 +1,1 @@
-<span id="post-{{ post.pk }}-score" class="score">{{ post.score }}</span>
-
+<span id="post-score-{{ post.pk }}">{{ post.score }}</span>

--- a/templates/core/post_detail.html
+++ b/templates/core/post_detail.html
@@ -59,7 +59,7 @@
       <button
         hx-post="{% url 'vote_post' post.pk %}"
         hx-vals='{"v":1}'
-        hx-target="#post-{{ post.pk }}-score"
+        hx-target="#post-score-{{ post.pk }}"
         hx-swap="outerHTML"
         aria-label="Upvote">▲</button>
 
@@ -68,7 +68,7 @@
       <button
         hx-post="{% url 'vote_post' post.pk %}"
         hx-vals='{"v":-1}'
-        hx-target="#post-{{ post.pk }}-score"
+        hx-target="#post-score-{{ post.pk }}"
         hx-swap="outerHTML"
         aria-label="Downvote">▼</button>
     </div>

--- a/templates/partials/feed_card.html
+++ b/templates/partials/feed_card.html
@@ -34,7 +34,7 @@
       <button
         hx-post="{% url 'vote_post' post.pk %}"
         hx-vals='{"v":1}'
-        hx-target="#post-{{ post.pk }}-score"
+        hx-target="#post-score-{{ post.pk }}"
         hx-swap="outerHTML"
         aria-label="Upvote">▲</button>
 
@@ -43,7 +43,7 @@
       <button
         hx-post="{% url 'vote_post' post.pk %}"
         hx-vals='{"v":-1}'
-        hx-target="#post-{{ post.pk }}-score"
+        hx-target="#post-score-{{ post.pk }}"
         hx-swap="outerHTML"
         aria-label="Downvote">▼</button>
     </div>


### PR DESCRIPTION
## Summary
- use `post-score-{id}` and `comment-score-{id}` IDs for score spans
- update vote templates and tests to target the new IDs

## Testing
- `python manage.py test` *(fails: css/app.css not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9438a23c8832cb04a12e80192a75b