### PR TITLE
Prevent duplicate vote widgets for repeated posts/comments

### DIFF
--- a/templates/core/partials/comment_item.html
+++ b/templates/core/partials/comment_item.html
@@ -10,7 +10,11 @@
     {% if comment.edited_at %}
       <span class="edited" title="Edited {{ comment.edited_at|date:'Y-m-d H:i' }}">edited</span>
     {% endif %}
-      {% include "core/partials/vote_widget.html" with comment=comment user=user request=request only %}
+      {% if show_vote_widget is not False %}
+        {% include "core/partials/vote_widget.html" with comment=comment user=user request=request only %}
+      {% else %}
+        <span id="comment-{{ comment.pk }}-score-item" class="score">{{ comment.score }}</span>
+      {% endif %}
     <button hx-get="/comments/new?parent={{ comment.pk }}&post={{ comment.post.pk }}"
             hx-target="#comment-{{ comment.pk }} > .children" hx-swap="beforeend">Reply</button>
     {% if comment|can_edit_comment:request.user %}

--- a/templates/core/partials/comment_row.html
+++ b/templates/core/partials/comment_row.html
@@ -16,7 +16,11 @@
   </div>
 
     <div class="comment-actions">
-        {% include "core/partials/vote_widget.html" with comment=comment user=user request=request tag='div' only %}
+        {% if show_vote_widget is not False %}
+          {% include "core/partials/vote_widget.html" with comment=comment user=user request=request tag='div' only %}
+        {% else %}
+          <span id="comment-{{ comment.pk }}-score-row" class="score">{{ comment.score }}</span>
+        {% endif %}
 
       <a class="reply"
          hx-get="{% url 'comment_reply_form' comment.pk %}"
@@ -30,7 +34,7 @@
     {% if kids %}
       <div class="comment-children">
         {% for child in kids %}
-          {% include "core/partials/comment_row.html" with comment=child depth=depth|add:1 request=request user=user only %}
+          {% include "core/partials/comment_row.html" with comment=child depth=depth|add:1 request=request user=user show_vote_widget=show_vote_widget only %}
         {% endfor %}
       </div>
     {% endif %}

--- a/templates/core/partials/post_row.html
+++ b/templates/core/partials/post_row.html
@@ -20,7 +20,11 @@
     <p class="post-excerpt">{{ post.excerpt }}</p>
     {% endif %}
     <div class="post-actions">
-      {% include "core/partials/vote_widget.html" with post=post user=user request=request only %}
+      {% if show_vote_widget is not False %}
+        {% include "core/partials/vote_widget.html" with post=post user=user request=request only %}
+      {% else %}
+        <span id="post-{{ post.pk }}-score-row" class="score">{{ post.score }}</span>
+      {% endif %}
       <a href="{{ post.get_absolute_url }}#comments">{{ post.comment_count }} comments</a>
     </div>
   {% endwith %}

--- a/templates/core/user_overview.html
+++ b/templates/core/user_overview.html
@@ -14,9 +14,9 @@
 {% include "core/partials/user_tab_bar.html" %}
 {% for item in activity %}
   {% if item.type == 'post' %}
-    {% include "core/partials/post_row.html" with post=item.obj %}
+    {% include "core/partials/post_row.html" with post=item.obj show_vote_widget=False %}
   {% else %}
-    {% include "core/partials/comment_row.html" with comment=item.obj %}
+    {% include "core/partials/comment_row.html" with comment=item.obj show_vote_widget=False %}
   {% endif %}
 {% empty %}
   <p>No activity yet.</p>

--- a/templates/partials/feed_card.html
+++ b/templates/partials/feed_card.html
@@ -30,7 +30,11 @@
   <p class="post-excerpt">{{ post.excerpt }}</p>
   {% endif %}
   <div class="post-actions">
-    {% include "core/partials/vote_widget.html" with post=post user=user request=request only %}
+    {% if show_vote_widget is not False %}
+      {% include "core/partials/vote_widget.html" with post=post user=user request=request only %}
+    {% else %}
+      <span id="post-{{ post.pk }}-score-card" class="score">{{ post.score }}</span>
+    {% endif %}
     <a href="{{ detail_url }}#comments">{{ post.comment_count }} comments</a>
     {% if post.astro_score %}
     <details class="astro-why">


### PR DESCRIPTION
## Summary
- allow disabling vote widget on post and comment templates
- render read-only score spans with unique IDs when votes are hidden
- use non-interactive scores on user activity pages

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'core')*
- `python - <<'PY' ...` (rendered feed card and post row) output: 1 occurrence of `id="post-1-score"`, static score row present
- `python - <<'PY' ...` (rendered comment rows) output: 1 occurrence of `id="comment-1-score"`, static score row present

------
https://chatgpt.com/codex/tasks/task_e_68ba52d21284832ca6e129bf941708ba