### PR TITLE
Add tests for post and comment deletion

### DIFF
--- a/core/tests/test_comment_delete.py
+++ b/core/tests/test_comment_delete.py
@@ -1,0 +1,47 @@
+from django.contrib.auth import get_user_model
+from django.core.cache import cache
+from django.test import TestCase
+from django.urls import reverse
+
+from core.models import Comment, Community, Post
+
+
+class CommentDeleteTests(TestCase):
+    def setUp(self):
+        cache.clear()
+        U = get_user_model()
+        self.user = U.objects.create_user("alice", password="pwd")
+        self.other = U.objects.create_user("bob", password="pwd")
+        self.community = Community.objects.create(
+            slug="t", name="Test", title="Test", created_by=self.user
+        )
+        self.post = Post.objects.create(
+            community=self.community,
+            author=self.user,
+            post_type="text",
+            title="Hello",
+        )
+        self.comment = Comment.objects.create(
+            post=self.post, author=self.user, body="Hi", path="0001"
+        )
+        self.post.comment_count = 1
+        self.post.save(update_fields=["comment_count"])
+        self.url = reverse("comment_delete", args=[self.comment.pk])
+
+    def test_author_soft_delete_htmx(self):
+        self.client.login(username="alice", password="pwd")
+        resp = self.client.post(self.url, HTTP_HX_REQUEST="true")
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn(b"comment deleted", resp.content)
+        self.comment.refresh_from_db()
+        self.assertTrue(self.comment.is_deleted)
+        self.assertEqual(self.comment.body, "")
+        self.post.refresh_from_db()
+        self.assertEqual(self.post.comment_count, 1)
+
+    def test_non_author_delete_returns_403(self):
+        self.client.login(username="bob", password="pwd")
+        resp = self.client.post(self.url, HTTP_HX_REQUEST="true")
+        self.assertEqual(resp.status_code, 403)
+        self.comment.refresh_from_db()
+        self.assertFalse(self.comment.is_deleted)

--- a/core/tests/test_post_delete_owner.py
+++ b/core/tests/test_post_delete_owner.py
@@ -1,0 +1,56 @@
+from django.contrib.auth import get_user_model
+from django.core.cache import cache
+from django.test import TestCase
+from django.urls import reverse
+
+from core.models import Community, Post, Vote
+from core.services.votes import cast_vote_post_once
+
+
+class PostDeleteOwnerTests(TestCase):
+    def setUp(self):
+        cache.clear()
+        U = get_user_model()
+        self.user = U.objects.create_user("alice", password="pwd")
+        self.other = U.objects.create_user("bob", password="pwd")
+        self.community = Community.objects.create(
+            slug="t", name="Test", title="Test", created_by=self.user
+        )
+
+    def test_author_soft_delete_htmx(self):
+        post = Post.objects.create(
+            community=self.community, author=self.user, post_type="text", title="Hello"
+        )
+        cast_vote_post_once(self.other, post, 1)
+        votes_before = Vote.objects.filter(target_type="post", target_id=post.pk).count()
+
+        # Post appears in global feed
+        resp = self.client.get(reverse("feed_list"), HTTP_HX_REQUEST="true")
+        self.assertIn(b"Hello", resp.content)
+
+        self.client.login(username="alice", password="pwd")
+        url = reverse("post_delete_owner", args=[post.pk])
+        resp = self.client.post(url, HTTP_HX_REQUEST="true")
+        self.assertEqual(resp.status_code, 204)
+        post.refresh_from_db()
+        self.assertTrue(post.is_deleted)
+        self.assertEqual(post.score, 1)
+        votes_after = Vote.objects.filter(target_type="post", target_id=post.pk).count()
+        self.assertEqual(votes_before, votes_after)
+
+        # Post removed from feed and detail page not found
+        resp = self.client.get(reverse("feed_list"), HTTP_HX_REQUEST="true")
+        self.assertNotIn(b"Hello", resp.content)
+        resp = self.client.get(post.get_absolute_url())
+        self.assertEqual(resp.status_code, 404)
+
+    def test_non_author_delete_returns_403(self):
+        post = Post.objects.create(
+            community=self.community, author=self.other, post_type="text", title="Nope"
+        )
+        self.client.login(username="alice", password="pwd")
+        url = reverse("post_delete_owner", args=[post.pk])
+        resp = self.client.post(url, HTTP_HX_REQUEST="true")
+        self.assertEqual(resp.status_code, 403)
+        post.refresh_from_db()
+        self.assertFalse(post.is_deleted)


### PR DESCRIPTION
## Summary
- add tests ensuring post owner HTMX deletions mark posts as deleted, remove them from feed, preserve votes, and block non-authors
- add tests confirming comment deletions clear body, show placeholder, keep parent comment count, and enforce author-only permissions

## Testing
- `python manage.py test core.tests.test_post_delete_owner core.tests.test_comment_delete`

------
https://chatgpt.com/codex/tasks/task_e_68ba6a0fa2c8832c8cdeb6cbec4498db