### PR TITLE
Add HTMX-aware login gating for votes

### DIFF
--- a/core/http.py
+++ b/core/http.py
@@ -1,0 +1,33 @@
+"""HTTP helper utilities."""
+
+from functools import wraps
+
+from django.http import HttpResponse
+from django.urls import reverse
+from django.contrib.auth.views import redirect_to_login
+
+
+def login_required_htmx(view):
+    """Require login with HTMX-aware handling.
+
+    If the user is authenticated, the wrapped view is called. For anonymous
+    HTMX requests a ``401`` response is returned with an ``HX-Redirect`` header
+    pointing at the login page. Normal anonymous requests are redirected to the
+    login page using :func:`redirect_to_login`.
+    """
+
+    @wraps(view)
+    def wrapper(request, *args, **kwargs):
+        if request.user.is_authenticated:
+            return view(request, *args, **kwargs)
+
+        if request.headers.get("HX-Request") == "true":
+            resp = HttpResponse(status=401)
+            login_url = reverse("login") + "?next=" + request.get_full_path()
+            resp["HX-Redirect"] = login_url
+            return resp
+
+        return redirect_to_login(request.get_full_path())
+
+    return wrapper
+

--- a/core/tests/test_vote_auth_gate.py
+++ b/core/tests/test_vote_auth_gate.py
@@ -1,0 +1,69 @@
+import pytest
+from django.urls import reverse
+from django.contrib.auth import get_user_model
+
+from core.models import Community, Post, Comment
+
+
+@pytest.fixture
+@pytest.mark.django_db
+
+def content():
+    User = get_user_model()
+    author = User.objects.create_user("author", password="pwd")
+    community = Community.objects.create(
+        slug="t", name="Test", title="Test", created_by=author
+    )
+    post = Post.objects.create(
+        community=community, author=author, post_type="text", title="Hello"
+    )
+    comment = Comment.objects.create(post=post, author=author, body="Hi")
+    return {"post": post, "comment": comment}
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("kind", ["post", "comment"])
+def test_htmx_requires_login(client, content, kind):
+    target = content[kind]
+    url = reverse(f"vote_{kind}", args=[target.pk])
+    resp = client.post(url, {"v": "1"}, HTTP_HX_REQUEST="true")
+    assert resp.status_code == 401
+    assert resp.headers["HX-Redirect"] == reverse("login") + f"?next={url}"
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("kind", ["post", "comment"])
+def test_normal_post_redirects_to_login(client, content, kind):
+    target = content[kind]
+    url = reverse(f"vote_{kind}", args=[target.pk])
+    resp = client.post(url, {"v": "1"})
+    assert resp.status_code == 302
+    assert resp["Location"] == reverse("login") + f"?next={url}"
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("kind", ["post", "comment"])
+def test_get_not_allowed(client, content, kind):
+    target = content[kind]
+    url = reverse(f"vote_{kind}", args=[target.pk])
+    resp = client.get(url)
+    assert resp.status_code == 405
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("kind", ["post", "comment"])
+def test_logged_in_vote_then_conflict(client, content, kind):
+    User = get_user_model()
+    voter = User.objects.create_user("voter", password="pwd")
+    client.force_login(voter)
+
+    target = content[kind]
+    url = reverse(f"vote_{kind}", args=[target.pk])
+
+    resp1 = client.post(url, {"v": "1"})
+    assert resp1.status_code == 200
+    target.refresh_from_db()
+    assert target.score == 1
+
+    resp2 = client.post(url, {"v": "1"})
+    assert resp2.status_code == 409

--- a/core/views.py
+++ b/core/views.py
@@ -56,6 +56,7 @@ from .services.votes import (
 from .oembed import fetch_oembed
 from .utils.embeds import build_embed_html
 from . import mod
+from .http import login_required_htmx
 
 
 def _is_banned(user):
@@ -1300,15 +1301,14 @@ def comment_delete(request, pk):
     )
 
 
-@login_required
 @require_POST
+@login_required_htmx
 def vote_post(request, pk):
     post = get_object_or_404(Post, pk=pk)
 
-    raw = request.POST.get("v")
     try:
-        want = int(raw)
-    except (TypeError, ValueError):
+        want = int(request.POST["v"])
+    except (KeyError, TypeError, ValueError):
         return HttpResponseBadRequest("Invalid vote")
     if want not in (1, -1):
         return HttpResponseBadRequest("Invalid vote")
@@ -1321,15 +1321,14 @@ def vote_post(request, pk):
     return render(request, "core/partials/post_score.html", {"post": post})
 
 
-@login_required
 @require_POST
+@login_required_htmx
 def vote_comment(request, pk):
     comment = get_object_or_404(Comment, pk=pk)
 
-    raw = request.POST.get("v")
     try:
-        want = int(raw)
-    except (TypeError, ValueError):
+        want = int(request.POST["v"])
+    except (KeyError, TypeError, ValueError):
         return HttpResponseBadRequest("Invalid vote")
     if want not in (1, -1):
         return HttpResponseBadRequest("Invalid vote")


### PR DESCRIPTION
## Summary
- Add `login_required_htmx` decorator returning 401 and HX-Redirect for anonymous HTMX requests
- Use decorator for `vote_post` and `vote_comment`, validating votes from POST only
- Test vote auth gating for posts and comments, including HTMX and normal requests

## Testing
- `python -m pytest core/tests/test_vote_auth_gate.py -q`
- `python -m pytest -q` *(fails: Missing staticfiles manifest entry for 'css/app.css')*

------
https://chatgpt.com/codex/tasks/task_e_68b95891e144832ca8be5c8917be8f10