### PR TITLE
Fix comment include context and ID targeting

### DIFF
--- a/templates/core/partials/comment_row.html
+++ b/templates/core/partials/comment_row.html
@@ -1,4 +1,5 @@
-<article class="comment" id="c{{ comment.pk }}" style="--depth: {{ depth|default:'0' }}">
+<article class="comment" id="comment-{{ comment.pk }}" style="--depth: {{ depth|default:'0' }}">
+  <a id="c{{ comment.pk }}"></a>
   <header class="comment-meta">
     <a class="author" href="{% url 'user_overview' comment.author.username %}">{{ comment.author.username }}</a>
     <span class="dot">•</span>
@@ -24,11 +25,11 @@
 
       <a class="reply"
          hx-get="{% url 'comment_reply_form' comment.pk %}"
-         hx-target="#c{{ comment.pk }} .reply-target"
+         hx-target="#comment-{{ comment.pk }} .reply-target"
          hx-swap="innerHTML">Reply</a>
       {% if request.user == comment.author or request.user.is_staff %}
         <form method="post" action="{% url 'comment_delete' comment.pk %}" style="display:inline"
-              hx-post="{% url 'comment_delete' comment.pk %}" hx-target="#c{{ comment.pk }}" hx-swap="outerHTML">
+              hx-post="{% url 'comment_delete' comment.pk %}" hx-target="#comment-{{ comment.pk }}" hx-swap="outerHTML">
           {% csrf_token %}
           <button type="submit" class="btn-delete" aria-label="Delete comment">&times;</button>
         </form>

--- a/templates/core/user_comments.html
+++ b/templates/core/user_comments.html
@@ -3,7 +3,7 @@
 <h1>u/{{ profile_user.username }}</h1>
 {% include "core/partials/user_tab_bar.html" %}
 {% for comment in comments %}
-  {% include "core/partials/comment_row.html" %}
+  {% include "core/partials/comment_row.html" with comment=comment request=request user=request.user %}
 {% empty %}
   <p>No comments yet.</p>
 {% endfor %}

--- a/templates/core/user_overview.html
+++ b/templates/core/user_overview.html
@@ -16,7 +16,7 @@
   {% if item.type == 'post' %}
     {% include "core/partials/post_row.html" with post=item.obj show_vote_widget=False %}
   {% else %}
-    {% include "core/partials/comment_row.html" with comment=item.obj show_vote_widget=False %}
+    {% include "core/partials/comment_row.html" with comment=item.obj request=request user=request.user show_vote_widget=False %}
   {% endif %}
 {% empty %}
   <p>No activity yet.</p>


### PR DESCRIPTION
## Summary
- ensure comment row elements have stable `id="comment-{{ comment.pk }}"`
- pass `request` and `user` explicitly when including `comment_row.html`

## Testing
- `pytest` *(fails: AstroFeatureFlagViewTests::test_chip_containers_hidden_when_flag_disabled, test_homepage_layout, CommentLinkTests::test_post_detail_comment_links, PostDetailMediaTests::test_youtube_embed_has_placeholder, RateLimitTests::test_limit_enforced)*

------
https://chatgpt.com/codex/tasks/task_e_68ba7881efc8832cad0ceec213733c56