### PR TITLE
test: assert HX-Redirect on post deletes

### DIFF
--- a/core/tests_post_delete_owner.py
+++ b/core/tests_post_delete_owner.py
@@ -42,7 +42,7 @@ class PostDeleteOwnerTests(TestCase):
         resp = self.client.post(url, {"from": "detail"}, HTTP_HX_REQUEST="true")
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(
-            resp.headers.get("HX-Redirect"),
+            resp.headers["HX-Redirect"],
             reverse("community", args=[self.community.slug]),
         )
         post.refresh_from_db()
@@ -68,6 +68,7 @@ class PostDeleteOwnerTests(TestCase):
         resp = self.client.post(url, HTTP_HX_REQUEST="true")
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.content, b"")
+        self.assertNotIn("HX-Redirect", resp.headers)
         post.refresh_from_db()
         self.assertTrue(post.is_deleted)
 
@@ -114,6 +115,7 @@ class PostDeleteOwnerTests(TestCase):
             resp = self.client.post(url, HTTP_HX_REQUEST="true")
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.content, b"")
+        self.assertNotIn("HX-Redirect", resp.headers)
         mock_recompute.assert_not_called()
         post.refresh_from_db()
         self.assertTrue(post.is_deleted)


### PR DESCRIPTION
## Summary
- ensure HX-Redirect header asserted for HTMX detail deletions
- verify feed-row deletions return empty body and no HX-Redirect

## Testing
- `python manage.py test core.tests_post_delete_owner`


------
https://chatgpt.com/codex/tasks/task_e_68ba7e52a980832c98c8bc0924b6e081