### PR TITLE
Refine HTMX guard error handling

### DIFF
--- a/static/js/htmx-guard.js
+++ b/static/js/htmx-guard.js
@@ -19,37 +19,30 @@
     setTimeout(function () { toast.style.opacity = '0'; }, 2000);
     setTimeout(function () { toast.remove(); }, 2300);
   }
-
-  function reenableVoteButtons(target) {
-    if (!target) return;
-    var container = target.closest('.vote, .comment-vote');
-    if (!container) return;
-    container.querySelectorAll('button').forEach(function (btn) {
-      btn.disabled = false;
-    });
-  }
-
   document.body.addEventListener('htmx:beforeSwap', function (evt) {
     var status = evt.detail.xhr.status;
+
+    if (status === 200) {
+      return;
+    }
+
     if (status === 401) {
       var redirect = evt.detail.xhr.getResponseHeader('HX-Redirect');
       if (redirect) {
         window.location.href = redirect;
       }
       showToast('Please log in');
-      reenableVoteButtons(evt.detail.target);
       evt.detail.shouldSwap = false;
+      return;
     }
+
     if (status === 403) {
       showToast('Action forbidden');
-      reenableVoteButtons(evt.detail.target);
-      evt.detail.shouldSwap = false;
     }
     if (status === 409) {
       showToast("You've already voted");
-      evt.detail.shouldSwap = false;
     }
-    if (status >= 500 && status < 600) {
+    if (status === 403 || status === 409 || (status >= 500 && status < 600)) {
       evt.detail.shouldSwap = false;
     }
   });


### PR DESCRIPTION
## Summary
- simplify HTMX error guard by removing vote button re-enabling
- prevent swapping on auth/validation/server errors and follow HX-Redirect header

## Testing
- `python manage.py test` *(fails: Missing staticfiles manifest entry for 'css/app.css'; ModuleNotFoundError: freezegun)*

------
https://chatgpt.com/codex/tasks/task_e_68ba500fbfa8832c94d95fafd03e7fed