### PR TITLE
Serve HTMX locally with CSRF meta tag

### DIFF
--- a/static/js/htmx-csrf.js
+++ b/static/js/htmx-csrf.js
@@ -1,16 +1,13 @@
 // Adds Django CSRF header to all HTMX requests
 (function () {
-  function getCookie(name) {
-    let v = null;
-    if (document.cookie) {
-      document.cookie.split(';').forEach(c => {
-        c = c.trim();
-        if (c.startsWith(name + '=')) v = decodeURIComponent(c.slice(name.length + 1));
-      });
-    }
-    return v;
+  function csrfToken() {
+    const meta = document.querySelector('meta[name="csrf-token"]');
+    return meta ? meta.getAttribute('content') : '';
   }
   document.body.addEventListener('htmx:configRequest', function (evt) {
-    evt.detail.headers['X-CSRFToken'] = getCookie('csrftoken');
+    const token = csrfToken();
+    if (token) {
+      evt.detail.headers['X-CSRFToken'] = token;
+    }
   });
 }());

--- a/templates/core/base.html
+++ b/templates/core/base.html
@@ -4,6 +4,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="csrf-token" content="{{ csrf_token }}">
   <title>{% block title %}SureJan{% endblock %}</title>
   <link rel="stylesheet" href="{% static 'css/app.css' %}">
   {% block head %}{% endblock %}


### PR DESCRIPTION
## Summary
- expose a csrf-token meta tag in the base template
- send X-CSRFToken header on HTMX requests via small helper script

## Testing
- `DJANGO_COLLECTSTATIC=1 python manage.py test 2>&1 | tail -n 20 | cut -c1-200` *(fails: FAIL: test_youtube_link_post, other failures and errors)*
- `DJANGO_ALLOWED_HOSTS=testserver DJANGO_COLLECTSTATIC=1 python manage.py shell <<'PY' ... PY`

------
https://chatgpt.com/codex/tasks/task_e_68b94a788168832ca508a894026c6ddd