### PR TITLE
Add User-Agent header for OG image scraping

### DIFF
--- a/core/utils/thumbnails.py
+++ b/core/utils/thumbnails.py
@@ -12,7 +12,11 @@ OG_IMAGE_RE = re.compile(r"<meta\s+property=['\"]og:image['\"]\s+content=['\"]([
 def scrape_og_image(url: str) -> Optional[str]:
     """Return the first OpenGraph image URL for ``url`` if present."""
     try:
-        resp = requests.get(url, timeout=5)
+        resp = requests.get(
+            url,
+            timeout=5,
+            headers={"User-Agent": "Mozilla/5.0 (compatible; SureJanBot/1.0)"},
+        )
         resp.raise_for_status()
     except Exception:
         return None


### PR DESCRIPTION
## Summary
- include a User-Agent header when scraping OpenGraph images

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'core')*

------
https://chatgpt.com/codex/tasks/task_e_68bb6c641f24832c89bbf1c7ee409703