### PR TITLE
Restrict embed and image host whitelists

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -85,8 +85,6 @@ ENABLE_TWITTER_EMBEDS = os.environ.get("ENABLE_TWITTER_EMBEDS", "0") in (
 
 EMBED_WHITELIST = [
     "https://www.youtube.com",
-    "https://www.youtube-nocookie.com",
-    "https://rumble.com",
 ]
 if ENABLE_TWITTER_EMBEDS:
     EMBED_WHITELIST.append("https://platform.twitter.com")
@@ -119,7 +117,8 @@ if not DEBUG:
             "default-src": ("'self'",),
             "script-src": ("'self'",),
             "style-src": ("'self'", "'unsafe-inline'"),
-            "img-src": ("'self'", "https:", "data:"),
+            "img-src": ("'self'", "https://i.ytimg.com", "https://*.twimg.com",
+                        "https://*.rumble.com", "data:"),
             "connect-src": ("'self'",),
             "frame-src": tuple(["'self'"] + EMBED_WHITELIST),
             "frame-ancestors": ("'self'",),


### PR DESCRIPTION
## Summary
- Narrow EMBED_WHITELIST to YouTube and optional Twitter
- Limit CSP img-src to a small set of explicit hosts

## Testing
- `python manage.py test` *(fails: failures=6, errors=47, skipped=2)*

------
https://chatgpt.com/codex/tasks/task_e_68bab9871714832ca85ab991e744d1c2