### PR TITLE
refactor: extract vote widget partial

### DIFF
--- a/templates/core/partials/post_row.html
+++ b/templates/core/partials/post_row.html
@@ -20,31 +20,7 @@
     <p class="post-excerpt">{{ post.body|truncatechars:180 }}</p>
     {% endif %}
     <div class="post-actions">
-      <div class="vote post-vote" id="post-{{ post.pk }}-vote"{% if user.is_authenticated %}
-           hx-on::after-request="this.querySelectorAll('button').forEach(btn => btn.disabled = true)"{% endif %}>
-        {% if user.is_authenticated %}
-        <button
-          hx-post="{% url 'vote_post' post.pk %}"
-          hx-vals='{"v":1}'
-          hx-target="#post-score-{{ post.pk }}"
-          hx-swap="outerHTML"
-          aria-label="Upvote">▲</button>
-
-        {% include "core/partials/post_score.html" with post=post only %}
-
-        <button
-          hx-post="{% url 'vote_post' post.pk %}"
-          hx-vals='{"v":-1}'
-          hx-target="#post-score-{{ post.pk }}"
-          hx-swap="outerHTML"
-          aria-label="Downvote">▼</button>
-        {% else %}
-        <button disabled aria-label="Upvote">▲</button>
-        {% include "core/partials/post_score.html" with post=post only %}
-        <button disabled aria-label="Downvote">▼</button>
-        <a href="{% url 'login' %}?next={{ request.path }}">Log in to vote</a>
-        {% endif %}
-      </div>
+      {% include "core/partials/vote_widget.html" with post=post user=user request=request only %}
       <a href="{{ post.get_absolute_url }}#comments">{{ post.comment_count }} comments</a>
     </div>
   {% endwith %}

--- a/templates/core/partials/vote_widget.html
+++ b/templates/core/partials/vote_widget.html
@@ -1,0 +1,25 @@
+<div class="vote post-vote" id="post-{{ post.pk }}-vote"{% if user.is_authenticated %}
+     hx-on::after-request="this.querySelectorAll('button').forEach(btn => btn.disabled = true)"{% endif %}>
+  {% if user.is_authenticated %}
+  <button
+    hx-post="{% url 'vote_post' post.pk %}"
+    hx-vals='{"v":1}'
+    hx-target="#post-score-{{ post.pk }}"
+    hx-swap="outerHTML"
+    aria-label="Upvote">▲</button>
+
+  {% include "core/partials/post_score.html" with post=post only %}
+
+  <button
+    hx-post="{% url 'vote_post' post.pk %}"
+    hx-vals='{"v":-1}'
+    hx-target="#post-score-{{ post.pk }}"
+    hx-swap="outerHTML"
+    aria-label="Downvote">▼</button>
+  {% else %}
+  <button disabled aria-label="Upvote">▲</button>
+  {% include "core/partials/post_score.html" with post=post only %}
+  <button disabled aria-label="Downvote">▼</button>
+  <a href="{% url 'login' %}?next={{ request.path }}">Log in to vote</a>
+  {% endif %}
+</div>

--- a/templates/core/post_detail.html
+++ b/templates/core/post_detail.html
@@ -55,31 +55,7 @@
   {% endif %}
 
   <div class="post-actions">
-    <div class="vote post-vote" id="post-{{ post.pk }}-vote"{% if user.is_authenticated %}
-         hx-on::after-request="this.querySelectorAll('button').forEach(btn => btn.disabled = true)"{% endif %}>
-      {% if user.is_authenticated %}
-      <button
-        hx-post="{% url 'vote_post' post.pk %}"
-        hx-vals='{"v":1}'
-        hx-target="#post-score-{{ post.pk }}"
-        hx-swap="outerHTML"
-        aria-label="Upvote">▲</button>
-
-      {% include "core/partials/post_score.html" with post=post only %}
-
-      <button
-        hx-post="{% url 'vote_post' post.pk %}"
-        hx-vals='{"v":-1}'
-        hx-target="#post-score-{{ post.pk }}"
-        hx-swap="outerHTML"
-        aria-label="Downvote">▼</button>
-      {% else %}
-      <button disabled aria-label="Upvote">▲</button>
-      {% include "core/partials/post_score.html" with post=post only %}
-      <button disabled aria-label="Downvote">▼</button>
-      <a href="{% url 'login' %}?next={{ request.path }}">Log in to vote</a>
-      {% endif %}
-    </div>
+    {% include "core/partials/vote_widget.html" with post=post user=user request=request only %}
 
     {% if severity_band %}
       <div class="astro-meter" title="Astro severity: {{ severity|floatformat:0 }}/100">

--- a/templates/partials/feed_card.html
+++ b/templates/partials/feed_card.html
@@ -30,31 +30,7 @@
   <p class="post-excerpt">{{ post.body|truncatechars:180 }}</p>
   {% endif %}
   <div class="post-actions">
-    <div class="vote post-vote" id="post-{{ post.pk }}-vote"{% if user.is_authenticated %}
-         hx-on::after-request="this.querySelectorAll('button').forEach(btn => btn.disabled = true)"{% endif %}>
-      {% if user.is_authenticated %}
-      <button
-        hx-post="{% url 'vote_post' post.pk %}"
-        hx-vals='{"v":1}'
-        hx-target="#post-score-{{ post.pk }}"
-        hx-swap="outerHTML"
-        aria-label="Upvote">▲</button>
-
-      {% include "core/partials/post_score.html" with post=post only %}
-
-      <button
-        hx-post="{% url 'vote_post' post.pk %}"
-        hx-vals='{"v":-1}'
-        hx-target="#post-score-{{ post.pk }}"
-        hx-swap="outerHTML"
-        aria-label="Downvote">▼</button>
-      {% else %}
-      <button disabled aria-label="Upvote">▲</button>
-      {% include "core/partials/post_score.html" with post=post only %}
-      <button disabled aria-label="Downvote">▼</button>
-      <a href="{% url 'login' %}?next={{ request.path }}">Log in to vote</a>
-      {% endif %}
-    </div>
+    {% include "core/partials/vote_widget.html" with post=post user=user request=request only %}
     <a href="{{ detail_url }}#comments">{{ post.comment_count }} comments</a>
     {% if post.astro_score %}
     <details class="astro-why">


### PR DESCRIPTION
## Summary
- add reusable `vote_widget.html` partial for voting controls
- use vote widget include in feed, list, and detail templates

## Testing
- `pytest` *(fails: Missing staticfiles manifest entry for 'css/app.css'; EndpointConnectionError to localhost)*

------
https://chatgpt.com/codex/tasks/task_e_68b962bc0234832c9fa449d60d235edf