### PR TITLE
Use OG image fallback for embeds

### DIFF
--- a/core/tests/test_post_detail_media.py
+++ b/core/tests/test_post_detail_media.py
@@ -38,6 +38,29 @@ class PostDetailMediaTests(TestCase):
             resp, 'src="https://img.youtube.com/vi/abc/hqdefault.jpg"'
         )
 
+    @patch("core.utils.embeds.fetch_og_image")
+    @patch("core.utils.embeds.fetch_oembed")
+    def test_embed_uses_og_image_when_no_thumbnail(
+        self, mock_oembed, mock_fetch_og_image
+    ):
+        mock_oembed.return_value = {
+            "type": "embed",
+            "html": '<iframe src="https://www.youtube.com/embed/abc"></iframe>',
+            "thumbnail_url": None,
+        }
+        mock_fetch_og_image.return_value = "https://cdn.example/og.jpg"
+        post = Post.objects.create(
+            community=self.community,
+            author=self.user,
+            post_type="link",
+            title="Video OG",
+            content_url="https://www.youtube.com/watch?v=abc",
+        )
+        resp = self.client.get(
+            reverse("post_detail", args=[self.community.slug, post.pk, post.slug])
+        )
+        self.assertContains(resp, 'src="https://cdn.example/og.jpg"')
+
     @patch("core.utils.embeds.fetch_oembed")
     def test_rumble_embed_has_placeholder(self, mock_oembed):
         mock_oembed.return_value = {

--- a/core/utils/embeds.py
+++ b/core/utils/embeds.py
@@ -7,7 +7,7 @@ from django.conf import settings
 from django.utils.html import escape
 
 from core.oembed import fetch_oembed
-from core.utils.thumbnails import svg_placeholder
+from core.utils.thumbnails import fetch_og_image, svg_placeholder
 
 
 def build_embed_html(url: str) -> str:
@@ -33,15 +33,12 @@ def build_embed_html(url: str) -> str:
             f'rel="noopener nofollow">{escape(parsed.netloc)}</a></div>'
         )
 
-    thumb = data.get("thumbnail_url") or ""
-    # Prefer secure thumbnails when available
-    if thumb.startswith("http://"):
-        thumb = "https://" + thumb[len("http://") :]
     html = data.get("html", "")
 
     src = ""
+    placeholder_label = "Preview"
+    vid = None
     if "youtube" in domain:
-        vid = None
         for pattern in [r"v=([\w-]+)", r"be/([\w-]+)", r"embed/([\w-]+)"]:
             m = re.search(pattern, url)
             if m:
@@ -56,9 +53,8 @@ def build_embed_html(url: str) -> str:
                 f'<div class="link-card"><a href="{escape(url)}" '
                 f'rel="noopener nofollow">{escape(parsed.netloc)}</a></div>'
             )
-        if not thumb:
-            thumb = f"https://i.ytimg.com/vi/{vid}/hqdefault.jpg"
         src = f"https://www.youtube-nocookie.com/embed/{vid}"
+        placeholder_label = "YouTube preview"
     elif "rumble.com" in domain:
         # 1) Try to read iframe src from the provider HTML (support " and ' quotes)
         m = re.search(r"src=['\"]([^'\"]+)['\"]", html or "")
@@ -78,22 +74,7 @@ def build_embed_html(url: str) -> str:
                 f'<div class="link-card"><a href="{escape(url)}" '
                 f'rel="noopener nofollow">{escape(parsed.netloc)}</a></div>'
             )
-
-        # 3) Thumbnail fallback: when oEmbed misses it, use a tiny inline SVG
-        #    (keeps CSP-friendly, no external host needed)
-        if not thumb:
-            thumb = svg_placeholder("Rumble preview")
-
-        return (
-            f'<div class="post-embed" data-src="{escape(src)}" '
-            f'style="position:relative;padding-top:56.25%;overflow:hidden;">'
-            f'  <a href="{escape(url)}" rel="noopener nofollow" '
-            f'style="position:absolute;top:0;left:0;width:100%;height:100%;display:block;">'
-            f'    <img src="{escape(thumb)}" alt="" loading="lazy" decoding="async" '
-            f'referrerpolicy="no-referrer" style="width:100%;height:100%;object-fit:cover;">'
-            f'  </a>'
-            f'</div>'
-        )
+        placeholder_label = "Rumble preview"
     elif "twitter.com" in domain or "x.com" in domain:
         if not getattr(settings, "ENABLE_TWITTER_EMBEDS", False):
             return (
@@ -107,24 +88,26 @@ def build_embed_html(url: str) -> str:
                 f'rel="noopener nofollow">{escape(parsed.netloc)}</a></div>'
             )
         src = f"https://platform.twitter.com/embed/Tweet.html?id={m.group(1)}"
+        placeholder_label = "Tweet preview"
     else:
         return (
             f'<div class="link-card"><a href="{escape(url)}" '
             f'rel="noopener nofollow">{escape(parsed.netloc)}</a></div>'
         )
-
-    thumb_html = (
-        f'<img src="{escape(thumb)}" alt="" loading="lazy" decoding="async" '
-        'referrerpolicy="no-referrer" '
-        'style="width:100%;height:100%;object-fit:cover;">'
-        if thumb
-        else ""
-    )
+    thumb = data.get("thumbnail_url") or fetch_og_image(url)
+    if not thumb and "youtube" in domain and vid:
+        thumb = f"https://i.ytimg.com/vi/{vid}/hqdefault.jpg"
+    if not thumb:
+        thumb = svg_placeholder(placeholder_label)
+    if thumb.startswith("http://"):
+        thumb = "https://" + thumb[len("http://") :]
 
     return (
         f'<div class="post-embed" data-src="{escape(src)}" '
         'style="position:relative;padding-top:56.25%;overflow:hidden;">'
         f'<a href="{escape(url)}" rel="noopener nofollow" '
         'style="position:absolute;top:0;left:0;width:100%;height:100%;display:block;">'
-        f'{thumb_html}</a></div>'
+        f'<img src="{escape(thumb)}" alt="" loading="lazy" decoding="async" '
+        'referrerpolicy="no-referrer" style="width:100%;height:100%;object-fit:cover;">'
+        '</a></div>'
     )

--- a/core/utils/thumbnails.py
+++ b/core/utils/thumbnails.py
@@ -23,6 +23,15 @@ def scrape_og_image(url: str) -> Optional[str]:
     return None
 
 
+def fetch_og_image(url: str) -> Optional[str]:
+    """Fetch the OpenGraph image for ``url``.
+
+    A light wrapper around :func:`scrape_og_image` that is easier to mock in
+    tests. Returns ``None`` when no OG image is available or fetching fails.
+    """
+    return scrape_og_image(url)
+
+
 def svg_placeholder(label: str) -> str:
     """Return a small inline SVG placeholder data URI with ``label`` text."""
     text = html.escape(label or "")


### PR DESCRIPTION
## Summary
- add `fetch_og_image` helper wrapping og-image scraping
- use OG image fallback for embed thumbnails and always render `<img>`
- test using OG image when `thumbnail_url` missing

## Testing
- `pytest` *(fails: sqlite3.OperationalError: near "EXISTS": syntax error)*

------
https://chatgpt.com/codex/tasks/task_e_68bb62ca22d8832c8af954489a8966b2