### PR TITLE
Require login for voting controls

### DIFF
--- a/core/tests/test_links.py
+++ b/core/tests/test_links.py
@@ -2,7 +2,7 @@ from django.contrib.auth import get_user_model
 from django.core.cache import cache
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.template.loader import render_to_string
-from django.test import TestCase
+from django.test import RequestFactory, TestCase
 from django.urls import reverse
 from io import BytesIO
 from PIL import Image
@@ -75,20 +75,24 @@ class PostLinkTests(TestCase):
             title="Hello",
             image=img,
         )
+        self.factory = RequestFactory()
 
     def test_feed_card_uses_absolute_url(self):
         url = self.post.get_absolute_url()
-        html = render_to_string("partials/feed_card.html", {"post": self.post})
+        request = self.factory.get("/")
+        html = render_to_string("partials/feed_card.html", {"post": self.post}, request=request)
         self.assertEqual(html.count(f'href="{url}"'), 2)
         self.assertIn(f'href="{url}#comments"', html)
 
     def test_post_row_uses_absolute_url(self):
         url = self.post.get_absolute_url()
-        html = render_to_string("core/partials/post_row.html", {"post": self.post})
+        request = self.factory.get("/")
+        html = render_to_string("core/partials/post_row.html", {"post": self.post}, request=request)
         self.assertEqual(html.count(f'href="{url}"'), 2)
         self.assertIn(f'href="{url}#comments"', html)
 
     def test_post_row_links_author(self):
         user_url = reverse("user_overview", args=[self.user.username])
-        html = render_to_string("core/partials/post_row.html", {"post": self.post})
+        request = self.factory.get("/")
+        html = render_to_string("core/partials/post_row.html", {"post": self.post}, request=request)
         self.assertIn(f'href="{user_url}"', html)

--- a/core/tests/test_vote_templates.py
+++ b/core/tests/test_vote_templates.py
@@ -1,0 +1,40 @@
+import pytest
+from django.contrib.auth import get_user_model
+
+from core.models import Community, Post, Comment
+
+
+@pytest.fixture
+def content(db):
+    User = get_user_model()
+    author = User.objects.create_user("author", password="pwd")
+    community = Community.objects.create(
+        slug="t", name="Test", title="Test", created_by=author
+    )
+    post = Post.objects.create(
+        community=community, author=author, post_type="text", title="Hello"
+    )
+    comment = Comment.objects.create(post=post, author=author, body="Hi")
+    return post, comment
+
+
+@pytest.mark.django_db
+def test_anonymous_shows_login_prompt(client, content):
+    post, _ = content
+    resp = client.get(post.get_absolute_url())
+    html = resp.content.decode()
+    assert "hx-post" not in html
+    assert "Log in to vote" in html
+
+
+@pytest.mark.django_db
+def test_authenticated_shows_vote_buttons(client, content):
+    post, comment = content
+    User = get_user_model()
+    voter = User.objects.create_user("voter", password="pwd")
+    client.force_login(voter)
+    resp = client.get(post.get_absolute_url())
+    html = resp.content.decode()
+    assert "hx-post" in html
+    assert f'hx-target="#post-score-{post.pk}"' in html
+    assert f'hx-target="#comment-score-{comment.pk}"' in html

--- a/templates/core/partials/comment_item.html
+++ b/templates/core/partials/comment_item.html
@@ -10,8 +10,9 @@
     {% if comment.edited_at %}
       <span class="edited" title="Edited {{ comment.edited_at|date:'Y-m-d H:i' }}">edited</span>
     {% endif %}
-    <span class="vote comment-vote" id="comment-{{ comment.pk }}-vote"
-          hx-on::after-request="this.querySelectorAll('button').forEach(btn => btn.disabled = true)">
+    <span class="vote comment-vote" id="comment-{{ comment.pk }}-vote"{% if user.is_authenticated %}
+          hx-on::after-request="this.querySelectorAll('button').forEach(btn => btn.disabled = true)"{% endif %}>
+      {% if user.is_authenticated %}
       <button
         hx-post="{% url 'vote_comment' comment.pk %}"
         hx-vals='{"v":1}'
@@ -27,6 +28,12 @@
         hx-target="#comment-score-{{ comment.pk }}"
         hx-swap="outerHTML"
         aria-label="Downvote">▼</button>
+      {% else %}
+      <button disabled aria-label="Upvote">▲</button>
+      {% include "core/partials/comment_score.html" %}
+      <button disabled aria-label="Downvote">▼</button>
+      <a href="{% url 'login' %}?next={{ request.path }}">Log in to vote</a>
+      {% endif %}
     </span>
     <button hx-get="/comments/new?parent={{ comment.pk }}&post={{ comment.post.pk }}"
             hx-target="#comment-{{ comment.pk }} > .children" hx-swap="beforeend">Reply</button>

--- a/templates/core/partials/comment_row.html
+++ b/templates/core/partials/comment_row.html
@@ -16,8 +16,9 @@
   </div>
 
     <div class="comment-actions">
-      <div class="comment-vote" id="comment-{{ comment.pk }}-vote"
-           hx-on::after-request="this.querySelectorAll('button').forEach(btn => btn.disabled = true)">
+      <div class="comment-vote" id="comment-{{ comment.pk }}-vote"{% if user.is_authenticated %}
+           hx-on::after-request="this.querySelectorAll('button').forEach(btn => btn.disabled = true)"{% endif %}>
+        {% if user.is_authenticated %}
         <button
           hx-post="{% url 'vote_comment' comment.pk %}"
           hx-vals='{"v":1}'
@@ -33,6 +34,12 @@
           hx-target="#comment-score-{{ comment.pk }}"
           hx-swap="outerHTML"
           aria-label="Downvote">▼</button>
+        {% else %}
+        <button disabled aria-label="Upvote">▲</button>
+        <span id="comment-score-{{ comment.pk }}">{{ comment.score }}</span>
+        <button disabled aria-label="Downvote">▼</button>
+        <a href="{% url 'login' %}?next={{ request.path }}">Log in to vote</a>
+        {% endif %}
       </div>
 
       <a class="reply"
@@ -47,7 +54,7 @@
     {% if kids %}
       <div class="comment-children">
         {% for child in kids %}
-          {% include "core/partials/comment_row.html" with comment=child depth=depth|add:1 only %}
+          {% include "core/partials/comment_row.html" with comment=child depth=depth|add:1 request=request user=user only %}
         {% endfor %}
       </div>
     {% endif %}

--- a/templates/core/partials/post_row.html
+++ b/templates/core/partials/post_row.html
@@ -20,8 +20,9 @@
     <p class="post-excerpt">{{ post.body|truncatechars:180 }}</p>
     {% endif %}
     <div class="post-actions">
-      <div class="vote post-vote" id="post-{{ post.pk }}-vote"
-           hx-on::after-request="this.querySelectorAll('button').forEach(btn => btn.disabled = true)">
+      <div class="vote post-vote" id="post-{{ post.pk }}-vote"{% if user.is_authenticated %}
+           hx-on::after-request="this.querySelectorAll('button').forEach(btn => btn.disabled = true)"{% endif %}>
+        {% if user.is_authenticated %}
         <button
           hx-post="{% url 'vote_post' post.pk %}"
           hx-vals='{"v":1}'
@@ -37,6 +38,12 @@
           hx-target="#post-score-{{ post.pk }}"
           hx-swap="outerHTML"
           aria-label="Downvote">▼</button>
+        {% else %}
+        <button disabled aria-label="Upvote">▲</button>
+        {% include "core/partials/post_score.html" with post=post only %}
+        <button disabled aria-label="Downvote">▼</button>
+        <a href="{% url 'login' %}?next={{ request.path }}">Log in to vote</a>
+        {% endif %}
       </div>
       <a href="{{ post.get_absolute_url }}#comments">{{ post.comment_count }} comments</a>
     </div>

--- a/templates/core/post_detail.html
+++ b/templates/core/post_detail.html
@@ -55,8 +55,9 @@
   {% endif %}
 
   <div class="post-actions">
-    <div class="vote post-vote" id="post-{{ post.pk }}-vote"
-         hx-on::after-request="this.querySelectorAll('button').forEach(btn => btn.disabled = true)">
+    <div class="vote post-vote" id="post-{{ post.pk }}-vote"{% if user.is_authenticated %}
+         hx-on::after-request="this.querySelectorAll('button').forEach(btn => btn.disabled = true)"{% endif %}>
+      {% if user.is_authenticated %}
       <button
         hx-post="{% url 'vote_post' post.pk %}"
         hx-vals='{"v":1}'
@@ -72,6 +73,12 @@
         hx-target="#post-score-{{ post.pk }}"
         hx-swap="outerHTML"
         aria-label="Downvote">▼</button>
+      {% else %}
+      <button disabled aria-label="Upvote">▲</button>
+      {% include "core/partials/post_score.html" with post=post only %}
+      <button disabled aria-label="Downvote">▼</button>
+      <a href="{% url 'login' %}?next={{ request.path }}">Log in to vote</a>
+      {% endif %}
     </div>
 
     {% if severity_band %}
@@ -116,7 +123,7 @@
 
   <div id="comment-tree">
     {% for c in comments %}
-      {% include "core/partials/comment_row.html" with comment=c depth=0 only %}
+      {% include "core/partials/comment_row.html" with comment=c depth=0 request=request user=request.user only %}
     {% empty %}
       <p class="muted">No comments yet.</p>
     {% endfor %}

--- a/templates/partials/feed_card.html
+++ b/templates/partials/feed_card.html
@@ -30,8 +30,9 @@
   <p class="post-excerpt">{{ post.body|truncatechars:180 }}</p>
   {% endif %}
   <div class="post-actions">
-    <div class="vote post-vote" id="post-{{ post.pk }}-vote"
-         hx-on::after-request="this.querySelectorAll('button').forEach(btn => btn.disabled = true)">
+    <div class="vote post-vote" id="post-{{ post.pk }}-vote"{% if user.is_authenticated %}
+         hx-on::after-request="this.querySelectorAll('button').forEach(btn => btn.disabled = true)"{% endif %}>
+      {% if user.is_authenticated %}
       <button
         hx-post="{% url 'vote_post' post.pk %}"
         hx-vals='{"v":1}'
@@ -47,6 +48,12 @@
         hx-target="#post-score-{{ post.pk }}"
         hx-swap="outerHTML"
         aria-label="Downvote">▼</button>
+      {% else %}
+      <button disabled aria-label="Upvote">▲</button>
+      {% include "core/partials/post_score.html" with post=post only %}
+      <button disabled aria-label="Downvote">▼</button>
+      <a href="{% url 'login' %}?next={{ request.path }}">Log in to vote</a>
+      {% endif %}
     </div>
     <a href="{{ detail_url }}#comments">{{ post.comment_count }} comments</a>
     {% if post.astro_score %}


### PR DESCRIPTION
## Summary
- Gate post and comment vote buttons behind authentication with disabled controls and login prompt for anonymous users
- Test that anonymous pages show login prompt and logged-in pages show interactive HTMX vote targets

## Testing
- `DJANGO_COLLECTSTATIC=1 pytest core/tests/test_vote_templates.py -q`
- `DJANGO_COLLECTSTATIC=1 pytest` *(fails: Missing staticfiles manifest entry for css/app.css)*

------
https://chatgpt.com/codex/tasks/task_e_68b9599efd6c832caf6a28a962d97e5d