### PR TITLE
Use plain text excerpts in feed snippets

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -13,9 +13,11 @@ from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse
 from datetime import timedelta
 from django.utils import timezone
-from django.utils.text import slugify
+from django.utils.text import slugify, Truncator
+from django.utils.html import strip_tags
 from urllib.parse import urlparse
 import logging
+import re
 
 from PIL import Image
 from io import BytesIO
@@ -152,6 +154,17 @@ class Post(models.Model):
     @property
     def slug(self):
         return slugify(self.title)
+
+    @property
+    def excerpt(self):
+        if self.body:
+            text = strip_tags(self.body)
+        elif self.link_domain:
+            text = self.link_domain
+        else:
+            return ""
+        text = re.sub(r"\s+", " ", text).strip()
+        return Truncator(text).chars(180)
 
     def get_absolute_url(self):
         return reverse("post_detail", args=[self.community.slug, self.pk, self.slug])

--- a/core/tests/test_post_excerpt.py
+++ b/core/tests/test_post_excerpt.py
@@ -1,0 +1,54 @@
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from ..models import Community, Post
+
+
+class PostExcerptTests(TestCase):
+    def setUp(self):
+        U = get_user_model()
+        self.user = U.objects.create_user("alice", password="pwd")
+        self.community = Community.objects.create(
+            slug="t", name="Test", title="Test", created_by=self.user
+        )
+
+    def test_excerpt_strips_html(self):
+        post = Post.objects.create(
+            community=self.community,
+            author=self.user,
+            post_type="text",
+            title="Hello",
+            body="<p>Hello <strong>world</strong></p>",
+        )
+        self.assertEqual(post.excerpt, "Hello world")
+
+    def test_excerpt_truncates_long_body(self):
+        long_body = "<p>" + "a" * 210 + "</p>"
+        post = Post.objects.create(
+            community=self.community,
+            author=self.user,
+            post_type="text",
+            title="Hello",
+            body=long_body,
+        )
+        self.assertTrue(post.excerpt.endswith("…"))
+        self.assertLessEqual(len(post.excerpt), 180)
+
+    def test_excerpt_falls_back_to_domain(self):
+        post = Post.objects.create(
+            community=self.community,
+            author=self.user,
+            post_type="link",
+            title="Link",
+            content_url="https://example.com/article",
+        )
+        self.assertEqual(post.excerpt, "example.com")
+
+    def test_excerpt_empty_without_body_or_domain(self):
+        post = Post.objects.create(
+            community=self.community,
+            author=self.user,
+            post_type="image",
+            title="Image",
+        )
+        self.assertEqual(post.excerpt, "")

--- a/templates/core/partials/post_row.html
+++ b/templates/core/partials/post_row.html
@@ -16,8 +16,8 @@
       {% else %}[deleted]{% endif %} · {{ post.created_at|timesince }} ago
     </div>
     <h3 class="post-title"><a href="{{ detail_url }}">{{ post.title }}</a></h3>
-    {% if post.body %}
-    <p class="post-excerpt">{{ post.body|truncatechars:180 }}</p>
+    {% if post.excerpt %}
+    <p class="post-excerpt">{{ post.excerpt }}</p>
     {% endif %}
     <div class="post-actions">
       {% include "core/partials/vote_widget.html" with post=post user=user request=request only %}

--- a/templates/partials/feed_card.html
+++ b/templates/partials/feed_card.html
@@ -26,8 +26,8 @@
   <h3 class="post-title"><a href="{{ detail_url }}">{{ post.title }}</a></h3>
   {% if post.is_deleted %}<span class="state-badge">deleted</span>{% endif %}
   {% if post.is_draft %}<span class="state-badge">draft</span>{% endif %}
-  {% if post.body %}
-  <p class="post-excerpt">{{ post.body|truncatechars:180 }}</p>
+  {% if post.excerpt %}
+  <p class="post-excerpt">{{ post.excerpt }}</p>
   {% endif %}
   <div class="post-actions">
     {% include "core/partials/vote_widget.html" with post=post user=user request=request only %}


### PR DESCRIPTION
## Summary
- add Post.excerpt property that strips HTML and truncates to 180 chars
- render post.excerpt in feed card and post row instead of raw HTML
- test Post.excerpt behavior

## Testing
- `python manage.py test core.tests.test_post_excerpt`
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'freezegun')*

------
https://chatgpt.com/codex/tasks/task_e_68ba2315e6b0832cbbe62962e7721549