### PR TITLE
Render embeds in feed listings

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -52,6 +52,7 @@ from .services.votes import (
 )
 from . import mod
 from .http import login_required_htmx
+from .utils.embeds import build_embed_html
 
 
 def _is_banned(user):
@@ -420,6 +421,9 @@ SORT_TABS = [
 def _render_posts(request, posts, next_page, show_community=False, sort_query=""):
     """Render a list of posts and optional pagination link."""
 
+    for post in posts:
+        post.embed_html = build_embed_html(getattr(post, "content_url", "") or "")
+
     html = render_to_string(
         "core/partials/post_list.html",
         {
@@ -454,8 +458,11 @@ def feed_list(request):
         qs = feed_queryset(sort, t, base_qs=base_qs)
         paginator = Paginator(qs, size)
         page_obj = paginator.get_page(page)
+        posts = list(page_obj.object_list)
+        for post in posts:
+            post.embed_html = build_embed_html(post.content_url or "")
         ctx = {
-            "posts": list(page_obj.object_list),
+            "posts": posts,
             "next_page": page_obj.next_page_number() if page_obj.has_next() else None,
             "tab": sort,
             "t": t,
@@ -487,6 +494,8 @@ def home(request):
     posts = list(qs[offset : offset + PAGE_SIZE + 1])
     next_page = page + 1 if len(posts) > PAGE_SIZE else None
     posts = posts[:PAGE_SIZE]
+    for post in posts:
+        post.embed_html = build_embed_html(post.content_url or "")
 
     sort_query = ""
     if sort and sort != "hot":

--- a/templates/core/feed.html
+++ b/templates/core/feed.html
@@ -1,9 +1,18 @@
 {% extends "core/base.html" %}
+{% load static %}
 
 {% block content %}
 {% include "core/partials/feed_controls.html" %}
-<div id="feed-list" hx-get="{% url 'feed_list' %}?tab={{ tab }}{% if t and t != 'all' %}&t={{ t }}{% endif %}" hx-trigger="load" hx-swap="innerHTML">
+<div id="feed-list"
+     hx-get="{% url 'feed_list' %}?tab={{ tab }}{% if t and t != 'all' %}&t={{ t }}{% endif %}"
+     hx-trigger="load" hx-swap="innerHTML"
+     hx-on="htmx:afterSwap:window.initEmbeds && window.initEmbeds(this)">
   <div class="skeleton" style="height:80px;margin-bottom:1rem;"></div>
   <div class="skeleton" style="height:80px;"></div>
 </div>
+{% endblock %}
+
+{% block scripts %}
+{{ block.super }}
+<script src="{% static 'js/embeds.js' %}" defer></script>
 {% endblock %}

--- a/templates/core/home.html
+++ b/templates/core/home.html
@@ -1,4 +1,5 @@
 {% extends "core/base.html" %}
+{% load static %}
 {% block header_center %}
   <a href="?sort=hot"{% if request.GET.sort|default:'hot' == 'hot' %} aria-current="page"{% endif %}>Hot</a>
   <a href="?sort=new"{% if request.GET.sort == 'new' %} aria-current="page"{% endif %}>New</a>
@@ -8,7 +9,13 @@
 <section aria-labelledby="feed-heading">
   {# optional: replace a “Feed” title #}
   <h1 id="feed-heading" class="sr-only">Home</h1>
-  {% include "core/partials/post_list.html" with posts=posts next_page=next_page sort_query=sort_query %}
+  <div id="feed-list" hx-on="htmx:afterSwap:window.initEmbeds && window.initEmbeds(this)">
+    {% include "core/partials/post_list.html" with posts=posts next_page=next_page sort_query=sort_query %}
+  </div>
 </section>
 {% endblock %}
 
+{% block scripts %}
+{{ block.super }}
+<script src="{% static 'js/embeds.js' %}" defer></script>
+{% endblock %}

--- a/templates/core/partials/post_row.html
+++ b/templates/core/partials/post_row.html
@@ -19,6 +19,9 @@
     {% if post.excerpt %}
     <p class="post-excerpt">{{ post.excerpt }}</p>
     {% endif %}
+    {% if post.embed_html %}
+    {{ post.embed_html|safe }}
+    {% endif %}
     <div class="post-actions">
       {% if show_vote_widget is not False %}
         {% include "core/partials/vote_widget.html" with post=post user=user request=request only %}

--- a/templates/partials/feed_card.html
+++ b/templates/partials/feed_card.html
@@ -26,10 +26,13 @@
   <h3 class="post-title"><a href="{{ detail_url }}">{{ post.title }}</a></h3>
   {% if post.is_deleted %}<span class="state-badge">deleted</span>{% endif %}
   {% if post.is_draft %}<span class="state-badge">draft</span>{% endif %}
-  {% if post.excerpt %}
-  <p class="post-excerpt">{{ post.excerpt }}</p>
-  {% endif %}
-  <div class="post-actions">
+    {% if post.excerpt %}
+    <p class="post-excerpt">{{ post.excerpt }}</p>
+    {% endif %}
+    {% if post.embed_html %}
+    {{ post.embed_html|safe }}
+    {% endif %}
+    <div class="post-actions">
     {% if show_vote_widget is not False %}
       {% include "core/partials/vote_widget.html" with post=post user=user request=request only %}
     {% else %}


### PR DESCRIPTION
## Summary
- build embed HTML for posts in feed and home views
- render embedded content in feed cards and post rows
- load embeds.js on feed pages and init embeds after HTMX swaps

## Testing
- `pytest -q` *(fails: OperationalError near "EXISTS" dropping column during migrations)*

------
https://chatgpt.com/codex/tasks/task_e_68bac2467408832c912860bd68d6c714