### PR TITLE
Encode query string in HTMX login redirects

### DIFF
--- a/core/http.py
+++ b/core/http.py
@@ -1,6 +1,7 @@
 """HTTP helper utilities."""
 
 from functools import wraps
+from urllib.parse import quote
 
 from django.http import HttpResponse
 from django.urls import reverse
@@ -23,7 +24,7 @@ def login_required_htmx(view):
 
         if request.headers.get("HX-Request") == "true":
             resp = HttpResponse(status=401)
-            login_url = reverse("login") + "?next=" + request.get_full_path()
+            login_url = reverse("login") + "?next=" + quote(request.get_full_path())
             resp["HX-Redirect"] = login_url
             return resp
 

--- a/core/tests/test_vote_auth_gate.py
+++ b/core/tests/test_vote_auth_gate.py
@@ -1,6 +1,7 @@
 import pytest
 from django.urls import reverse
 from django.contrib.auth import get_user_model
+from urllib.parse import quote
 
 from core.models import Community, Post, Comment
 
@@ -29,6 +30,17 @@ def test_htmx_requires_login(client, content, kind):
     resp = client.post(url, {"v": "1"}, HTTP_HX_REQUEST="true")
     assert resp.status_code == 401
     assert resp.headers["HX-Redirect"] == reverse("login") + f"?next={url}"
+
+
+@pytest.mark.django_db
+def test_htmx_redirect_with_query_string(client, content):
+    target = content["post"]
+    base_url = reverse("vote_post", args=[target.pk])
+    url = base_url + "?foo=bar"
+    resp = client.post(url, {"v": "1"}, HTTP_HX_REQUEST="true")
+    assert resp.status_code == 401
+    expected = reverse("login") + "?next=" + quote(url)
+    assert resp.headers["HX-Redirect"] == expected
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Summary
- encode `next` parameter with `urllib.parse.quote` for HTMX login redirects
- test that HX-Redirect header encodes query strings

## Testing
- `DJANGO_COLLECTSTATIC=1 pytest core/tests/test_vote_auth_gate.py::test_htmx_redirect_with_query_string -q`
- `DJANGO_COLLECTSTATIC=1 pytest` *(fails: Missing staticfiles manifest entry for 'css/app.css')*


------
https://chatgpt.com/codex/tasks/task_e_68b967d02d88832ca4b361240911ef4b