### PR TITLE
Preserve query parameters on login redirect

### DIFF
--- a/templates/core/partials/comment_item.html
+++ b/templates/core/partials/comment_item.html
@@ -32,7 +32,7 @@
       <button disabled aria-label="Upvote">▲</button>
       {% include "core/partials/comment_score.html" %}
       <button disabled aria-label="Downvote">▼</button>
-      <a href="{% url 'login' %}?next={{ request.path }}">Log in to vote</a>
+      <a href="{% url 'login' %}?next={{ request.get_full_path|urlencode }}">Log in to vote</a>
       {% endif %}
     </span>
     <button hx-get="/comments/new?parent={{ comment.pk }}&post={{ comment.post.pk }}"

--- a/templates/core/partials/vote_widget.html
+++ b/templates/core/partials/vote_widget.html
@@ -20,6 +20,6 @@
   <button disabled aria-label="Upvote">▲</button>
   {% include "core/partials/post_score.html" with post=post only %}
   <button disabled aria-label="Downvote">▼</button>
-  <a href="{% url 'login' %}?next={{ request.path }}">Log in to vote</a>
+  <a href="{% url 'login' %}?next={{ request.get_full_path|urlencode }}">Log in to vote</a>
   {% endif %}
 </div>

--- a/tests/test_login_redirect.py
+++ b/tests/test_login_redirect.py
@@ -1,0 +1,30 @@
+import pytest
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from urllib.parse import quote
+
+from core.models import Community, Post
+
+
+@pytest.mark.django_db
+def test_login_redirect_preserves_query(client):
+    User = get_user_model()
+    creator = User.objects.create_user(username="alice", password="pw")
+    community = Community.objects.create(slug="t", name="Test", title="Test", created_by=creator)
+    post = Post.objects.create(
+        community=community,
+        author=creator,
+        post_type="text",
+        title="T1",
+        body="body",
+    )
+    url = reverse("post_detail", args=[community.slug, post.pk, post.slug])
+    full_url = f"{url}?foo=bar"
+
+    resp = client.get(full_url)
+    assert resp.status_code == 200
+    assert f"?next={quote(full_url)}" in resp.content.decode()
+
+    login_url = reverse("login") + f"?next={quote(full_url)}"
+    resp = client.post(login_url, {"username": "alice", "password": "pw"}, follow=True)
+    assert resp.wsgi_request.get_full_path() == full_url


### PR DESCRIPTION
## Summary
- ensure login links for voting keep full request path with query parameters
- add regression test for login redirect preserving query parameters

## Testing
- `DJANGO_COLLECTSTATIC=1 python manage.py collectstatic --noinput`
- `DJANGO_COLLECTSTATIC=1 pytest tests/test_login_redirect.py::test_login_redirect_preserves_query -q`


------
https://chatgpt.com/codex/tasks/task_e_68b966e74ef0832cadc8f81c9b70e5c1