### PR TITLE
Fix client validation for image posts

### DIFF
--- a/static/js/post_submit_validate.js
+++ b/static/js/post_submit_validate.js
@@ -3,15 +3,18 @@ document.addEventListener('DOMContentLoaded', () => {
   const form = document.querySelector('#post-form');
   if (!form) return;
 
-  const postType = form.querySelector('#id_post_type');
   const title = form.querySelector('#id_title');
   const body = form.querySelector('#id_body');
   const contentUrl = form.querySelector('#id_content_url');
   const images = form.querySelector('#id_images');
   const postBtn = document.querySelector('#post-btn');
+  const postTypeRadios = form.querySelectorAll('input[name="post_type"]');
+
+  const getType = () =>
+    form.querySelector('input[name="post_type"]:checked')?.value;
 
   const validate = () => {
-    const type = postType?.value;
+    const type = getType();
     const titleVal = title?.value.trim();
     const bodyVal = body?.value.trim();
     const urlVal = contentUrl?.value.trim();
@@ -23,17 +26,17 @@ document.addEventListener('DOMContentLoaded', () => {
     } else if (type === 'link') {
       ok = !!(titleVal && urlVal);
     } else if (type === 'images') {
-      // Only require title and at least one image.
       ok = !!(titleVal && filesLen > 0);
     }
 
     if (postBtn) postBtn.disabled = !ok;
   };
 
-  [postType, title, body, contentUrl, images].forEach((el) => {
+  [title, body, contentUrl, images].forEach((el) => {
     el?.addEventListener('input', validate);
     el?.addEventListener('change', validate);
   });
+  postTypeRadios.forEach((el) => el.addEventListener('change', validate));
 
   validate();
 });

--- a/templates/core/submit.html
+++ b/templates/core/submit.html
@@ -26,8 +26,7 @@
       {{ form.content_url.errors }}
     </div>
     <div class="form-row">
-      {{ form.images.label_tag }}
-      <input type="file" name="images" id="id_images" multiple>
+      {{ form.images.label_tag }} {{ form.images }}
       {{ form.images.errors }}
     </div>
     <div class="form-row">


### PR DESCRIPTION
## Summary
- render image upload field directly from PostForm
- validate submit button based on selected post type and file input

## Testing
- `pytest` *(fails: AstroFeatureFlagViewTests::test_chip_containers_hidden_when_flag_disabled; test_homepage_layout; CommentLinkTests::test_post_detail_comment_links; PostDetailMediaTests::test_image_slideshow_renders; PostDetailMediaTests::test_youtube_embed_has_placeholder; RateLimitTests::test_limit_enforced; RouteTests::test_mod_astro; RouteTests::test_vote_comment_htmx_with_csrf; RouteTests::test_vote_post_htmx_returns_span; RouteTests::test_vote_post_non_htmx_returns_span)*

------
https://chatgpt.com/codex/tasks/task_e_68ba3ceb470c832c996c27810b9337c8