### PR TITLE
Add client-side validation for post submissions

### DIFF
--- a/static/js/post_submit_validate.js
+++ b/static/js/post_submit_validate.js
@@ -1,0 +1,24 @@
+// Handles enabling/disabling the submit buttons on the post submit form.
+document.addEventListener('DOMContentLoaded', () => {
+  const titleEl = document.querySelector('#id_title');
+  const bodyEl = document.querySelector('#id_body');
+  const contentUrlEl = document.querySelector('#id_content_url');
+  const imagesEl = document.querySelector('#id_images');
+
+  function update() {
+    const title = titleEl?.value.trim();
+    const body = bodyEl?.value.trim();
+    const contentUrl = contentUrlEl?.value.trim();
+    const imagesHasValue = !!(imagesEl && ((imagesEl.files && imagesEl.files.length > 0) || imagesEl.value));
+    const ok = title && (body || contentUrl || imagesHasValue);
+    document.querySelectorAll('#post-btn,#post-btn-mobile').forEach(btn => {
+      if (btn) btn.disabled = !ok;
+    });
+  }
+
+  [titleEl, bodyEl, contentUrlEl, imagesEl].forEach(el => {
+    if (el) el.addEventListener('input', update);
+  });
+
+  update();
+});

--- a/templates/core/post_submit.html
+++ b/templates/core/post_submit.html
@@ -77,5 +77,6 @@
 <script src="{% static 'js/editor.js' %}" defer></script>
 <script src="{% static 'js/embeds.js' %}" defer></script>
 <script src="{% static 'js/post_submit.js' %}" defer></script>
+<script src="{% static 'js/post_submit_validate.js' %}" defer></script>
 <script src="{% static 'js/link_preview.js' %}" defer></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add new `post_submit_validate.js` to enable/disable submit buttons based on form inputs
- include validation script on post submit template

## Testing
- `pytest` *(fails: attempted run hits S3 upload and requires configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68ba0cbf379c832cbda8c7b505aea3bb