### PR TITLE
Add HTMX guard script for auth/error handling

### DIFF
--- a/core/tests/test_htmx_guard_included.py
+++ b/core/tests/test_htmx_guard_included.py
@@ -1,0 +1,16 @@
+import pytest
+from django.urls import reverse
+from django.test import override_settings
+
+
+@pytest.mark.django_db
+@override_settings(
+    STATICFILES_STORAGE="django.contrib.staticfiles.storage.StaticFilesStorage",
+    STORAGES={"staticfiles": {"BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage"}},
+)
+def test_htmx_guard_included(client):
+    resp = client.get(reverse('home'))
+    assert resp.status_code == 200
+    html = resp.content.decode()
+    assert '<script src="/static/js/htmx-guard.js" defer></script>' in html
+

--- a/static/js/htmx-guard.js
+++ b/static/js/htmx-guard.js
@@ -1,0 +1,16 @@
+// Handles certain HTMX error responses globally
+(function () {
+  document.body.addEventListener('htmx:beforeSwap', function (evt) {
+    var status = evt.detail.xhr.status;
+    if (status === 401) {
+      var redirect = evt.detail.xhr.getResponseHeader('HX-Redirect');
+      if (redirect) {
+        window.location.href = redirect;
+      }
+      evt.detail.shouldSwap = false;
+    }
+    if (status === 403 || status === 409 || (status >= 500 && status < 600)) {
+      evt.detail.shouldSwap = false;
+    }
+  });
+}());

--- a/templates/core/base.html
+++ b/templates/core/base.html
@@ -32,6 +32,7 @@
   {% include "core/partials/footer.html" %}
   <!-- HTMX (local) -->
   <script src="{% static 'js/htmx.min.js' %}" defer></script>
+  <script src="{% static 'js/htmx-guard.js' %}" defer></script>
   <script src="{% static 'js/htmx-csrf.js' %}" defer></script>
   {% block scripts %}{% endblock %}
 </body>


### PR DESCRIPTION
## Summary
- add `htmx-guard.js` to handle 401 redirects and suppress 403/409/5xx swaps
- include guard script in core base template
- test that `htmx-guard.js` is loaded on pages using `base.html`

## Testing
- `pytest core/tests/test_htmx_guard_included.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b95b9b9c48832c8c0c3b273b69174d