### PR TITLE
Add soft delete support to comments

### DIFF
--- a/core/migrations/0026_comment_soft_delete.py
+++ b/core/migrations/0026_comment_soft_delete.py
@@ -1,0 +1,35 @@
+from django.conf import settings
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("core", "0025_remove_vote_uniq_vote_post_user_and_more"),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="comment",
+            name="deleted_at",
+            field=models.DateTimeField(null=True, blank=True),
+        ),
+        migrations.AddField(
+            model_name="comment",
+            name="deleted_by",
+            field=models.ForeignKey(
+                to=settings.AUTH_USER_MODEL,
+                null=True,
+                blank=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="+",
+            ),
+        ),
+        migrations.AddField(
+            model_name="comment",
+            name="is_deleted",
+            field=models.BooleanField(default=False, db_index=True),
+        ),
+    ]

--- a/core/models.py
+++ b/core/models.py
@@ -283,6 +283,15 @@ class Comment(models.Model):
     score = models.IntegerField(default=0)
     created_at = models.DateTimeField(auto_now_add=True)
     edited_at = models.DateTimeField(null=True, blank=True)
+    is_deleted = models.BooleanField(default=False, db_index=True)
+    deleted_at = models.DateTimeField(null=True, blank=True)
+    deleted_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        null=True,
+        blank=True,
+        on_delete=models.SET_NULL,
+        related_name="+",
+    )
 
     class Meta:
         indexes = [
@@ -294,6 +303,15 @@ class Comment(models.Model):
     def depth(self):
         """Return the nesting depth based on the comment path."""
         return self.path.count("/")
+
+    def soft_delete(self, by_user):
+        self.is_deleted = True
+        self.deleted_at = timezone.now()
+        self.deleted_by = by_user
+        self.body = ""
+        self.save(
+            update_fields=["is_deleted", "deleted_at", "deleted_by", "body"]
+        )
 
 
 class Vote(models.Model):


### PR DESCRIPTION
## Summary
- add `is_deleted`, `deleted_at`, and `deleted_by` fields on comments
- implement `Comment.soft_delete` to mark comments deleted and scrub body
- add migration for new comment fields

## Testing
- `pytest -x` *(fails: AstroFeatureFlagViewTests::test_chip_containers_hidden_when_flag_disabled)*

------
https://chatgpt.com/codex/tasks/task_e_68ba5fe49800832c9d25adb5e424f5ea