### PR TITLE
Mark post hard delete as admin-only

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -65,6 +65,7 @@ urlpatterns = [
         core_views.post_delete_owner,
         name="post_delete_owner",
     ),
+    # Hard delete (admin-only; not linked from templates)
     path("post/<int:pk>/delete/", core_views.post_delete, name="post_delete"),
     path("post/<int:pk>/remove/", core_views.post_remove, name="post_remove"),
     path("post/<int:pk>/lock/", core_views.post_lock, name="post_lock"),

--- a/core/views.py
+++ b/core/views.py
@@ -1180,7 +1180,11 @@ def post_delete_owner(request, pk):
 @require_POST
 @csrf_protect
 def post_delete(request, pk):
-    """Delete a post; only staff members may perform this action."""
+    """Hard delete a post.
+
+    This view is intended for administrative use only and isn't linked from the
+    standard user interface. Only staff members may perform this action.
+    """
     if not request.user.is_staff:
         return HttpResponseForbidden("Forbidden")
     post = get_object_or_404(Post.objects.filter(is_deleted=False), pk=pk)


### PR DESCRIPTION
## Summary
- add inline comment in core URLs noting that post hard delete route is not linked in templates
- document post hard delete view as administrative-only

## Testing
- `pytest` *(fails: ModuleNotFoundError / ImproperlyConfigured)*

------
https://chatgpt.com/codex/tasks/task_e_68ba68f4c468832cb2c854ed340b08a8