### PR TITLE
Improve Rumble embed parsing and thumbnail fallback

### DIFF
--- a/core/tests/test_post_detail_media.py
+++ b/core/tests/test_post_detail_media.py
@@ -59,6 +59,50 @@ class PostDetailMediaTests(TestCase):
         self.assertContains(resp, 'href="https://rumble.com/vxyz-test.html"')
         self.assertContains(resp, 'src="https://thumb.jpg"')
 
+    @patch("core.utils.embeds.fetch_oembed")
+    def test_rumble_embed_handles_single_quotes_in_iframe(self, mock_oembed):
+        mock_oembed.return_value = {
+            "type": "embed",
+            "html": "<iframe src='https://rumble.com/embed/vxyz/?pub=4'></iframe>",
+            "thumbnail_url": None,
+        }
+        post = Post.objects.create(
+            community=self.community,
+            author=self.user,
+            post_type="link",
+            title="Rumble SQ",
+            content_url="https://rumble.com/vxyz-test.html",
+        )
+        resp = self.client.get(
+            reverse("post_detail", args=[self.community.slug, post.pk, post.slug])
+        )
+        self.assertContains(resp, 'data-src="https://rumble.com/embed/vxyz/?pub=4"')
+        self.assertContains(resp, 'href="https://rumble.com/vxyz-test.html"')
+        # With missing thumbnail_url, we should still render an <img> (data: URL fallback)
+        self.assertContains(resp, 'src="data:image/svg+xml;utf8,')
+
+    @patch("core.utils.embeds.fetch_oembed")
+    def test_rumble_embed_falls_back_when_no_iframe_html(self, mock_oembed):
+        # oEmbed returns no iframe; builder derives /embed/<id>/ from page URL /vxyz-...
+        mock_oembed.return_value = {
+            "type": "embed",
+            "html": "<div>no iframe here</div>",
+            "thumbnail_url": None,
+        }
+        post = Post.objects.create(
+            community=self.community,
+            author=self.user,
+            post_type="link",
+            title="Rumble Fallback",
+            content_url="https://rumble.com/vxyz-interesting-video.html",
+        )
+        resp = self.client.get(
+            reverse("post_detail", args=[self.community.slug, post.pk, post.slug])
+        )
+        self.assertContains(resp, 'data-src="https://rumble.com/embed/vxyz/"')
+        self.assertContains(resp, 'href="https://rumble.com/vxyz-interesting-video.html"')
+        self.assertContains(resp, 'src="data:image/svg+xml;utf8,')
+
     def test_image_slideshow_renders(self):
         post = Post.objects.create(
             community=self.community,

--- a/core/utils/embeds.py
+++ b/core/utils/embeds.py
@@ -59,13 +59,50 @@ def build_embed_html(url: str) -> str:
             thumb = f"https://i.ytimg.com/vi/{vid}/hqdefault.jpg"
         src = f"https://www.youtube-nocookie.com/embed/{vid}"
     elif "rumble.com" in domain:
-        m = re.search(r'src="([^"]+)"', html)
-        if not m:
+        # 1) Try to read iframe src from the provider HTML (support " and ' quotes)
+        m = re.search(r"src=['\"]([^'\"]+)['\"]", html or "")
+        src = m.group(1) if m else ""
+
+        # 2) If no src in HTML, try to derive an embed id from the URL like:
+        #    https://rumble.com/vxyz-test.html  -> id: vxyz
+        #    Fallback to building https://rumble.com/embed/<id>/ if we find one
+        if not src:
+            m2 = re.search(r"/(v[\w]+)[-\.]", url)  # captures vxyz from /vxyz-test.html
+            if m2:
+                src = f"https://rumble.com/embed/{m2.group(1)}/"
+
+        # If still no usable src, degrade to a plain link card
+        if not src:
             return (
                 f'<div class="link-card"><a href="{escape(url)}" '
                 f'rel="noopener nofollow">{escape(parsed.netloc)}</a></div>'
             )
-        src = m.group(1)
+
+        # 3) Thumbnail fallback: when oEmbed misses it, use a tiny inline SVG
+        #    (keeps CSP-friendly, no external host needed)
+        if not thumb:
+            svg = (
+                "data:image/svg+xml;utf8,"
+                "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1200 675'>"
+                "<rect width='1200' height='675' fill='%23e5e5e5'/>"
+                "<circle cx='600' cy='337' r='120' fill='%23999'/>"
+                "<polygon points='560,277 560,397 660,337' fill='white'/>"
+                "<text x='50%' y='90%' dominant-baseline='middle' text-anchor='middle' "
+                "font-family='system-ui, sans-serif' font-size='40' fill='%23666'>Rumble preview</text>"
+                "</svg>"
+            )
+            thumb = svg
+
+        return (
+            f'<div class="post-embed" data-src="{escape(src)}" '
+            f'style="position:relative;padding-top:56.25%;overflow:hidden;">'
+            f'  <a href="{escape(url)}" rel="noopener nofollow" '
+            f'style="position:absolute;top:0;left:0;width:100%;height:100%;display:block;">'
+            f'    <img src="{escape(thumb)}" alt="" loading="lazy" decoding="async" '
+            f'referrerpolicy="no-referrer" style="width:100%;height:100%;object-fit:cover;">'
+            f'  </a>'
+            f'</div>'
+        )
     elif "twitter.com" in domain or "x.com" in domain:
         if not getattr(settings, "ENABLE_TWITTER_EMBEDS", False):
             return (


### PR DESCRIPTION
## Summary
- improve Rumble embed parsing to handle varied iframe HTML and missing thumbnail URLs
- add inline SVG thumbnail fallback for Rumble embeds
- extend post detail media tests for Rumble single-quote and no-iframe cases

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'core'; django settings not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68baaa7debac832cb7952e0ec8e39385