### PR TITLE
Enable strict Whitenoise manifest checks

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -243,9 +243,8 @@ STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
 
 STORAGES = {"staticfiles": {"BACKEND": STATICFILES_STORAGE}}
 
-# Temporary guard to avoid 500s from missing manifest entries while iterating.
-# REMOVE once favicon/static references are correct and collectstatic is clean.
-WHITENOISE_MANIFEST_STRICT = False
+# Enforce manifest integrity for static files to surface missing references.
+WHITENOISE_MANIFEST_STRICT = True
 
 # Required envs
 AWS_STORAGE_BUCKET_NAME = os.getenv("AWS_STORAGE_BUCKET_NAME")


### PR DESCRIPTION
## Summary
- enable strict Whitenoise manifest mode after verifying static assets

## Testing
- `DJANGO_COLLECTSTATIC=1 python manage.py collectstatic --noinput`
- `pytest` *(fails: No module named 'core'; missing pytest-django and freezegun)*
- `podman build -t surejan-test .` *(fails: Forbidden pulling base image)*

------
https://chatgpt.com/codex/tasks/task_e_68b94d8349a8832ca0d46966b9ddcfc3