### PR TITLE
Remove duplicate Post button from submit page

### DIFF
--- a/static/js/post_submit_validate.js
+++ b/static/js/post_submit_validate.js
@@ -1,4 +1,4 @@
-// Handles enabling/disabling the submit buttons on the post submit form.
+// Handles enabling/disabling the submit button on the post submit form.
 document.addEventListener('DOMContentLoaded', () => {
   const titleEl = document.querySelector('#id_title');
   const bodyEl = document.querySelector('#id_body');
@@ -11,9 +11,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const contentUrl = contentUrlEl?.value.trim();
     const imagesHasValue = !!(imagesEl && ((imagesEl.files && imagesEl.files.length > 0) || imagesEl.value));
     const ok = title && (body || contentUrl || imagesHasValue);
-    document.querySelectorAll('#post-btn,#post-btn-mobile').forEach(btn => {
-      if (btn) btn.disabled = !ok;
-    });
+    const postBtn = document.querySelector('#post-btn');
+    if (postBtn) postBtn.disabled = !ok;
   }
 
   [titleEl, bodyEl, contentUrlEl, imagesEl].forEach(el => {

--- a/templates/core/submit.html
+++ b/templates/core/submit.html
@@ -45,9 +45,6 @@
   <div id="link-preview" data-preview-url="{% url 'oembed_preview' %}"></div>
   <div id="md-preview" data-markdown-url="{% url 'markdown_preview' %}"></div>
 </div>
-<div class="sticky-bar mobile-actions">
-  <button type="submit" form="post-form" class="button primary" id="post-btn-mobile" disabled>Post</button>
-</div>
 {% endblock %}
 
 {% block scripts %}


### PR DESCRIPTION
## Summary
- Remove sticky mobile submit bar so submit page has a single Post button
- Update submit validation script to enable only the main Post button

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'core'; django settings not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68ba22012340832c8dc746eea0aecee5