### PR TITLE
Lock target rows when tallying votes

### DIFF
--- a/core/services/votes.py
+++ b/core/services/votes.py
@@ -38,6 +38,12 @@ def _cast_vote_once(user, *, post=None, comment=None, want: int) -> int:
         row.value = want
         row.save(update_fields=["value"])
 
+        # Lock the target row to prevent concurrent score updates
+        if target_type == "post":
+            target = Post.objects.select_for_update().get(pk=target_id)
+        else:
+            target = Comment.objects.select_for_update().get(pk=target_id)
+
         qs = Vote.objects.filter(target_type=target_type, target_id=target_id)
         total = qs.aggregate(t=Sum("value"))["t"] or 0
         target.score = total

--- a/core/tests_vote_service.py
+++ b/core/tests_vote_service.py
@@ -1,5 +1,8 @@
+import threading
+
 from django.contrib.auth import get_user_model
-from django.test import TestCase
+from django.db import close_old_connections
+from django.test import TestCase, TransactionTestCase, skipUnlessDBFeature
 
 from .models import Comment, Community, Post, get_points
 from .services.votes import cast_vote_post_once, cast_vote_comment_once, AlreadyVoted
@@ -45,3 +48,59 @@ class VoteServiceTests(TestCase):
         self.assertEqual(self.comment.score, -1)
         self.author.profile.refresh_from_db()
         self.assertEqual(get_points(self.author), -1)
+
+
+
+@skipUnlessDBFeature("supports_select_for_update")
+class VoteServiceConcurrencyTests(TransactionTestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.voter1 = User.objects.create_user("voter1", password="pwd")
+        self.voter2 = User.objects.create_user("voter2", password="pwd")
+        self.author = User.objects.create_user("author", password="pwd")
+        self.community = Community.objects.create(
+            slug="t", name="Test", title="Test", created_by=self.author
+        )
+        self.post = Post.objects.create(
+            community=self.community, author=self.author, post_type="text", title="Hello"
+        )
+        self.comment = Comment.objects.create(
+            post=self.post, author=self.author, body="Hi"
+        )
+
+    def _run_concurrent(self, func):
+        barrier = threading.Barrier(2)
+        errors = []
+
+        def runner(user):
+            close_old_connections()
+            try:
+                barrier.wait()
+                func(user)
+            except Exception as exc:  # pragma: no cover - surfaced in tests
+                errors.append(exc)
+
+        t1 = threading.Thread(target=runner, args=(self.voter1,))
+        t2 = threading.Thread(target=runner, args=(self.voter2,))
+        t1.start()
+        t2.start()
+        t1.join()
+        t2.join()
+        if errors:
+            raise errors[0]
+
+    def test_concurrent_post_votes(self):
+        def vote(user):
+            cast_vote_post_once(user, self.post, 1)
+
+        self._run_concurrent(vote)
+        self.post.refresh_from_db()
+        self.assertEqual(self.post.score, 2)
+
+    def test_concurrent_comment_votes(self):
+        def vote(user):
+            cast_vote_comment_once(user, self.comment, 1)
+
+        self._run_concurrent(vote)
+        self.comment.refresh_from_db()
+        self.assertEqual(self.comment.score, 2)


### PR DESCRIPTION
## Summary
- ensure vote score recomputation locks the target post or comment row
- add concurrency tests to verify simultaneous votes keep correct score

## Testing
- `DJANGO_COLLECTSTATIC=1 python manage.py test core.tests_vote_service`

------
https://chatgpt.com/codex/tasks/task_e_68b96ad7ee9c832cbd7686255d0b6933