### PR TITLE
Use HTMX for post and comment votes

### DIFF
--- a/templates/core/partials/comment_item.html
+++ b/templates/core/partials/comment_item.html
@@ -10,24 +10,23 @@
     {% if comment.edited_at %}
       <span class="edited" title="Edited {{ comment.edited_at|date:'Y-m-d H:i' }}">edited</span>
     {% endif %}
-    <span class="vote">
-      <form hx-post="{% url 'vote_comment' comment.pk %}?v=1"
-            hx-target="#comment-score-{{ comment.pk }}"
-            hx-swap="outerHTML"
-            method="post" class="inline">
-        {% csrf_token %}
-        <button type="submit" aria-label="Upvote">▲</button>
-      </form>
+    <span class="vote comment-vote" id="comment-{{ comment.pk }}-vote"
+          hx-on::after-request="this.querySelectorAll('button').forEach(btn => btn.disabled = true)">
+      <button
+        hx-post="{% url 'vote_comment' comment.pk %}"
+        hx-vals='{"v":1}'
+        hx-target="#comment-score-{{ comment.pk }}"
+        hx-swap="outerHTML"
+        aria-label="Upvote">▲</button>
 
       {% include "core/partials/comment_score.html" %}
 
-      <form hx-post="{% url 'vote_comment' comment.pk %}?v=-1"
-            hx-target="#comment-score-{{ comment.pk }}"
-            hx-swap="outerHTML"
-            method="post" class="inline">
-        {% csrf_token %}
-        <button type="submit" aria-label="Downvote">▼</button>
-      </form>
+      <button
+        hx-post="{% url 'vote_comment' comment.pk %}"
+        hx-vals='{"v":-1}'
+        hx-target="#comment-score-{{ comment.pk }}"
+        hx-swap="outerHTML"
+        aria-label="Downvote">▼</button>
     </span>
     <button hx-get="/comments/new?parent={{ comment.pk }}&post={{ comment.post.pk }}"
             hx-target="#comment-{{ comment.pk }} > .children" hx-swap="beforeend">Reply</button>

--- a/templates/core/partials/comment_row.html
+++ b/templates/core/partials/comment_row.html
@@ -16,23 +16,24 @@
   </div>
 
     <div class="comment-actions">
-      <form hx-post="{% url 'vote_comment' comment.pk %}?v=1"
-            hx-target="#comment-score-{{ comment.pk }}"
-            hx-swap="outerHTML"
-            method="post" class="inline">
-        {% csrf_token %}
-        <button type="submit" aria-label="Upvote">▲</button>
-      </form>
+      <div class="comment-vote" id="comment-{{ comment.pk }}-vote"
+           hx-on::after-request="this.querySelectorAll('button').forEach(btn => btn.disabled = true)">
+        <button
+          hx-post="{% url 'vote_comment' comment.pk %}"
+          hx-vals='{"v":1}'
+          hx-target="#comment-score-{{ comment.pk }}"
+          hx-swap="outerHTML"
+          aria-label="Upvote">▲</button>
 
-      <span id="comment-score-{{ comment.pk }}">{{ comment.score }}</span>
+        <span id="comment-score-{{ comment.pk }}">{{ comment.score }}</span>
 
-      <form hx-post="{% url 'vote_comment' comment.pk %}?v=-1"
-            hx-target="#comment-score-{{ comment.pk }}"
-            hx-swap="outerHTML"
-            method="post" class="inline">
-        {% csrf_token %}
-        <button type="submit" aria-label="Downvote">▼</button>
-      </form>
+        <button
+          hx-post="{% url 'vote_comment' comment.pk %}"
+          hx-vals='{"v":-1}'
+          hx-target="#comment-score-{{ comment.pk }}"
+          hx-swap="outerHTML"
+          aria-label="Downvote">▼</button>
+      </div>
 
       <a class="reply"
          hx-get="{% url 'comment_reply_form' comment.pk %}"

--- a/templates/core/partials/post_row.html
+++ b/templates/core/partials/post_row.html
@@ -20,7 +20,8 @@
     <p class="post-excerpt">{{ post.body|truncatechars:180 }}</p>
     {% endif %}
     <div class="post-actions">
-      <div class="vote" id="post-{{ post.pk }}-vote">
+      <div class="vote post-vote" id="post-{{ post.pk }}-vote"
+           hx-on::after-request="this.querySelectorAll('button').forEach(btn => btn.disabled = true)">
         <button
           hx-post="{% url 'vote_post' post.pk %}"
           hx-vals='{"v":1}'

--- a/templates/core/post_detail.html
+++ b/templates/core/post_detail.html
@@ -55,7 +55,8 @@
   {% endif %}
 
   <div class="post-actions">
-    <div class="vote" id="post-{{ post.pk }}-vote">
+    <div class="vote post-vote" id="post-{{ post.pk }}-vote"
+         hx-on::after-request="this.querySelectorAll('button').forEach(btn => btn.disabled = true)">
       <button
         hx-post="{% url 'vote_post' post.pk %}"
         hx-vals='{"v":1}'

--- a/templates/partials/feed_card.html
+++ b/templates/partials/feed_card.html
@@ -30,7 +30,8 @@
   <p class="post-excerpt">{{ post.body|truncatechars:180 }}</p>
   {% endif %}
   <div class="post-actions">
-    <div class="vote" id="post-{{ post.pk }}-vote">
+    <div class="vote post-vote" id="post-{{ post.pk }}-vote"
+         hx-on::after-request="this.querySelectorAll('button').forEach(btn => btn.disabled = true)">
       <button
         hx-post="{% url 'vote_post' post.pk %}"
         hx-vals='{"v":1}'


### PR DESCRIPTION
## Summary
- wrap post vote buttons in `.post-vote` containers and disable after requests
- add `.comment-vote` containers and HTMX attributes for comment voting

## Testing
- `DJANGO_COLLECTSTATIC=1 python manage.py test` *(fails: ValueError: The file 'css/app.css' could not be found...)*

------
https://chatgpt.com/codex/tasks/task_e_68b94523bdd8832cbc8726700c380dfb