### PR TITLE
Add link preview script for post submission

### DIFF
--- a/static/js/embeds.js
+++ b/static/js/embeds.js
@@ -1,9 +1,7 @@
-document.addEventListener('DOMContentLoaded', function () {
-  document.querySelectorAll('.post-embed[data-src]').forEach(function (wrapper) {
-    var link = wrapper.querySelector('a');
-    var src = wrapper.dataset.src;
-    if (!link) return;
-    link.addEventListener('click', function (e) {
+(function(){
+  function attach(wrapper, src, link){
+    if (!src || !link) return;
+    link.addEventListener('click', function(e){
       e.preventDefault();
       var iframe = document.createElement('iframe');
       iframe.src = src;
@@ -17,6 +15,20 @@ document.addEventListener('DOMContentLoaded', function () {
       iframe.style.height = '100%';
       wrapper.innerHTML = '';
       wrapper.appendChild(iframe);
+    }, { once: true });
+  }
+
+  function initEmbeds(root){
+    root = root || document;
+    root.querySelectorAll('.post-embed[data-src]').forEach(function(wrapper){
+      attach(wrapper, wrapper.dataset.src, wrapper.querySelector('a'));
     });
-  });
-});
+    root.querySelectorAll('[data-embed-src]').forEach(function(wrapper){
+      var link = wrapper.querySelector('a') || wrapper;
+      attach(wrapper, wrapper.dataset.embedSrc, link);
+    });
+  }
+
+  window.initEmbeds = initEmbeds;
+  document.addEventListener('DOMContentLoaded', function(){ initEmbeds(document); });
+})();

--- a/static/js/link_preview.js
+++ b/static/js/link_preview.js
@@ -1,0 +1,66 @@
+(function(){
+  function validUrl(value){
+    try {
+      new URL(value);
+      return true;
+    } catch (e) {
+      return false;
+    }
+  }
+
+  function enableEmbeds(root){
+    if (window.initEmbeds) {
+      window.initEmbeds(root);
+      return;
+    }
+    root.querySelectorAll('[data-embed-src]').forEach(function(wrapper){
+      var link = wrapper.querySelector('a') || wrapper;
+      var src = wrapper.dataset.embedSrc;
+      if (!src || !link) return;
+      link.addEventListener('click', function(e){
+        e.preventDefault();
+        var iframe = document.createElement('iframe');
+        iframe.src = src;
+        iframe.setAttribute('sandbox', 'allow-scripts allow-same-origin');
+        iframe.setAttribute('allowfullscreen', '');
+        iframe.setAttribute('loading', 'lazy');
+        iframe.style.position = 'absolute';
+        iframe.style.top = '0';
+        iframe.style.left = '0';
+        iframe.style.width = '100%';
+        iframe.style.height = '100%';
+        wrapper.innerHTML = '';
+        wrapper.appendChild(iframe);
+      }, { once: true });
+    });
+  }
+
+  async function fetchPreview(url){
+    const preview = document.getElementById('link-preview');
+    if (!preview) return;
+    if (!validUrl(url)){
+      preview.innerHTML = '';
+      return;
+    }
+    try {
+      const resp = await fetch(`/oembed/preview?url=${encodeURIComponent(url)}`);
+      if (!resp.ok) {
+        preview.innerHTML = '';
+        return;
+      }
+      const html = await resp.text();
+      preview.innerHTML = html;
+      enableEmbeds(preview);
+    } catch (e) {
+      preview.innerHTML = '';
+    }
+  }
+
+  document.addEventListener('DOMContentLoaded', function(){
+    var input = document.getElementById('id_link');
+    if (!input) return;
+    input.addEventListener('input', function(e){
+      fetchPreview(e.target.value.trim());
+    });
+  });
+})();

--- a/templates/core/post_submit.html
+++ b/templates/core/post_submit.html
@@ -75,5 +75,7 @@
 {% block scripts %}
 {{ block.super }}
 <script src="{% static 'js/editor.js' %}" defer></script>
+<script src="{% static 'js/embeds.js' %}" defer></script>
 <script src="{% static 'js/post_submit.js' %}" defer></script>
+<script src="{% static 'js/link_preview.js' %}" defer></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add `link_preview.js` to load link previews and click-to-load embeds
- expose reusable `initEmbeds` helper and include script on post submission page
- wire up scripts in post submission template

## Testing
- `pytest` *(fails: Requested setting INSTALLED_APPS...)*

------
https://chatgpt.com/codex/tasks/task_e_68ba07046ab8832cbbfee099f89b0948