### PR TITLE
Add markdown preview endpoint and fix submit form

### DIFF
--- a/core/tests_markdown_preview.py
+++ b/core/tests_markdown_preview.py
@@ -4,10 +4,10 @@ from django.urls import reverse
 
 class MarkdownPreviewViewTests(TestCase):
     def test_get_preview(self):
-        resp = self.client.get(reverse('preview_markdown'), {'body': '**Hi**'}, HTTP_HOST='localhost')
+        resp = self.client.get(reverse('markdown_preview'), {'q': '**Hi**'}, HTTP_HOST='localhost')
         self.assertEqual(resp.status_code, 200)
         self.assertIn('<strong>Hi</strong>', resp.content.decode())
 
     def test_rejects_post(self):
-        resp = self.client.post(reverse('preview_markdown'), {'body': 'Hi'}, HTTP_HOST='localhost')
+        resp = self.client.post(reverse('markdown_preview'), {'q': 'Hi'}, HTTP_HOST='localhost')
         self.assertEqual(resp.status_code, 405)

--- a/core/urls.py
+++ b/core/urls.py
@@ -14,6 +14,7 @@ urlpatterns = [
     path("posts", core_views.transparency_posts, name="transparency_posts"),
     # Markdown preview endpoint
     path("preview", core_views.preview_markdown, name="preview_markdown"),
+    path("markdown/preview/", core_views.markdown_preview, name="markdown_preview"),
     path("oembed/preview/", core_views.oembed_preview, name="oembed_preview"),
     path("submit", core_views.post_submit, name="post_submit"),
 

--- a/core/views.py
+++ b/core/views.py
@@ -127,6 +127,16 @@ def preview_markdown(request):
     return render(request, "core/partials/preview.html", {"html": mark_safe(clean)})
 
 
+@require_GET
+@ratelimit(key="user", rate="5/m", method=["GET"], block=False)
+def markdown_preview(request):
+    """Return sanitized HTML fragment for provided markdown text."""
+    text = request.GET.get("q", "").strip() or request.GET.get("text", "").strip()
+    html = markdown_renderer(text)
+    clean = bleach.clean(html, tags=ALLOWED_TAGS, attributes=ALLOWED_ATTRIBUTES, strip=True)
+    return HttpResponse(clean)
+
+
 def mission(request):
     return render(request, "core/mission.html")
 

--- a/static/js/post_submit_preview.js
+++ b/static/js/post_submit_preview.js
@@ -44,7 +44,7 @@ document.addEventListener('DOMContentLoaded', () => {
           return;
         }
         try {
-          const params = new URLSearchParams({ body: value });
+          const params = new URLSearchParams({ q: value });
           const resp = await fetch(`${markdownUrl}?${params.toString()}`);
           if (!resp.ok) {
             mdPreview.innerHTML = '';

--- a/templates/core/submit.html
+++ b/templates/core/submit.html
@@ -6,7 +6,7 @@
   <a href="{% url 'home' %}">← Back to feed</a>
   <h1>Submit Post</h1>
   <p class="form-helper">Title is required. Include body <strong>or</strong> media.</p>
-  <form id="post-form" method="post" enctype="multipart/form-data" class="submit-form" data-testid="submit-form">
+  <form id="post-form" method="post" action="{% url 'post_submit' %}" enctype="multipart/form-data" class="submit-form" data-testid="submit-form">
     {% csrf_token %}
     <div id="form-errors" aria-live="assertive">{{ form.non_field_errors }}</div>
     <div class="form-row">


### PR DESCRIPTION
## Summary
- add GET-only `markdown_preview` endpoint that sanitizes markdown and returns HTML
- wire `/submit` to use new endpoint and static preview/validation scripts
- send markdown preview requests with `q` parameter and include tests

## Testing
- `pytest` *(fails: AstroFeatureFlagViewTests::test_chip_containers_hidden_when_flag_disabled, test_homepage_layout, CommentLinkTests::test_post_detail_comment_links, PostDetailMediaTests::test_image_slideshow_renders, PostDetailMediaTests::test_youtube_embed_has_placeholder, RateLimitTests::test_limit_enforced, RouteTests::test_mod_astro, RouteTests::test_vote_comment_htmx_with_csrf, RouteTests::test_vote_post_htmx_returns_span, RouteTests::test_vote_post_non_htmx_returns_span)*

------
https://chatgpt.com/codex/tasks/task_e_68ba1d524658832c9e2606fec1c84839