### PR TITLE
Add local media fallback when S3 missing

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -252,30 +252,29 @@ AWS_ACCESS_KEY_ID = os.getenv("AWS_ACCESS_KEY_ID", "")
 AWS_SECRET_ACCESS_KEY = os.getenv("AWS_SECRET_ACCESS_KEY", "")
 AWS_S3_ENDPOINT_URL = os.getenv("AWS_S3_ENDPOINT_URL", "")  # e.g. https://fly.storage.tigris.dev
 AWS_S3_REGION_NAME = os.getenv("AWS_S3_REGION_NAME", "auto")
-# MEDIA_URL must come from env in runtime
-# (okay to be dummy during build)
-if IS_BUILD:
-    MEDIA_URL = os.getenv("MEDIA_URL", "https://example.invalid/")
-else:
-    required = [
-        AWS_STORAGE_BUCKET_NAME,
-        AWS_ACCESS_KEY_ID,
-        AWS_SECRET_ACCESS_KEY,
-        AWS_S3_ENDPOINT_URL,
-        os.getenv("MEDIA_URL"),
-    ]
-    if not all(required):
-        raise RuntimeError("S3 media env not configured")
+# Determine if S3 is fully configured and enabled
+required = [
+    AWS_STORAGE_BUCKET_NAME,
+    AWS_ACCESS_KEY_ID,
+    AWS_SECRET_ACCESS_KEY,
+    AWS_S3_ENDPOINT_URL,
+    os.getenv("MEDIA_URL"),
+]
+USE_S3 = os.getenv("USE_S3", "1") in ("1", "true", "True")
+if USE_S3 and all(required) and not IS_BUILD:
     MEDIA_URL = os.environ["MEDIA_URL"]
+    DEFAULT_FILE_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"
+    AWS_QUERYSTRING_AUTH = False
+    AWS_S3_ADDRESSING_STYLE = "virtual"
+    AWS_S3_SIGNATURE_VERSION = "s3v4"
+    AWS_DEFAULT_ACL = "public-read"
+    AWS_S3_OBJECT_PARAMETERS = {"CacheControl": "public, max-age=94608000"}
+else:
+    DEFAULT_FILE_STORAGE = "django.core.files.storage.FileSystemStorage"
+    MEDIA_ROOT = BASE_DIR / "media"
+    MEDIA_URL = "/media/"
 
-DEFAULT_FILE_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"
-AWS_QUERYSTRING_AUTH = False
-AWS_S3_ADDRESSING_STYLE = "virtual"
-AWS_S3_SIGNATURE_VERSION = "s3v4"
-AWS_DEFAULT_ACL = "public-read"
-AWS_S3_OBJECT_PARAMETERS = {"CacheControl": "public, max-age=94608000"}
-
-# Ensure STORAGES['default'] points to S3
+# Ensure STORAGES['default'] points to the active storage backend
 STORAGES["default"] = {"BACKEND": DEFAULT_FILE_STORAGE}
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Fall back to local media storage when S3 variables are missing or USE_S3 flag is off
- Preserve existing S3 configuration for production

## Testing
- `pytest -q` *(fails: NoReverseMatch: Reverse for 'markdown_preview' not found and other failures)*

------
https://chatgpt.com/codex/tasks/task_e_68ba17bb1e8c832c90e7697377fa23d8