### PR TITLE
Add image post button validation

### DIFF
--- a/static/js/post_submit_validate.js
+++ b/static/js/post_submit_validate.js
@@ -1,0 +1,40 @@
+// Handles basic client-side validation for the post submit form.
+document.addEventListener('DOMContentLoaded', () => {
+  const form = document.querySelector('#post-form');
+  if (!form) return;
+
+  const postType = form.querySelector('#id_post_type');
+  const title = form.querySelector('#id_title');
+  const body = form.querySelector('#id_body');
+  const contentUrl = form.querySelector('#id_content_url');
+  const images = form.querySelector('#id_images');
+  const postBtn = document.querySelector('#post-btn');
+
+  const validate = () => {
+    const type = postType?.value;
+    const titleVal = title?.value.trim();
+    const bodyVal = body?.value.trim();
+    const urlVal = contentUrl?.value.trim();
+    const filesLen = images?.files?.length || 0;
+
+    let ok = false;
+    if (type === 'text') {
+      ok = !!(titleVal && bodyVal);
+    } else if (type === 'link') {
+      ok = !!(titleVal && urlVal);
+    } else if (type === 'images') {
+      // Only require title and at least one image.
+      ok = !!(titleVal && filesLen > 0);
+    }
+
+    if (postBtn) postBtn.disabled = !ok;
+  };
+
+  [postType, title, body, contentUrl, images].forEach((el) => {
+    el?.addEventListener('input', validate);
+    el?.addEventListener('change', validate);
+  });
+
+  validate();
+});
+

--- a/templates/core/submit.html
+++ b/templates/core/submit.html
@@ -50,6 +50,7 @@
 
 {% block scripts %}
 {{ block.super }}
-<script src="{% static 'js/editor.js' %}" defer></script>
-<script src="{% static 'js/post_submit_preview.js' %}" defer></script>
-{% endblock %}
+  <script src="{% static 'js/editor.js' %}" defer></script>
+  <script src="{% static 'js/post_submit_preview.js' %}" defer></script>
+  <script src="{% static 'js/post_submit_validate.js' %}" defer></script>
+  {% endblock %}


### PR DESCRIPTION
## Summary
- validate submit button for post forms
- require title and at least one image for image posts
- add script to submit page

## Testing
- `pytest -q` *(fails: AstroFeatureFlagViewTests::test_chip_containers_hidden_when_flag_disabled, test_homepage_layout, CommentLinkTests::test_post_detail_comment_links, PostDetailMediaTests::test_image_slideshow_renders, PostDetailMediaTests::test_youtube_embed_has_placeholder, RateLimitTests::test_limit_enforced, RouteTests::test_mod_astro, RouteTests::test_vote_comment_htmx_with_csrf, RouteTests::test_vote_post_htmx_returns_span, RouteTests::test_vote_post_non_htmx_returns_span)*

------
https://chatgpt.com/codex/tasks/task_e_68ba3271eb70832c81c8b068f16a45ba