### PR TITLE
Add HTMX delete action to comment row partial

### DIFF
--- a/templates/core/partials/comment_row.html
+++ b/templates/core/partials/comment_row.html
@@ -26,6 +26,13 @@
          hx-get="{% url 'comment_reply_form' comment.pk %}"
          hx-target="#c{{ comment.pk }} .reply-target"
          hx-swap="innerHTML">Reply</a>
+      {% if request.user == comment.author or request.user.is_staff %}
+        <form method="post" action="{% url 'comment_delete' comment.pk %}" style="display:inline"
+              hx-post="{% url 'comment_delete' comment.pk %}" hx-target="#c{{ comment.pk }}" hx-swap="outerHTML">
+          {% csrf_token %}
+          <button type="submit" class="btn-delete" aria-label="Delete comment">&times;</button>
+        </form>
+      {% endif %}
     </div>
 
   <div class="reply-target"></div>


### PR DESCRIPTION
## Summary
- Allow authors and staff to delete comments from the comment row view
- Preserve comment `<article>` IDs so HTMX targeting works

## Testing
- `python manage.py test core.tests_comment_delete core.tests.test_comment_delete`


------
https://chatgpt.com/codex/tasks/task_e_68ba71fd92fc832c87bdf070e5dd2fd7