### PR TITLE
Add vote URL patterns for posts and comments

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -55,7 +55,7 @@ urlpatterns = [
     path("comments/new", core_views.comment_new, name="comment_new"),
     path("comments/create", core_views.comment_create, name="comment_create"),
     path("comments/children", core_views.comment_children, name="comment_children"),
-    path("vote/post/<int:pk>/", core_views.vote_post, name="vote_post"),
+    path("posts/vote/<int:pk>/", core_views.vote_post, name="vote_post"),
     path("comments/vote/<int:pk>/", core_views.vote_comment, name="vote_comment"),
     # Post moderation
     path("post/<int:pk>/edit/", core_views.post_edit, name="post_edit"),


### PR DESCRIPTION
## Summary
- Add routes for post and comment voting

## Testing
- `DJANGO_COLLECTSTATIC=1 python manage.py shell` *(reverse vote_post & vote_comment)*
- `DJANGO_COLLECTSTATIC=1 pytest` *(fails: file 'css/app.css' could not be found, invalid endpoints)*

------
https://chatgpt.com/codex/tasks/task_e_68b9483a9bac832c93b324d381a64927