### PR TITLE
Use local static file storage in tests

### DIFF
--- a/config/test_settings.py
+++ b/config/test_settings.py
@@ -1,0 +1,22 @@
+"""Test-specific Django settings."""
+
+import os
+
+# Mark as build phase so base settings don't require S3 configuration.
+os.environ.setdefault("DJANGO_COLLECTSTATIC", "1")
+
+from .settings import *  # noqa: F401,F403
+
+
+# Use local storage backends during tests to avoid collectstatic and external services.
+STATICFILES_STORAGE = "django.contrib.staticfiles.storage.StaticFilesStorage"
+DEFAULT_FILE_STORAGE = "django.core.files.storage.FileSystemStorage"
+
+STORAGES = {
+    **STORAGES,
+    "staticfiles": {"BACKEND": STATICFILES_STORAGE},
+    "default": {"BACKEND": DEFAULT_FILE_STORAGE},
+}
+
+MEDIA_ROOT = BASE_DIR / "test-media"
+

--- a/core/tests/test_htmx_guard_included.py
+++ b/core/tests/test_htmx_guard_included.py
@@ -1,13 +1,8 @@
 import pytest
 from django.urls import reverse
-from django.test import override_settings
 
 
 @pytest.mark.django_db
-@override_settings(
-    STATICFILES_STORAGE="django.contrib.staticfiles.storage.StaticFilesStorage",
-    STORAGES={"staticfiles": {"BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage"}},
-)
 def test_htmx_guard_included(client):
     resp = client.get(reverse('home'))
     assert resp.status_code == 200

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-DJANGO_SETTINGS_MODULE = config.settings
+DJANGO_SETTINGS_MODULE = config.test_settings
 testpaths =
     tests
     core/tests


### PR DESCRIPTION
## Summary
- add `config.test_settings` to use Django's local file storage during tests
- point pytest at the test settings module
- drop per-test staticfile override for htmx guard test

## Testing
- `pytest tests/test_smoke_v2.py::test_signup_submit_sort_and_commands -q` *(fails: Reverse for 'markdown_preview' not found)*
- `pytest core/tests/test_htmx_guard_included.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba1695abe0832cb2cf34d2ff4d225a