### PR TITLE
Precompute embed HTML for post content

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -709,6 +709,8 @@ def post_detail(request, community, pk, slug):
         else:
             band = "red"
 
+    embed_html = build_embed_html(post.content_url or "")
+
     context = {
         "post": post,
         "comments": comments,
@@ -717,6 +719,7 @@ def post_detail(request, community, pk, slug):
         "q": q,
         "severity": severity,
         "severity_band": band,
+        "embed_html": embed_html,
     }
     return render(request, "core/post_detail.html", context)
 
@@ -773,6 +776,8 @@ def post_detail_id(request, pk):
         else:
             band = "red"
 
+    embed_html = build_embed_html(post.content_url or "")
+
     context = {
         "post": post,
         "comments": comments,
@@ -781,6 +786,7 @@ def post_detail_id(request, pk):
         "q": q,
         "severity": severity,
         "severity_band": band,
+        "embed_html": embed_html,
     }
     return render(request, "core/post_detail.html", context)
 

--- a/templates/core/post_detail.html
+++ b/templates/core/post_detail.html
@@ -1,5 +1,5 @@
 {% extends "core/base.html" %}
-{% load permissions static embeds %}
+{% load permissions static %}
 {% url 'post_detail' post.community.slug post.pk post.slug as post_url %}
 
 {% block head_extra %}
@@ -41,7 +41,7 @@
     >
   </figure>
 {% elif post.content_url %}
-  {{ post.content_url|build_embed_html|safe }}
+  {{ embed_html|safe }}
 {% endif %}
 
   {% if post.body %}


### PR DESCRIPTION
## Summary
- Precompute embed HTML in `post_detail` and `post_detail_id` views and pass into template context
- Render precomputed embed HTML in the post detail template
- Ensure `embeds.js` remains loaded for click-to-play embeds

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'core'; django ImproperlyConfigured)*

------
https://chatgpt.com/codex/tasks/task_e_68bac3acdfb0832c9dfe413de9548515