### PR TITLE
Extract generic vote widget for posts and comments

### DIFF
--- a/templates/core/partials/comment_item.html
+++ b/templates/core/partials/comment_item.html
@@ -10,31 +10,7 @@
     {% if comment.edited_at %}
       <span class="edited" title="Edited {{ comment.edited_at|date:'Y-m-d H:i' }}">edited</span>
     {% endif %}
-    <span class="vote comment-vote" id="comment-{{ comment.pk }}-vote"{% if user.is_authenticated %}
-          hx-on::after-request="this.querySelectorAll('button').forEach(btn => btn.disabled = true)"{% endif %}>
-      {% if user.is_authenticated %}
-      <button
-        hx-post="{% url 'vote_comment' comment.pk %}"
-        hx-vals='{"v":1}'
-        hx-target="#comment-score-{{ comment.pk }}"
-        hx-swap="outerHTML"
-        aria-label="Upvote">▲</button>
-
-      {% include "core/partials/comment_score.html" %}
-
-      <button
-        hx-post="{% url 'vote_comment' comment.pk %}"
-        hx-vals='{"v":-1}'
-        hx-target="#comment-score-{{ comment.pk }}"
-        hx-swap="outerHTML"
-        aria-label="Downvote">▼</button>
-      {% else %}
-      <button disabled aria-label="Upvote">▲</button>
-      {% include "core/partials/comment_score.html" %}
-      <button disabled aria-label="Downvote">▼</button>
-      <a href="{% url 'login' %}?next={{ request.get_full_path|urlencode }}">Log in to vote</a>
-      {% endif %}
-    </span>
+      {% include "core/partials/vote_widget.html" with comment=comment user=user request=request only %}
     <button hx-get="/comments/new?parent={{ comment.pk }}&post={{ comment.post.pk }}"
             hx-target="#comment-{{ comment.pk }} > .children" hx-swap="beforeend">Reply</button>
     {% if comment|can_edit_comment:request.user %}

--- a/templates/core/partials/comment_row.html
+++ b/templates/core/partials/comment_row.html
@@ -16,31 +16,7 @@
   </div>
 
     <div class="comment-actions">
-      <div class="comment-vote" id="comment-{{ comment.pk }}-vote"{% if user.is_authenticated %}
-           hx-on::after-request="this.querySelectorAll('button').forEach(btn => btn.disabled = true)"{% endif %}>
-        {% if user.is_authenticated %}
-        <button
-          hx-post="{% url 'vote_comment' comment.pk %}"
-          hx-vals='{"v":1}'
-          hx-target="#comment-score-{{ comment.pk }}"
-          hx-swap="outerHTML"
-          aria-label="Upvote">▲</button>
-
-        <span id="comment-score-{{ comment.pk }}">{{ comment.score }}</span>
-
-        <button
-          hx-post="{% url 'vote_comment' comment.pk %}"
-          hx-vals='{"v":-1}'
-          hx-target="#comment-score-{{ comment.pk }}"
-          hx-swap="outerHTML"
-          aria-label="Downvote">▼</button>
-        {% else %}
-        <button disabled aria-label="Upvote">▲</button>
-        <span id="comment-score-{{ comment.pk }}">{{ comment.score }}</span>
-        <button disabled aria-label="Downvote">▼</button>
-        <a href="{% url 'login' %}?next={{ request.path }}">Log in to vote</a>
-        {% endif %}
-      </div>
+        {% include "core/partials/vote_widget.html" with comment=comment user=user request=request tag='div' only %}
 
       <a class="reply"
          hx-get="{% url 'comment_reply_form' comment.pk %}"

--- a/templates/core/partials/vote_widget.html
+++ b/templates/core/partials/vote_widget.html
@@ -1,25 +1,43 @@
-<div class="vote post-vote" id="post-{{ post.pk }}-vote"{% if user.is_authenticated %}
+{% comment %}
+  Generic vote widget for posts and comments.
+  Pass either ``post`` or ``comment``. Optionally override ``tag``
+  to change the wrapper element (defaults: div for posts, span for comments).
+{% endcomment %}
+{% with obj=post|default:comment kind=post|yesno:"post,comment" default_wrapper=post|yesno:"div,span" %}
+  {% with wrapper=tag|default:default_wrapper %}
+<{{ wrapper }} class="vote {{ kind }}-vote" id="{{ kind }}-{{ obj.pk }}-vote"{% if user.is_authenticated %}
      hx-on::after-request="this.querySelectorAll('button').forEach(btn => btn.disabled = true)"{% endif %}>
   {% if user.is_authenticated %}
   <button
-    hx-post="{% url 'vote_post' post.pk %}"
+    hx-post="{% if kind == 'post' %}{% url 'vote_post' obj.pk %}{% else %}{% url 'vote_comment' obj.pk %}{% endif %}"
     hx-vals='{"v":1}'
-    hx-target="#post-score-{{ post.pk }}"
+    hx-target="#{{ kind }}-score-{{ obj.pk }}"
     hx-swap="outerHTML"
     aria-label="Upvote">▲</button>
 
-  {% include "core/partials/post_score.html" with post=post only %}
+  {% if kind == 'post' %}
+    {% include "core/partials/post_score.html" with post=obj only %}
+  {% else %}
+    {% include "core/partials/comment_score.html" with comment=obj only %}
+  {% endif %}
 
   <button
-    hx-post="{% url 'vote_post' post.pk %}"
+    hx-post="{% if kind == 'post' %}{% url 'vote_post' obj.pk %}{% else %}{% url 'vote_comment' obj.pk %}{% endif %}"
     hx-vals='{"v":-1}'
-    hx-target="#post-score-{{ post.pk }}"
+    hx-target="#{{ kind }}-score-{{ obj.pk }}"
     hx-swap="outerHTML"
     aria-label="Downvote">▼</button>
   {% else %}
   <button disabled aria-label="Upvote">▲</button>
-  {% include "core/partials/post_score.html" with post=post only %}
+  {% if kind == 'post' %}
+    {% include "core/partials/post_score.html" with post=obj only %}
+  {% else %}
+    {% include "core/partials/comment_score.html" with comment=obj only %}
+  {% endif %}
   <button disabled aria-label="Downvote">▼</button>
   <a href="{% url 'login' %}?next={{ request.get_full_path|urlencode }}">Log in to vote</a>
   {% endif %}
-</div>
+</{{ wrapper }}>
+  {% endwith %}
+{% endwith %}
+


### PR DESCRIPTION
## Summary
- DRY voting UI by creating a generic `vote_widget` for both posts and comments
- Replace comment templates' duplicated vote markup with the reusable partial
- Support flexible wrappers via optional tag override

## Testing
- `pytest` *(fails: Missing staticfiles manifest entry for 'css/app.css')*


------
https://chatgpt.com/codex/tasks/task_e_68b96965dba0832c86158723323d5006