### PR TITLE
Refactor vote widget branching

### DIFF
--- a/templates/core/partials/vote_widget.html
+++ b/templates/core/partials/vote_widget.html
@@ -3,41 +3,59 @@
   Pass either ``post`` or ``comment``. Optionally override ``tag``
   to change the wrapper element (defaults: div for posts, span for comments).
 {% endcomment %}
-{% with obj=post|default:comment kind=post|yesno:"post,comment" default_wrapper=post|yesno:"div,span" %}
-  {% with wrapper=tag|default:default_wrapper %}
-<{{ wrapper }} class="vote {{ kind }}-vote" id="{{ kind }}-{{ obj.pk }}-vote"{% if user.is_authenticated %}
-     hx-on::after-request="this.querySelectorAll('button').forEach(btn => btn.disabled = true)"{% endif %}>
+{% if post %}
+  {% with wrapper=tag|default:"div" %}
+<{{ wrapper }} class="vote post-vote" id="post-{{ post.pk }}-vote"{% if user.is_authenticated %} hx-on::after-request="this.querySelectorAll('button').forEach(btn => btn.disabled = true)"{% endif %}>
   {% if user.is_authenticated %}
   <button
-    hx-post="{% if kind == 'post' %}{% url 'vote_post' obj.pk %}{% else %}{% url 'vote_comment' obj.pk %}{% endif %}"
+    hx-post="{% url 'vote_post' post.pk %}"
     hx-vals='{"v":1}'
-    hx-target="#{{ kind }}-score-{{ obj.pk }}"
+    hx-target="#post-score-{{ post.pk }}"
     hx-swap="outerHTML"
     aria-label="Upvote">▲</button>
 
-  {% if kind == 'post' %}
-    {% include "core/partials/post_score.html" with post=obj only %}
-  {% else %}
-    {% include "core/partials/comment_score.html" with comment=obj only %}
-  {% endif %}
+    {% include "core/partials/post_score.html" with post=post only %}
 
   <button
-    hx-post="{% if kind == 'post' %}{% url 'vote_post' obj.pk %}{% else %}{% url 'vote_comment' obj.pk %}{% endif %}"
+    hx-post="{% url 'vote_post' post.pk %}"
     hx-vals='{"v":-1}'
-    hx-target="#{{ kind }}-score-{{ obj.pk }}"
+    hx-target="#post-score-{{ post.pk }}"
     hx-swap="outerHTML"
     aria-label="Downvote">▼</button>
   {% else %}
   <button disabled aria-label="Upvote">▲</button>
-  {% if kind == 'post' %}
-    {% include "core/partials/post_score.html" with post=obj only %}
-  {% else %}
-    {% include "core/partials/comment_score.html" with comment=obj only %}
-  {% endif %}
+    {% include "core/partials/post_score.html" with post=post only %}
   <button disabled aria-label="Downvote">▼</button>
   <a href="{% url 'login' %}?next={{ request.get_full_path|urlencode }}">Log in to vote</a>
   {% endif %}
 </{{ wrapper }}>
   {% endwith %}
-{% endwith %}
+{% elif comment %}
+  {% with wrapper=tag|default:"span" %}
+<{{ wrapper }} class="vote comment-vote" id="comment-{{ comment.pk }}-vote"{% if user.is_authenticated %} hx-on::after-request="this.querySelectorAll('button').forEach(btn => btn.disabled = true)"{% endif %}>
+  {% if user.is_authenticated %}
+  <button
+    hx-post="{% url 'vote_comment' comment.pk %}"
+    hx-vals='{"v":1}'
+    hx-target="#comment-score-{{ comment.pk }}"
+    hx-swap="outerHTML"
+    aria-label="Upvote">▲</button>
+
+    {% include "core/partials/comment_score.html" with comment=comment only %}
+
+  <button
+    hx-post="{% url 'vote_comment' comment.pk %}"
+    hx-vals='{"v":-1}'
+    hx-target="#comment-score-{{ comment.pk }}"
+    hx-swap="outerHTML"
+    aria-label="Downvote">▼</button>
+  {% else %}
+  <button disabled aria-label="Upvote">▲</button>
+    {% include "core/partials/comment_score.html" with comment=comment only %}
+  <button disabled aria-label="Downvote">▼</button>
+  <a href="{% url 'login' %}?next={{ request.get_full_path|urlencode }}">Log in to vote</a>
+  {% endif %}
+</{{ wrapper }}>
+  {% endwith %}
+{% endif %}
 


### PR DESCRIPTION
## Summary
- Split vote widget into explicit post/comment branches with wrapper defaults
- Preserve HTMX behavior and score includes with single-object context

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'core')*

------
https://chatgpt.com/codex/tasks/task_e_68b96f309a78832cb48a678041cdd97d