### PR TITLE
Show toast and reset buttons on HTMX errors

### DIFF
--- a/static/js/htmx-guard.js
+++ b/static/js/htmx-guard.js
@@ -1,5 +1,34 @@
 // Handles certain HTMX error responses globally
 (function () {
+  function showToast(message) {
+    var toast = document.createElement('div');
+    toast.textContent = message;
+    toast.style.position = 'fixed';
+    toast.style.bottom = '1rem';
+    toast.style.left = '50%';
+    toast.style.transform = 'translateX(-50%)';
+    toast.style.background = '#333';
+    toast.style.color = '#fff';
+    toast.style.padding = '0.5rem 1rem';
+    toast.style.borderRadius = '4px';
+    toast.style.zIndex = '1000';
+    toast.style.opacity = '0';
+    toast.style.transition = 'opacity 0.3s';
+    document.body.appendChild(toast);
+    requestAnimationFrame(function () { toast.style.opacity = '1'; });
+    setTimeout(function () { toast.style.opacity = '0'; }, 2000);
+    setTimeout(function () { toast.remove(); }, 2300);
+  }
+
+  function reenableVoteButtons(target) {
+    if (!target) return;
+    var container = target.closest('.vote, .comment-vote');
+    if (!container) return;
+    container.querySelectorAll('button').forEach(function (btn) {
+      btn.disabled = false;
+    });
+  }
+
   document.body.addEventListener('htmx:beforeSwap', function (evt) {
     var status = evt.detail.xhr.status;
     if (status === 401) {
@@ -7,9 +36,21 @@
       if (redirect) {
         window.location.href = redirect;
       }
+      showToast('Please log in');
+      reenableVoteButtons(evt.detail.target);
       evt.detail.shouldSwap = false;
     }
-    if (status === 403 || status === 409 || (status >= 500 && status < 600)) {
+    if (status === 403) {
+      showToast('Action forbidden');
+      reenableVoteButtons(evt.detail.target);
+      evt.detail.shouldSwap = false;
+    }
+    if (status === 409) {
+      showToast("You've already voted");
+      reenableVoteButtons(evt.detail.target);
+      evt.detail.shouldSwap = false;
+    }
+    if (status >= 500 && status < 600) {
       evt.detail.shouldSwap = false;
     }
   });


### PR DESCRIPTION
## Summary
- Display toast notifications for unauthorized, forbidden, or duplicate HTMX requests
- Re-enable vote buttons after failed HTMX requests

## Testing
- `DJANGO_COLLECTSTATIC=1 pytest -q` *(fails: AstroFeatureFlagViewTests::test_chip_containers_hidden_when_flag_disabled, test_homepage_layout, test_post_detail_comment_links, test_feed_card_uses_absolute_url, test_post_row_links_author, test_post_row_uses_absolute_url, test_image_slideshow_renders, test_youtube_embed_has_placeholder, test_rate_limit_counter::test_limit_enforced, test_routes::test_mod_astro, test_vote_comment_htmx_with_csrf)*

------
https://chatgpt.com/codex/tasks/task_e_68b960d37a20832ca71b16f489d54144