### PR TITLE
Drop cached embed_html field and render embeds dynamically

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -68,14 +68,13 @@ class PostAdmin(admin.ModelAdmin):
         "heading",
         "body",
         "content_url",
-        "embed_html",
         "link_domain",
         "score",
         "hot_rank",
         "created_at",
     )
     list_filter = ("post_type", "community")
-    search_fields = ("title", "heading", "body", "content_url", "embed_html", "link_domain")
+    search_fields = ("title", "heading", "body", "content_url", "link_domain")
     readonly_fields = (
         "score",
         "hot_rank",

--- a/core/migrations/0018_remove_post_url_post_content_url_post_embed_html_and_more.py
+++ b/core/migrations/0018_remove_post_url_post_content_url_post_embed_html_and_more.py
@@ -24,11 +24,6 @@ class Migration(migrations.Migration):
         ),
         migrations.AddField(
             model_name="post",
-            name="embed_html",
-            field=models.TextField(blank=True),
-        ),
-        migrations.AddField(
-            model_name="post",
             name="heading",
             field=models.CharField(blank=True, max_length=500),
         ),

--- a/core/models.py
+++ b/core/models.py
@@ -117,7 +117,6 @@ class Post(models.Model):
     heading = models.CharField(max_length=500, blank=True)
     body = models.TextField(blank=True)
     content_url = models.URLField(blank=True)
-    embed_html = models.TextField(blank=True)
     embed = models.ForeignKey(
         "Embed", null=True, blank=True, on_delete=models.SET_NULL, related_name="posts"
     )
@@ -232,7 +231,6 @@ class Post(models.Model):
         self.heading = ""
         self.body = ""
         self.content_url = ""
-        self.embed_html = ""
         self.link_domain = ""
         if self.image:
             self.image.delete(save=False)
@@ -251,7 +249,6 @@ class Post(models.Model):
                 "heading",
                 "body",
                 "content_url",
-                "embed_html",
                 "link_domain",
                 "image",
                 "image_thumb",

--- a/core/templatetags/embeds.py
+++ b/core/templatetags/embeds.py
@@ -1,0 +1,10 @@
+from django import template
+from core.utils.embeds import build_embed_html as _build_embed_html
+
+register = template.Library()
+
+
+@register.filter
+def build_embed_html(url: str) -> str:
+    """Return embed HTML or a link card for ``url``."""
+    return _build_embed_html(url)

--- a/core/utils/embeds.py
+++ b/core/utils/embeds.py
@@ -32,7 +32,7 @@ def build_embed_html(url: str) -> str:
             f'rel="noopener nofollow">{escape(parsed.netloc)}</a></div>'
         )
 
-    thumb = data.get("thumbnail_url", "")
+    thumb = data.get("thumbnail_url") or ""
     # Prefer secure thumbnails when available
     if thumb.startswith("http://"):
         thumb = "https://" + thumb[len("http://") :]
@@ -41,7 +41,7 @@ def build_embed_html(url: str) -> str:
     src = ""
     if "youtube" in domain:
         vid = None
-        for pattern in [r"v=([\w-]{11})", r"be/([\w-]{11})", r"embed/([\w-]{11})"]:
+        for pattern in [r"v=([\w-]+)", r"be/([\w-]+)", r"embed/([\w-]+)"]:
             m = re.search(pattern, url)
             if m:
                 vid = m.group(1)

--- a/core/views.py
+++ b/core/views.py
@@ -694,10 +694,6 @@ def post_detail(request, community, pk, slug):
         comments = comments.order_by("-score", "path")
 
     images = list(post.image_links.all())
-    has_gallery = bool(images)
-    has_upload = bool(post.image)
-    show_embed = bool(post.content_url) and not (has_gallery or has_upload)
-    embed_html = build_embed_html(post.content_url) if show_embed else ""
 
     severity = None
     band = None
@@ -723,7 +719,6 @@ def post_detail(request, community, pk, slug):
     context = {
         "post": post,
         "comments": comments,
-        "embed_html": embed_html,
         "images": images,
         "c_sort": c_sort,
         "q": q,
@@ -763,10 +758,6 @@ def post_detail_id(request, pk):
         comments = comments.order_by("-score", "path")
 
     images = list(post.image_links.all())
-    has_gallery = bool(images)
-    has_upload = bool(post.image)
-    show_embed = bool(post.content_url) and not (has_gallery or has_upload)
-    embed_html = build_embed_html(post.content_url) if show_embed else ""
 
     severity = None
     band = None
@@ -792,7 +783,6 @@ def post_detail_id(request, pk):
     context = {
         "post": post,
         "comments": comments,
-        "embed_html": embed_html,
         "images": images,
         "c_sort": c_sort,
         "q": q,
@@ -817,10 +807,8 @@ def post_edit(request, pk):
             post = form.save(commit=False)
             if post.content_url:
                 post.link_domain = urlparse(post.content_url).netloc
-                post.embed_html = build_embed_html(post.content_url)
             else:
                 post.link_domain = ""
-                post.embed_html = ""
             post.save()
             messages.success(request, "Post updated")
             return redirect(

--- a/templates/core/partials/post_preview.html
+++ b/templates/core/partials/post_preview.html
@@ -1,3 +1,4 @@
+{% load embeds %}
 <article class="post-preview">
   <h2>{{ post.title }}</h2>
   {% if post.heading %}
@@ -5,12 +6,13 @@
   {% endif %}
   {% if post.image and post.image.url %}
   <div class="post-image"><img src="{{ post.image.url }}" loading="lazy" decoding="async" alt=""></div>
-  {% elif post.embed_html %}
-  <div class="post-embed">{{ post.embed_html|safe }}</div>
   {% elif post.content_url %}
-  <div class="link-card"><a href="{{ post.content_url }}" rel="noopener nofollow">{{ post.link_domain }}</a></div>
+  {{ post.content_url|build_embed_html|safe }}
   {% endif %}
   {% if post.body %}
   <div class="post-caption prose">{{ post.body|safe }}</div>
+  {% endif %}
+  {% if ASTROTURF_WATCH %}
+  <div hx-get="{% url 'post_signals_chips' post.pk %}" hx-trigger="load"></div>
   {% endif %}
 </article>

--- a/templates/core/partials/post_row.html
+++ b/templates/core/partials/post_row.html
@@ -36,5 +36,8 @@
         {% endif %}
       {% endif %}
     </div>
+    {% if ASTROTURF_WATCH %}
+    <div hx-get="{% url 'post_signals_chips' post.pk %}" hx-trigger="load"></div>
+    {% endif %}
   {% endwith %}
 </article>

--- a/templates/core/post_detail.html
+++ b/templates/core/post_detail.html
@@ -1,5 +1,5 @@
 {% extends "core/base.html" %}
-{% load permissions static %}
+{% load permissions static embeds %}
 {% url 'post_detail' post.community.slug post.pk post.slug as post_url %}
 
 {% block head_extra %}
@@ -40,12 +40,8 @@
       onerror="this.onerror=null; this.closest('figure').remove()"
     >
   </figure>
-{% elif embed_html %}
-  <div class="post-embed aspect-16-9">
-    <div class="embed-inner">{{ embed_html|safe }}</div>
-  </div>
 {% elif post.content_url %}
-  <p class="link-card"><a href="{{ post.content_url }}" rel="noopener nofollow">{{ post.content_url }}</a></p>
+  {{ post.content_url|build_embed_html|safe }}
 {% endif %}
 
   {% if post.body %}
@@ -77,6 +73,9 @@
     </div>
   {% else %}
     <em>[deleted by author]</em>
+  {% endif %}
+  {% if ASTROTURF_WATCH %}
+  <div hx-get="{% url 'post_signals_chips' post.pk %}" hx-trigger="load"></div>
   {% endif %}
 </article>
 


### PR DESCRIPTION
## Summary
- remove deprecated `embed_html` column and related admin/migration entries
- build embed markup at request time via new `build_embed_html` template filter
- update post templates to generate embeds and load engagement chips dynamically

## Testing
- `pytest` *(fails: layout, link, rate limit tests)*

------
https://chatgpt.com/codex/tasks/task_e_68baaecf6144832ca4b0921570666a6e