### PR TITLE
Refine post submission validation

### DIFF
--- a/static/js/post_submit_validate.js
+++ b/static/js/post_submit_validate.js
@@ -4,13 +4,24 @@ document.addEventListener('DOMContentLoaded', () => {
   const bodyEl = document.querySelector('#id_body');
   const contentUrlEl = document.querySelector('#id_content_url');
   const imagesEl = document.querySelector('#id_images');
+  const postTypeEls = document.querySelectorAll('input[name="post_type"]');
 
   function update() {
+    const postType = document.querySelector('input[name="post_type"]:checked')?.value;
     const title = titleEl?.value.trim();
     const body = bodyEl?.value.trim();
     const contentUrl = contentUrlEl?.value.trim();
-    const imagesHasValue = !!(imagesEl && ((imagesEl.files && imagesEl.files.length > 0) || imagesEl.value));
-    const ok = title && (body || contentUrl || imagesHasValue);
+    const imagesHasValue = !!(
+      imagesEl && ((imagesEl.files && imagesEl.files.length > 0) || imagesEl.value)
+    );
+
+    let ok = false;
+    if (title) {
+      if (postType === 'text') ok = !!body;
+      else if (postType === 'link') ok = !!contentUrl;
+      else if (postType === 'images') ok = imagesHasValue;
+    }
+
     const postBtn = document.querySelector('#post-btn');
     if (postBtn) postBtn.disabled = !ok;
   }
@@ -18,6 +29,7 @@ document.addEventListener('DOMContentLoaded', () => {
   [titleEl, bodyEl, contentUrlEl, imagesEl].forEach(el => {
     if (el) el.addEventListener('input', update);
   });
+  postTypeEls.forEach(el => el.addEventListener('change', update));
 
   update();
 });


### PR DESCRIPTION
## Summary
- validate post submission fields based on selected `post_type`
- trigger validation when post type radios change

## Testing
- `python manage.py test` *(fails: Missing staticfiles manifest entry for 'css/app.css')*


------
https://chatgpt.com/codex/tasks/task_e_68ba28111f64832c8e683b0cce2b4936