### PR TITLE
Add post type field to submit form

### DIFF
--- a/templates/core/submit.html
+++ b/templates/core/submit.html
@@ -14,6 +14,10 @@
       {{ form.community.errors }}
     </div>
     <div class="form-row">
+      {{ form.post_type.label_tag }} {{ form.post_type }}
+      {{ form.post_type.errors }}
+    </div>
+    <div class="form-row">
       {{ form.title.label_tag }} {{ form.title }}
       {{ form.title.errors }}
     </div>


### PR DESCRIPTION
## Summary
- Render post_type field on post submit form so server-side errors display

## Testing
- `DJANGO_COLLECTSTATIC=1 python manage.py test core.tests_post_form_validation.PostFormValidationTests.test_title_only_rejected --verbosity=2`


------
https://chatgpt.com/codex/tasks/task_e_68ba14ce2ecc832cb9680b856f4ee7ff