### PR TITLE
Improve vote widget accessibility and status handling

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -335,6 +335,19 @@ body.layout-root {
   opacity: 0.5;
 }
 
+/* Hide status text visually but keep it accessible to screen readers */
+.vote-status{
+  position:absolute;
+  width:1px;
+  height:1px;
+  padding:0;
+  margin:-1px;
+  overflow:hidden;
+  clip:rect(0 0 0 0);
+  white-space:nowrap;
+  border:0;
+}
+
 .post-actions .score{
   display: inline-block;
   min-width: 1.5ch;

--- a/templates/core/partials/vote_widget.html
+++ b/templates/core/partials/vote_widget.html
@@ -5,7 +5,7 @@
 {% endcomment %}
 {% if post %}
   {% with wrapper=tag|default:"div" %}
-<{{ wrapper }} class="vote post-vote" id="post-{{ post.pk }}-vote" hx-on::after-request="if(event.detail.xhr.status===200){this.classList.add('voted');this.querySelectorAll('button').forEach(btn=>btn.disabled=true)}">
+<{{ wrapper }} class="vote post-vote" id="post-{{ post.pk }}-vote" hx-on::after-swap="if(event.detail.xhr.status===200){this.classList.add('voted');this.querySelectorAll('button').forEach(btn=>btn.disabled=true);this.querySelector('.vote-status').textContent='Vote saved'}">
   <button
     hx-post="{% url 'vote_post' post.pk %}"
     hx-vals='{"v":1}'
@@ -19,11 +19,12 @@
     hx-target="#post-{{ post.pk }}-score"
     hx-swap="outerHTML"
     aria-label="Downvote">▼</button>
+  <span class="vote-status" aria-live="polite"></span>
 </{{ wrapper }}>
   {% endwith %}
 {% elif comment %}
   {% with wrapper=tag|default:"span" %}
-<{{ wrapper }} class="vote comment-vote" id="comment-{{ comment.pk }}-vote" hx-on::after-request="if(event.detail.xhr.status===200){this.classList.add('voted');this.querySelectorAll('button').forEach(btn=>btn.disabled=true)}">
+<{{ wrapper }} class="vote comment-vote" id="comment-{{ comment.pk }}-vote" hx-on::after-swap="if(event.detail.xhr.status===200){this.classList.add('voted');this.querySelectorAll('button').forEach(btn=>btn.disabled=true);this.querySelector('.vote-status').textContent='Vote saved'}">
   <button
     hx-post="{% url 'vote_comment' comment.pk %}"
     hx-vals='{"v":1}'
@@ -37,6 +38,7 @@
     hx-target="#comment-{{ comment.pk }}-score"
     hx-swap="outerHTML"
     aria-label="Downvote">▼</button>
+  <span class="vote-status" aria-live="polite"></span>
 </{{ wrapper }}>
   {% endwith %}
 {% endif %}


### PR DESCRIPTION
## Summary
- use `hx-on::after-swap` in vote widget
- disable buttons and report status via hidden `.vote-status` message
- visually hide `.vote-status` but keep it screen-reader accessible

## Testing
- `python manage.py test` *(fails: Missing staticfiles manifest entry for 'css/app.css')*

------
https://chatgpt.com/codex/tasks/task_e_68ba4ef4a710832c996c3df448b614cb