### PR TITLE
Standardize vote score element IDs

### DIFF
--- a/core/tests/test_routes.py
+++ b/core/tests/test_routes.py
@@ -62,7 +62,7 @@ class RouteTests(TestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertHTMLEqual(
             resp.content.decode(),
-            f'<span id="post-score-{self.post.pk}">1</span>',
+            f'<span id="post-{self.post.pk}-score">1</span>',
         )
 
     def test_vote_post_non_htmx_returns_span(self):
@@ -72,7 +72,7 @@ class RouteTests(TestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertHTMLEqual(
             resp.content.decode(),
-            f'<span id="post-score-{self.post.pk}">1</span>',
+            f'<span id="post-{self.post.pk}-score">1</span>',
         )
 
     def test_vote_post_invalid_value_returns_400(self):
@@ -138,5 +138,5 @@ class RouteTests(TestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertHTMLEqual(
             resp.content.decode(),
-            f'<span id="comment-score-{self.comment.pk}">1</span>',
+            f'<span id="comment-{self.comment.pk}-score">1</span>',
         )

--- a/core/tests/test_vote_templates.py
+++ b/core/tests/test_vote_templates.py
@@ -36,5 +36,5 @@ def test_authenticated_shows_vote_buttons(client, content):
     resp = client.get(post.get_absolute_url())
     html = resp.content.decode()
     assert "hx-post" in html
-    assert f'hx-target="#post-score-{post.pk}"' in html
-    assert f'hx-target="#comment-score-{comment.pk}"' in html
+    assert f'hx-target="#post-{post.pk}-score"' in html
+    assert f'hx-target="#comment-{comment.pk}-score"' in html

--- a/core/views.py
+++ b/core/views.py
@@ -1319,7 +1319,7 @@ def vote_post(request, pk):
     except AlreadyVoted:
         return HttpResponse(status=409)
 
-    return HttpResponse(f"<span id='post-score-{post.pk}'>{post.score}</span>")
+    return HttpResponse(f"<span id='post-{post.pk}-score'>{post.score}</span>")
 
 
 @require_POST
@@ -1339,7 +1339,7 @@ def vote_comment(request, pk):
     except AlreadyVoted:
         return HttpResponse(status=409)
 
-    return HttpResponse(f"<span id='comment-score-{comment.pk}'>{comment.score}</span>")
+    return HttpResponse(f"<span id='comment-{comment.pk}-score'>{comment.score}</span>")
 
 
 @login_required

--- a/docs/Voting-System-Spec.md
+++ b/docs/Voting-System-Spec.md
@@ -13,7 +13,7 @@
    * **No other transitions** allowed; repeat attempts return **409 Conflict** (or 200 with no‑op).
 3. **Single writer (Service Recompute):** Views call a service that writes the vote row **once** and then sets `score = SUM(value)` for that target. No model signals adjust score.
 4. **HTTP posture:** **POST‑only**; `v ∈ {+1, −1}` must be in **POST body**.
-5. **UI contract:** Each item has a single score span: `#post-score-{id}` / `#comment-score-{id}`. First successful vote may disable the buttons.
+5. **UI contract:** Each item has a single score span: `#post-{id}-score` / `#comment-{id}-score`. First successful vote may disable the buttons.
 6. **Concurrency:** Apply in `transaction.atomic()` with `select_for_update()` on the user’s vote row.
 7. **Prod safety:** Serve **local** HTMX; add CSRF header via static helper; **require Postgres** on Fly; ship a votes consistency check.
 
@@ -99,7 +99,7 @@ def vote_post(request, pk):
         cast_vote_post_once(request.user, post, want)
     except AlreadyVoted:
         return HttpResponse(status=409)  # immutable
-    return HttpResponse(f"<span id='post-score-{post.pk}'>{post.score}</span>")
+    return HttpResponse(f"<span id='post-{post.pk}-score'>{post.score}</span>")
 ```
 
 *(Add the analogous `vote_comment` that calls `cast_vote_comment_once`.)*
@@ -113,22 +113,22 @@ def vote_post(request, pk):
   <button aria-label="Upvote"
           hx-post="{% url 'vote_post' post.pk %}"
           hx-vals='{"v":1}'
-          hx-target="#post-score-{{ post.pk }}"
+          hx-target="#post-{{ post.pk }}-score"
           hx-swap="outerHTML"
           hx-on::after-request="this.closest('.post-vote').querySelectorAll('button').forEach(b=>b.disabled=true)">▲</button>
 
-  <span id="post-score-{{ post.pk }}">{{ post.score }}</span>
+  <span id="post-{{ post.pk }}-score">{{ post.score }}</span>
 
   <button aria-label="Downvote"
           hx-post="{% url 'vote_post' post.pk %}"
           hx-vals='{"v":-1}'
-          hx-target="#post-score-{{ post.pk }}"
+          hx-target="#post-{{ post.pk }}-score"
           hx-swap="outerHTML"
           hx-on::after-request="this.closest('.post-vote').querySelectorAll('button').forEach(b=>b.disabled=true)">▼</button>
 </div>
 ```
 
-*(Comments mirror the above with `vote_comment` and `#comment-score-…`.)*
+*(Comments mirror the above with `vote_comment` and `#comment-…-score`.)*
 
 ---
 

--- a/templates/core/partials/vote_widget.html
+++ b/templates/core/partials/vote_widget.html
@@ -9,14 +9,14 @@
   <button
     hx-post="{% url 'vote_post' post.pk %}"
     hx-vals='{"v":1}'
-    hx-target="#post-score-{{ post.pk }}"
+    hx-target="#post-{{ post.pk }}-score"
     hx-swap="outerHTML"
     aria-label="Upvote">▲</button>
-  <span id="post-score-{{ post.pk }}">{{ post.score }}</span>
+  <span id="post-{{ post.pk }}-score">{{ post.score }}</span>
   <button
     hx-post="{% url 'vote_post' post.pk %}"
     hx-vals='{"v":-1}'
-    hx-target="#post-score-{{ post.pk }}"
+    hx-target="#post-{{ post.pk }}-score"
     hx-swap="outerHTML"
     aria-label="Downvote">▼</button>
 </{{ wrapper }}>
@@ -27,14 +27,14 @@
   <button
     hx-post="{% url 'vote_comment' comment.pk %}"
     hx-vals='{"v":1}'
-    hx-target="#comment-score-{{ comment.pk }}"
+    hx-target="#comment-{{ comment.pk }}-score"
     hx-swap="outerHTML"
     aria-label="Upvote">▲</button>
-  <span id="comment-score-{{ comment.pk }}">{{ comment.score }}</span>
+  <span id="comment-{{ comment.pk }}-score">{{ comment.score }}</span>
   <button
     hx-post="{% url 'vote_comment' comment.pk %}"
     hx-vals='{"v":-1}'
-    hx-target="#comment-score-{{ comment.pk }}"
+    hx-target="#comment-{{ comment.pk }}-score"
     hx-swap="outerHTML"
     aria-label="Downvote">▼</button>
 </{{ wrapper }}>


### PR DESCRIPTION
## Summary
- use `post-<pk>-score` and `comment-<pk>-score` IDs and hx-targets in vote widget
- return updated span IDs from `vote_post` and `vote_comment`
- update docs and tests for new score ID pattern

## Testing
- `pytest` (fails: test_login_redirect_preserves_query, AstroFeatureFlagViewTests::test_chip_containers_hidden_when_flag_disabled, test_homepage_layout, CommentLinkTests::test_post_detail_comment_links, PostDetailMediaTests::test_youtube_embed_has_placeholder, RateLimitTests::test_limit_enforced, RouteTests::test_mod_astro, RouteTests::test_vote_comment_htmx_with_csrf, RouteTests::test_vote_post_htmx_returns_span, RouteTests::test_vote_post_non_htmx_returns_span, test_anonymous_shows_login_prompt)


------
https://chatgpt.com/codex/tasks/task_e_68ba4dd2a2d4832c977772c932119c95