### PR TITLE
Return disabled vote widget on HTMX requests

### DIFF
--- a/core/tests/test_routes.py
+++ b/core/tests/test_routes.py
@@ -71,15 +71,14 @@ class RouteTests(TestCase):
         self.assertIn("Log in to vote", html_comment)
         self.assertIn(f'id="comment-{self.comment.pk}-score"', html_comment)
 
-    def test_vote_post_htmx_returns_span(self):
+    def test_vote_post_htmx_returns_widget(self):
         self.client.login(username="tester", password="pwd")
         url = reverse("vote_post", args=[self.post.pk])
         resp = self.client.post(url, {"v": 1}, HTTP_HX_REQUEST="true")
         self.assertEqual(resp.status_code, 200)
-        self.assertHTMLEqual(
-            resp.content.decode(),
-            f'<span id="post-{self.post.pk}-score">1</span>',
-        )
+        html = resp.content.decode()
+        self.assertIn(f'id="post-{self.post.pk}-score"', html)
+        self.assertIn("disabled", html)
 
     def test_vote_post_non_htmx_returns_span(self):
         self.client.login(username="tester", password="pwd")
@@ -141,15 +140,14 @@ class RouteTests(TestCase):
         resp = self.client.post(url, {"v": 0}, HTTP_HX_REQUEST="true")
         self.assertEqual(resp.status_code, 400)
 
-    def test_vote_comment_htmx_returns_span(self):
+    def test_vote_comment_htmx_returns_widget(self):
         self.client.login(username="tester", password="pwd")
         url = reverse("vote_comment", args=[self.comment.pk])
         resp = self.client.post(url, {"v": 1}, HTTP_HX_REQUEST="true")
         self.assertEqual(resp.status_code, 200)
-        self.assertHTMLEqual(
-            resp.content.decode(),
-            f'<span id="comment-{self.comment.pk}-score">1</span>',
-        )
+        html = resp.content.decode()
+        self.assertIn(f'id="comment-{self.comment.pk}-score"', html)
+        self.assertIn("disabled", html)
 
     def test_comment_row_uses_score_id_contract_without_widget(self):
         rf = RequestFactory()
@@ -187,7 +185,6 @@ class RouteTests(TestCase):
             HTTP_X_CSRFTOKEN=token,
         )
         self.assertEqual(resp.status_code, 200)
-        self.assertHTMLEqual(
-            resp.content.decode(),
-            f'<span id="comment-{self.comment.pk}-score">1</span>',
-        )
+        html = resp.content.decode()
+        self.assertIn(f'id="comment-{self.comment.pk}-score"', html)
+        self.assertIn("disabled", html)

--- a/core/tests/test_vote_templates.py
+++ b/core/tests/test_vote_templates.py
@@ -38,8 +38,8 @@ def test_authenticated_shows_vote_buttons(client, content):
     resp = client.get(post.get_absolute_url())
     html = resp.content.decode()
     assert "hx-post" in html
-    assert f'hx-target="#post-{post.pk}-score"' in html
-    assert f'hx-target="#comment-{comment.pk}-score"' in html
+    assert f'hx-target="#post-{post.pk}-vote"' in html
+    assert f'hx-target="#comment-{comment.pk}-vote"' in html
 
 
 @pytest.mark.django_db

--- a/core/views.py
+++ b/core/views.py
@@ -1319,6 +1319,14 @@ def vote_post(request, pk):
     except AlreadyVoted:
         return HttpResponse(status=409)
 
+    if request.headers.get("HX-Request") == "true":
+        post.refresh_from_db()
+        return render(
+            request,
+            "core/partials/vote_widget.html",
+            {"post": post, "voted": True},
+        )
+
     return HttpResponse(f"<span id='post-{post.pk}-score'>{new_score}</span>")
 
 
@@ -1338,6 +1346,14 @@ def vote_comment(request, pk):
         new_score = cast_vote_comment_once(request.user, comment, want)
     except AlreadyVoted:
         return HttpResponse(status=409)
+
+    if request.headers.get("HX-Request") == "true":
+        comment.refresh_from_db()
+        return render(
+            request,
+            "core/partials/vote_widget.html",
+            {"comment": comment, "voted": True},
+        )
 
     return HttpResponse(f"<span id='comment-{comment.pk}-score'>{new_score}</span>")
 

--- a/docs/Voting-System-Spec.md
+++ b/docs/Voting-System-Spec.md
@@ -113,7 +113,7 @@ def vote_post(request, pk):
   <button aria-label="Upvote"
           hx-post="{% url 'vote_post' post.pk %}"
           hx-vals='{"v":1}'
-          hx-target="#post-{{ post.pk }}-score"
+          hx-target="#post-{{ post.pk }}-vote"
           hx-swap="outerHTML"
           hx-on::after-request="this.closest('.post-vote').querySelectorAll('button').forEach(b=>b.disabled=true)">▲</button>
 
@@ -122,7 +122,7 @@ def vote_post(request, pk):
   <button aria-label="Downvote"
           hx-post="{% url 'vote_post' post.pk %}"
           hx-vals='{"v":-1}'
-          hx-target="#post-{{ post.pk }}-score"
+          hx-target="#post-{{ post.pk }}-vote"
           hx-swap="outerHTML"
           hx-on::after-request="this.closest('.post-vote').querySelectorAll('button').forEach(b=>b.disabled=true)">▼</button>
 </div>

--- a/templates/core/partials/vote_widget.html
+++ b/templates/core/partials/vote_widget.html
@@ -5,53 +5,53 @@
 {% endcomment %}
 {% if post %}
   {% with wrapper=tag|default:"div" %}
-<{{ wrapper }} class="vote post-vote" id="post-{{ post.pk }}-vote"{% if user.is_authenticated %} hx-on::after-swap="if(event.detail.xhr.status===200){this.classList.add('voted');this.querySelectorAll('button').forEach(btn=>btn.disabled=true);this.querySelector('.vote-status').textContent='Vote saved'}"{% endif %}>
+<{{ wrapper }} class="vote post-vote{% if voted %} voted{% endif %}" id="post-{{ post.pk }}-vote"{% if user.is_authenticated %} hx-on::after-swap="if(event.detail.xhr.status===200){this.classList.add('voted');this.querySelectorAll('button').forEach(btn=>btn.disabled=true);this.querySelector('.vote-status').textContent='Vote saved'}"{% endif %}>
   {% if user.is_authenticated %}
   <button
     hx-post="{% url 'vote_post' post.pk %}"
     hx-vals='{"v":1}'
-    hx-target="#post-{{ post.pk }}-score"
+    hx-target="#post-{{ post.pk }}-vote"
     hx-swap="outerHTML"
-    aria-label="Upvote">▲</button>
+    aria-label="Upvote"{% if voted %} disabled{% endif %}>▲</button>
   <span id="post-{{ post.pk }}-score">{{ post.score }}</span>
   <button
     hx-post="{% url 'vote_post' post.pk %}"
     hx-vals='{"v":-1}'
-    hx-target="#post-{{ post.pk }}-score"
+    hx-target="#post-{{ post.pk }}-vote"
     hx-swap="outerHTML"
-    aria-label="Downvote">▼</button>
-  <span class="vote-status" aria-live="polite"></span>
+    aria-label="Downvote"{% if voted %} disabled{% endif %}>▼</button>
+  <span class="vote-status" aria-live="polite">{% if voted %}Vote saved{% endif %}</span>
   {% else %}
   <button disabled aria-label="Upvote">▲</button>
   <span id="post-{{ post.pk }}-score">{{ post.score }}</span>
   <button disabled aria-label="Downvote">▼</button>
-  <a href="{% url 'login' %}?next={{ request.get_full_path }}">Log in to vote</a>
+  <a href="{% url 'login' %}?next={{ request.get_full_path|urlencode }}">Log in to vote</a>
   {% endif %}
 </{{ wrapper }}>
   {% endwith %}
 {% elif comment %}
   {% with wrapper=tag|default:"span" %}
-<{{ wrapper }} class="vote comment-vote" id="comment-{{ comment.pk }}-vote"{% if user.is_authenticated %} hx-on::after-swap="if(event.detail.xhr.status===200){this.classList.add('voted');this.querySelectorAll('button').forEach(btn=>btn.disabled=true);this.querySelector('.vote-status').textContent='Vote saved'}"{% endif %}>
+<{{ wrapper }} class="vote comment-vote{% if voted %} voted{% endif %}" id="comment-{{ comment.pk }}-vote"{% if user.is_authenticated %} hx-on::after-swap="if(event.detail.xhr.status===200){this.classList.add('voted');this.querySelectorAll('button').forEach(btn=>btn.disabled=true);this.querySelector('.vote-status').textContent='Vote saved'}"{% endif %}>
   {% if user.is_authenticated %}
   <button
     hx-post="{% url 'vote_comment' comment.pk %}"
     hx-vals='{"v":1}'
-    hx-target="#comment-{{ comment.pk }}-score"
+    hx-target="#comment-{{ comment.pk }}-vote"
     hx-swap="outerHTML"
-    aria-label="Upvote">▲</button>
+    aria-label="Upvote"{% if voted %} disabled{% endif %}>▲</button>
   <span id="comment-{{ comment.pk }}-score">{{ comment.score }}</span>
   <button
     hx-post="{% url 'vote_comment' comment.pk %}"
     hx-vals='{"v":-1}'
-    hx-target="#comment-{{ comment.pk }}-score"
+    hx-target="#comment-{{ comment.pk }}-vote"
     hx-swap="outerHTML"
-    aria-label="Downvote">▼</button>
-  <span class="vote-status" aria-live="polite"></span>
+    aria-label="Downvote"{% if voted %} disabled{% endif %}>▼</button>
+  <span class="vote-status" aria-live="polite">{% if voted %}Vote saved{% endif %}</span>
   {% else %}
   <button disabled aria-label="Upvote">▲</button>
   <span id="comment-{{ comment.pk }}-score">{{ comment.score }}</span>
   <button disabled aria-label="Downvote">▼</button>
-  <a href="{% url 'login' %}?next={{ request.get_full_path }}">Log in to vote</a>
+  <a href="{% url 'login' %}?next={{ request.get_full_path|urlencode }}">Log in to vote</a>
   {% endif %}
 </{{ wrapper }}>
   {% endwith %}

--- a/tests/test_votes.py
+++ b/tests/test_votes.py
@@ -1,0 +1,28 @@
+import pytest
+from django.urls import reverse
+
+from core.models import Community, Post
+
+
+@pytest.fixture
+def post(db, django_user_model):
+    author = django_user_model.objects.create_user("author", password="pw")
+    community = Community.objects.create(slug="t", name="Test", title="Test", created_by=author)
+    return Post.objects.create(community=community, author=author, post_type="text", title="Hello")
+
+
+@pytest.mark.django_db
+def test_vote_is_immutable_and_buttons_disabled(client, django_user_model, post):
+    user = django_user_model.objects.create_user(username="u1", password="pw")
+    client.login(username="u1", password="pw")
+
+    url = reverse("vote_post", args=[post.id])
+
+    r1 = client.post(url, {"v": "1"}, HTTP_HX_REQUEST="true")
+    assert r1.status_code == 200
+    body = r1.content.decode()
+    assert f'id="post-{post.id}-score"' in body
+    assert "disabled" in body
+
+    r2 = client.post(url, {"v": "1"}, HTTP_HX_REQUEST="true")
+    assert r2.status_code == 409


### PR DESCRIPTION
## Summary
- Swap and disable vote widget buttons after an HTMX vote
- Render updated vote widget from `vote_post` and `vote_comment`
- Add regression test ensuring second post vote is rejected

## Testing
- `pytest tests/test_votes.py tests/test_login_redirect.py core/tests/test_vote_templates.py core/tests/test_routes.py::RouteTests::test_vote_post_htmx_returns_widget core/tests/test_routes.py::RouteTests::test_vote_comment_htmx_returns_widget core/tests/test_routes.py::RouteTests::test_vote_comment_htmx_with_csrf core/tests/test_routes.py::RouteTests::test_vote_comment_non_htmx_returns_span -q`
- `pytest` *(fails: core/tests/test_astro.py::AstroFeatureFlagViewTests::test_chip_containers_hidden_when_flag_disabled, core/tests/test_layout.py::test_homepage_layout, core/tests/test_links.py::CommentLinkTests::test_post_detail_comment_links, core/tests/test_post_detail_media.py::PostDetailMediaTests::test_youtube_embed_has_placeholder, core/tests/test_rate_limit_counter.py::RateLimitTests::test_limit_enforced)*

------
https://chatgpt.com/codex/tasks/task_e_68ba5c8b9610832cacc60ebd63705ead