### PR TITLE
Filter deleted posts from feeds

### DIFF
--- a/core/tests_deleted_post_visibility.py
+++ b/core/tests_deleted_post_visibility.py
@@ -1,0 +1,47 @@
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+
+from .models import Community, Post
+
+
+class DeletedPostVisibilityTests(TestCase):
+    def setUp(self):
+        user_model = get_user_model()
+        self.user = user_model.objects.create_user("alice", password="pwd")
+        self.community = Community.objects.create(
+            slug="t", name="Test", title="Test", created_by=self.user
+        )
+        self.live = Post.objects.create(
+            community=self.community,
+            author=self.user,
+            post_type="text",
+            title="Live",
+            score=5,
+        )
+        self.deleted = Post.objects.create(
+            community=self.community,
+            author=self.user,
+            post_type="text",
+            title="Gone",
+            score=1,
+            is_deleted=True,
+        )
+
+    def test_home_excludes_deleted(self):
+        resp = self.client.get(reverse("home"))
+        posts = resp.context["posts"]
+        self.assertEqual([p.pk for p in posts], [self.live.pk])
+
+    def test_feed_list_excludes_deleted(self):
+        for tab in ["hot", "new", "top"]:
+            resp = self.client.get(
+                reverse("feed_list"), {"tab": tab}, HTTP_HX_REQUEST="true"
+            )
+            posts = resp.context["posts"]
+            self.assertEqual([p.pk for p in posts], [self.live.pk])
+
+    def test_community_excludes_deleted(self):
+        resp = self.client.get(reverse("community", args=[self.community.slug]))
+        posts = resp.context["posts"]
+        self.assertEqual([p.pk for p in posts], [self.live.pk])

--- a/core/views.py
+++ b/core/views.py
@@ -526,7 +526,8 @@ def feed_list(request):
     if request.headers.get("HX-Request") == "true":
         page = int(request.GET.get("page", "1") or 1)
         size = int(request.GET.get("size", PAGE_SIZE) or PAGE_SIZE)
-        qs = feed_queryset(sort, t).filter(is_deleted=False)
+        base_qs = Post.objects.filter(is_deleted=False).select_related("community", "author")
+        qs = feed_queryset(sort, t, base_qs=base_qs)
         paginator = Paginator(qs, size)
         page_obj = paginator.get_page(page)
         ctx = {
@@ -556,7 +557,8 @@ def home(request):
         t = "all"
 
     page = int(request.GET.get("page", "1") or 1)
-    qs = feed_queryset(sort, t).filter(is_deleted=False)
+    base_qs = Post.objects.filter(is_deleted=False).select_related("community", "author")
+    qs = feed_queryset(sort, t, base_qs=base_qs)
     offset = (page - 1) * PAGE_SIZE
     posts = list(qs[offset : offset + PAGE_SIZE + 1])
     next_page = page + 1 if len(posts) > PAGE_SIZE else None


### PR DESCRIPTION
## Summary
- ensure home and feed_list querysets filter out deleted posts before ordering
- add regression tests to confirm deleted posts are hidden from home, community, and feed_list views

## Testing
- `python manage.py test core.tests_deleted_post_visibility -v 2`
- `python manage.py test` *(fails: assertion errors and missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68ba796159c0832ca70a7ec26c358089