### PR TITLE
Unify comment score IDs with posts

### DIFF
--- a/core/tests/test_routes.py
+++ b/core/tests/test_routes.py
@@ -1,5 +1,6 @@
 from django.contrib.auth import get_user_model
-from django.test import Client, TestCase
+from django.template.loader import render_to_string
+from django.test import Client, RequestFactory, TestCase
 from django.urls import reverse
 
 from core.models import Comment, Community, Post
@@ -122,6 +123,39 @@ class RouteTests(TestCase):
         url = reverse("vote_comment", args=[self.comment.pk])
         resp = self.client.post(url, {"v": 0}, HTTP_HX_REQUEST="true")
         self.assertEqual(resp.status_code, 400)
+
+    def test_vote_comment_htmx_returns_span(self):
+        self.client.login(username="tester", password="pwd")
+        url = reverse("vote_comment", args=[self.comment.pk])
+        resp = self.client.post(url, {"v": 1}, HTTP_HX_REQUEST="true")
+        self.assertEqual(resp.status_code, 200)
+        self.assertHTMLEqual(
+            resp.content.decode(),
+            f'<span id="comment-{self.comment.pk}-score">1</span>',
+        )
+
+    def test_comment_row_uses_score_id_contract_without_widget(self):
+        rf = RequestFactory()
+        request = rf.get("/")
+        html = render_to_string(
+            "core/partials/comment_row.html",
+            {"comment": self.comment, "show_vote_widget": False},
+            request=request,
+        )
+        self.assertIn(
+            f'id="comment-{self.comment.pk}-score"',
+            html,
+        )
+
+    def test_vote_comment_non_htmx_returns_span(self):
+        self.client.login(username="tester", password="pwd")
+        url = reverse("vote_comment", args=[self.comment.pk])
+        resp = self.client.post(url, {"v": 1})
+        self.assertEqual(resp.status_code, 200)
+        self.assertHTMLEqual(
+            resp.content.decode(),
+            f'<span id="comment-{self.comment.pk}-score">1</span>',
+        )
 
     def test_vote_comment_htmx_with_csrf(self):
         client = Client(enforce_csrf_checks=True)

--- a/core/views.py
+++ b/core/views.py
@@ -1315,11 +1315,11 @@ def vote_post(request, pk):
         return HttpResponseBadRequest("Invalid vote")
 
     try:
-        cast_vote_post_once(request.user, post, want)
+        new_score = cast_vote_post_once(request.user, post, want)
     except AlreadyVoted:
         return HttpResponse(status=409)
 
-    return HttpResponse(f"<span id='post-{post.pk}-score'>{post.score}</span>")
+    return HttpResponse(f"<span id='post-{post.pk}-score'>{new_score}</span>")
 
 
 @require_POST
@@ -1335,11 +1335,11 @@ def vote_comment(request, pk):
         return HttpResponseBadRequest("Invalid vote")
 
     try:
-        cast_vote_comment_once(request.user, comment, want)
+        new_score = cast_vote_comment_once(request.user, comment, want)
     except AlreadyVoted:
         return HttpResponse(status=409)
 
-    return HttpResponse(f"<span id='comment-{comment.pk}-score'>{comment.score}</span>")
+    return HttpResponse(f"<span id='comment-{comment.pk}-score'>{new_score}</span>")
 
 
 @login_required

--- a/templates/core/partials/comment_row.html
+++ b/templates/core/partials/comment_row.html
@@ -19,7 +19,7 @@
         {% if show_vote_widget is not False %}
           {% include "core/partials/vote_widget.html" with comment=comment user=user request=request tag='div' only %}
         {% else %}
-          <span id="comment-{{ comment.pk }}-score-row" class="score">{{ comment.score }}</span>
+          <span id="comment-{{ comment.pk }}-score" class="score">{{ comment.score }}</span>
         {% endif %}
 
       <a class="reply"

--- a/templates/core/partials/post_row.html
+++ b/templates/core/partials/post_row.html
@@ -23,7 +23,7 @@
       {% if show_vote_widget is not False %}
         {% include "core/partials/vote_widget.html" with post=post user=user request=request only %}
       {% else %}
-        <span id="post-{{ post.pk }}-score-row" class="score">{{ post.score }}</span>
+        <span id="post-{{ post.pk }}-score" class="score">{{ post.score }}</span>
       {% endif %}
       <a href="{{ post.get_absolute_url }}#comments">{{ post.comment_count }} comments</a>
     </div>


### PR DESCRIPTION
## Summary
- Use `comment-{id}-score` span IDs when the vote widget is hidden
- Return updated scores from `vote_post`/`vote_comment` views
- Add regression tests for comment vote responses and score ID contract

## Testing
- `pytest` *(fails: tests/test_login_redirect.py::test_login_redirect_preserves_query, core/tests/test_astro.py::AstroFeatureFlagViewTests::test_chip_containers_hidden_when_flag_disabled, core/tests/test_layout.py::test_homepage_layout, core/tests/test_links.py::CommentLinkTests::test_post_detail_comment_links, core/tests/test_post_detail_media.py::PostDetailMediaTests::test_youtube_embed_has_placeholder, core/tests/test_rate_limit_counter.py::RateLimitTests::test_limit_enforced, core/tests/test_routes.py::RouteTests::test_mod_astro, core/tests/test_routes.py::RouteTests::test_vote_comment_htmx_returns_span, core/tests/test_routes.py::RouteTests::test_vote_comment_htmx_with_csrf, core/tests/test_routes.py::RouteTests::test_vote_comment_non_htmx_returns_span, core/tests/test_routes.py::RouteTests::test_vote_post_htmx_returns_span, core/tests/test_routes.py::RouteTests::test_vote_post_non_htmx_returns_span)*
- `pytest core/tests/test_routes.py::RouteTests::test_vote_comment_htmx_returns_span core/tests/test_routes.py::RouteTests::test_vote_comment_non_htmx_returns_span core/tests/test_routes.py::RouteTests::test_comment_row_uses_score_id_contract_without_widget -q`
- `pytest core/tests/test_routes.py::RouteTests::test_vote_post_htmx_returns_span core/tests/test_routes.py::RouteTests::test_vote_post_non_htmx_returns_span core/tests/test_routes.py::RouteTests::test_vote_comment_htmx_with_csrf -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba56cdd9a0832cb3aa517d4088bab5