### PR TITLE
Add HTMX delete buttons for posts and comments

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -358,6 +358,23 @@ body.layout-root {
 /* If your vote buttons are inside <form>, keep forms inline */
 .post-actions .vote form{ display: inline; margin: 0; }
 
+/* Delete button */
+.btn-delete{
+  background:#dc2626;
+  color:#fff;
+  border:none;
+  border-radius:50%;
+  width:32px;
+  height:32px;
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  cursor:pointer;
+  font-size:16px;
+  line-height:1;
+}
+.btn-delete:hover{ background:#b91c1c; }
+
 /* Comment tree */
 .comment{ position:relative; padding:10px 0 10px calc(16px * var(--depth, 0)); }
 .comment-children{ margin-top:6px; }

--- a/templates/core/partials/comment_item.html
+++ b/templates/core/partials/comment_item.html
@@ -22,11 +22,11 @@
               hx-target="#comment-body-{{ comment.pk }}"
               hx-swap="outerHTML">Edit</button>
     {% endif %}
-    {% if request.user.id == comment.author_id or request.user.is_staff %}
+    {% if (request.user == comment.author or request.user.is_staff) and not comment.is_deleted %}
       <form method="post" action="{% url 'comment_delete' comment.pk %}" style="display:inline"
             hx-post="{% url 'comment_delete' comment.pk %}" hx-target="#comment-{{ comment.pk }}" hx-swap="outerHTML">
         {% csrf_token %}
-        <button type="submit" class="linklike" aria-label="Delete comment">delete</button>
+        <button type="submit" class="btn-delete" aria-label="Delete comment">&times;</button>
       </form>
     {% endif %}
   </div>

--- a/templates/core/partials/post_row.html
+++ b/templates/core/partials/post_row.html
@@ -1,4 +1,4 @@
-<article class="post-card" data-testid="post-card">
+<article id="post-{{ post.pk }}" class="post-card" data-testid="post-card">
   {% with detail_url=post.get_absolute_url %}
     {% if post.image_thumb or post.image %}
     <a href="{{ detail_url }}" class="thumb">
@@ -26,6 +26,13 @@
         <span id="post-{{ post.pk }}-score" class="score">{{ post.score }}</span>
       {% endif %}
       <a href="{{ post.get_absolute_url }}#comments">{{ post.comment_count }} comments</a>
+      {% if (request.user == post.author or request.user.is_staff) and not post.is_deleted %}
+      <form method="post" action="{% url 'post_delete_owner' post.pk %}" style="display:inline"
+            hx-post="{% url 'post_delete_owner' post.pk %}" hx-target="#post-{{ post.pk }}" hx-swap="outerHTML">
+        {% csrf_token %}
+        <button type="submit" class="btn-delete" aria-label="Delete post">&times;</button>
+      </form>
+      {% endif %}
     </div>
   {% endwith %}
 </article>

--- a/templates/core/post_detail.html
+++ b/templates/core/post_detail.html
@@ -7,7 +7,7 @@
 {% endblock %}
 
 {% block content %}
-<article class="post-detail">
+<article id="post-{{ post.pk }}" class="post-detail">
   <header class="post-header">
     <h1>{{ post.title }}</h1>
     <div class="meta">
@@ -64,6 +64,14 @@
         </div>
         <span class="astro-label">Astro</span>
       </div>
+    {% endif %}
+
+    {% if (request.user == post.author or request.user.is_staff) and not post.is_deleted %}
+    <form method="post" action="{% url 'post_delete_owner' post.pk %}"
+          hx-post="{% url 'post_delete_owner' post.pk %}" hx-target="#post-{{ post.pk }}" hx-swap="outerHTML" style="display:inline">
+      {% csrf_token %}
+      <button type="submit" class="btn-delete" aria-label="Delete post">&times;</button>
+    </form>
     {% endif %}
   </div>
 </article>


### PR DESCRIPTION
## Summary
- allow authors or staff to delete posts inline with HTMX
- add matching delete controls for comments
- style new delete buttons

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'core', freezegun missing, and Django settings not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68ba629b88bc832caa70ddf8c8ad4d12