### PR TITLE
Allow GET for oEmbed preview

### DIFF
--- a/core/tests_oembed_preview.py
+++ b/core/tests_oembed_preview.py
@@ -7,6 +7,7 @@ from django.test import Client
 import django
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+os.environ.setdefault("DJANGO_COLLECTSTATIC", "1")
 django.setup()
 
 from core.views import fetch_oembed
@@ -46,7 +47,13 @@ def test_fetch_oembed_falls_back_to_link_card():
 def test_oembed_preview_view_uses_helper():
     client = Client()
     with patch("core.views.fetch_oembed", return_value={"type": "link", "domain": "example.com", "favicon": "f", "url": "https://example.com", "title": "Example"}) as mock_fetch:
-        resp = client.post(reverse("oembed_preview"), {"url": "https://example.com"}, HTTP_HOST="localhost")
+        resp = client.get(reverse("oembed_preview"), {"url": "https://example.com"}, HTTP_HOST="localhost")
     assert resp.status_code == 200
     assert "example.com" in resp.content.decode()
     mock_fetch.assert_called_once()
+
+
+def test_oembed_preview_rejects_post():
+    client = Client()
+    resp = client.post(reverse("oembed_preview"), {"url": "https://example.com"}, HTTP_HOST="localhost")
+    assert resp.status_code == 405

--- a/core/urls.py
+++ b/core/urls.py
@@ -14,7 +14,7 @@ urlpatterns = [
     path("posts", core_views.transparency_posts, name="transparency_posts"),
     # Markdown preview endpoint
     path("preview", core_views.preview_markdown, name="preview_markdown"),
-    path("oembed/preview", core_views.oembed_preview, name="oembed_preview"),
+    path("oembed/preview/", core_views.oembed_preview, name="oembed_preview"),
     path("submit", core_views.post_submit, name="post_submit"),
 
     # Post signals

--- a/core/views.py
+++ b/core/views.py
@@ -100,10 +100,10 @@ ALLOWED_TAGS = [
 ALLOWED_ATTRIBUTES = {"a": ["href"]}
 
 
-@require_POST
-@ratelimit(key="user", rate="5/m", method=["POST"], block=False)
+@require_GET
+@ratelimit(key="user", rate="5/m", method=["GET"], block=False)
 def oembed_preview(request):
-    url = request.POST.get("url", "").strip()
+    url = request.GET.get("url", "").strip()
     if not url:
         return HttpResponse("")
     try:

--- a/static/js/link_preview.js
+++ b/static/js/link_preview.js
@@ -43,7 +43,7 @@
       return;
     }
     try {
-      const resp = await fetch(`/oembed/preview?url=${encodeURIComponent(url)}`);
+      const resp = await fetch(`/oembed/preview/?url=${encodeURIComponent(url)}`);
       if (!resp.ok) {
         preview.innerHTML = '';
         return;


### PR DESCRIPTION
## Summary
- Accept GET requests for `/oembed/preview/`
- Update URLconf and frontend fetch path to match new GET endpoint
- Add tests covering GET handling and POST rejection for oEmbed preview

## Testing
- `pytest core/tests_oembed_preview.py -q`
- `DJANGO_COLLECTSTATIC=1 pytest core/tests/test_astro.py::AstroFeatureFlagViewTests::test_chip_containers_hidden_when_flag_disabled -q --tb=line` *(fails: AssertionError: False is not true : Couldn't find '/posts/1/signals/chips' in the following response)*

------
https://chatgpt.com/codex/tasks/task_e_68ba082449e0832c9def5200fde858a9