### PR TITLE
Use OG image fallback for Twitter embeds without thumbnails

### DIFF
--- a/core/tests/test_post_detail_media.py
+++ b/core/tests/test_post_detail_media.py
@@ -151,6 +151,30 @@ class PostDetailMediaTests(TestCase):
         self.assertContains(resp, 'href="https://x.com/user/status/123"')
         self.assertContains(resp, 'src="http://pbs.twimg.com/thumb.jpg"')
 
+    @override_settings(ENABLE_TWITTER_EMBEDS=True)
+    @patch("core.utils.embeds.fetch_og_image")
+    @patch("core.utils.embeds.fetch_oembed")
+    def test_twitter_embed_uses_og_image_when_no_thumbnail(
+        self, mock_oembed, mock_fetch_og_image
+    ):
+        mock_oembed.return_value = {
+            "type": "embed",
+            "html": "<blockquote></blockquote>",
+            "thumbnail_url": None,
+        }
+        mock_fetch_og_image.return_value = "https://cdn.example/og.jpg"
+        post = Post.objects.create(
+            community=self.community,
+            author=self.user,
+            post_type="link",
+            title="Tweet OG",
+            content_url="https://x.com/user/status/123",
+        )
+        resp = self.client.get(
+            reverse("post_detail", args=[self.community.slug, post.pk, post.slug])
+        )
+        self.assertContains(resp, 'src="https://cdn.example/og.jpg"')
+
     def test_image_slideshow_renders(self):
         post = Post.objects.create(
             community=self.community,

--- a/core/utils/embeds.py
+++ b/core/utils/embeds.py
@@ -35,6 +35,8 @@ def build_embed_html(url: str) -> str:
 
     html = data.get("html", "")
 
+    thumb = data.get("thumbnail_url") or fetch_og_image(url)
+
     src = ""
     placeholder_label = "Preview"
     vid = None
@@ -94,7 +96,6 @@ def build_embed_html(url: str) -> str:
             f'<div class="link-card"><a href="{escape(url)}" '
             f'rel="noopener nofollow">{escape(parsed.netloc)}</a></div>'
         )
-    thumb = data.get("thumbnail_url") or fetch_og_image(url)
     if not thumb and "youtube" in domain and vid:
         thumb = f"https://i.ytimg.com/vi/{vid}/hqdefault.jpg"
     if not thumb:


### PR DESCRIPTION
## Summary
- ensure embed builder grabs `thumbnail_url` or OG image before building Twitter embed
- fall back to SVG placeholder when no thumbnail is available
- test Twitter OG-image fallback when oEmbed lacks `thumbnail_url`

## Testing
- `python manage.py test core.tests.test_post_detail_media.PostDetailMediaTests.test_twitter_embed_uses_og_image_when_no_thumbnail -v 2` *(fails: django.db.utils.OperationalError: near "EXISTS": syntax error)*

------
https://chatgpt.com/codex/tasks/task_e_68bb64c5c3fc832c92d2d17f0748be5a