### PR TITLE
Add OG thumbnail scraper with SVG placeholder fallback

### DIFF
--- a/core/tests/test_thumbnails.py
+++ b/core/tests/test_thumbnails.py
@@ -1,0 +1,26 @@
+from unittest.mock import patch, Mock
+
+from core.utils.thumbnails import resolve_thumbnail
+
+
+def _mock_response(text: str) -> Mock:
+    resp = Mock()
+    resp.text = text
+    resp.raise_for_status = lambda: None
+    return resp
+
+
+def test_scraper_returns_og_image_url():
+    html = "<html><head><meta property='og:image' content='https://cdn.example/img.jpg'></head></html>"
+    with patch("core.utils.thumbnails.requests.get", return_value=_mock_response(html)) as mock_get:
+        url = "https://example.com"
+        assert resolve_thumbnail(url, "Preview") == "https://cdn.example/img.jpg"
+        mock_get.assert_called_once_with(url, timeout=5)
+
+
+def test_placeholder_returned_when_missing():
+    html = "<html><head></head><body>No OG tags here</body></html>"
+    with patch("core.utils.thumbnails.requests.get", return_value=_mock_response(html)):
+        result = resolve_thumbnail("https://example.com", "Tweet preview")
+        assert result.startswith("data:image/svg+xml")
+        assert "Tweet preview" in result

--- a/core/utils/embeds.py
+++ b/core/utils/embeds.py
@@ -7,6 +7,7 @@ from django.conf import settings
 from django.utils.html import escape
 
 from core.oembed import fetch_oembed
+from core.utils.thumbnails import svg_placeholder
 
 
 def build_embed_html(url: str) -> str:
@@ -81,17 +82,7 @@ def build_embed_html(url: str) -> str:
         # 3) Thumbnail fallback: when oEmbed misses it, use a tiny inline SVG
         #    (keeps CSP-friendly, no external host needed)
         if not thumb:
-            svg = (
-                "data:image/svg+xml;utf8,"
-                "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1200 675'>"
-                "<rect width='1200' height='675' fill='%23e5e5e5'/>"
-                "<circle cx='600' cy='337' r='120' fill='%23999'/>"
-                "<polygon points='560,277 560,397 660,337' fill='white'/>"
-                "<text x='50%' y='90%' dominant-baseline='middle' text-anchor='middle' "
-                "font-family='system-ui, sans-serif' font-size='40' fill='%23666'>Rumble preview</text>"
-                "</svg>"
-            )
-            thumb = svg
+            thumb = svg_placeholder("Rumble preview")
 
         return (
             f'<div class="post-embed" data-src="{escape(src)}" '

--- a/core/utils/thumbnails.py
+++ b/core/utils/thumbnails.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import html
+import re
+from typing import Optional
+
+import requests
+
+OG_IMAGE_RE = re.compile(r"<meta\s+property=['\"]og:image['\"]\s+content=['\"]([^'\"]+)['\"]", re.IGNORECASE)
+
+
+def scrape_og_image(url: str) -> Optional[str]:
+    """Return the first OpenGraph image URL for ``url`` if present."""
+    try:
+        resp = requests.get(url, timeout=5)
+        resp.raise_for_status()
+    except Exception:
+        return None
+
+    match = OG_IMAGE_RE.search(resp.text)
+    if match:
+        return match.group(1)
+    return None
+
+
+def svg_placeholder(label: str) -> str:
+    """Return a small inline SVG placeholder data URI with ``label`` text."""
+    text = html.escape(label or "")
+    return (
+        "data:image/svg+xml;utf8,"
+        "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1200 675'>"
+        "<rect width='1200' height='675' fill='%23e5e5e5'/>"
+        f"<text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' "
+        f"font-family='system-ui, sans-serif' font-size='40' fill='%23666'>{text}</text>"
+        "</svg>"
+    )
+
+
+def resolve_thumbnail(url: str, label: str) -> str:
+    """Return OG image for ``url`` or a placeholder SVG when missing."""
+    return scrape_og_image(url) or svg_placeholder(label)


### PR DESCRIPTION
## Summary
- add `core/utils/thumbnails` helper to fetch first Open Graph image
- provide `svg_placeholder` function for inline preview labels
- simplify Rumble fallback thumbnail via shared helper
- test OG image scraping and SVG fallback behavior

## Testing
- `pytest` *(fails: ModuleNotFoundError, django settings not configured)*
- `pytest core/tests/test_thumbnails.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb61f87bb8832cbcdae733d149559d