### PR TITLE
Enable Twitter embeds

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -14,6 +14,8 @@ The `ASTROTURF_WATCH` environment variable (default `1`) controls all
 astroturf-detection features. Set `ASTROTURF_WATCH=0` to hide engagement
 chips and block transparency pages; related endpoints will return 404.
 
+Set `ENABLE_TWITTER_EMBEDS=True` via Fly secrets or environment variables to allow tweet embeds to render properly.
+
 ### Moderation
 
 Staff can remove posts without deleting them, lock conversations, or

--- a/fly.toml
+++ b/fly.toml
@@ -14,6 +14,7 @@ primary_region = "syd"
   AWS_S3_ENDPOINT_URL = "https://fly.storage.tigris.dev"
   AWS_S3_REGION_NAME = "auto"
   MEDIA_URL = "https://your-bucket-url/"
+  ENABLE_TWITTER_EMBEDS = "True"
 
 [deploy]
   release_command = "python manage.py migrate --noinput"


### PR DESCRIPTION
## Summary
- set `ENABLE_TWITTER_EMBEDS=True` in Fly config
- document Twitter embeds env requirement in deployment notes

## Testing
- `python manage.py test` *(fails: django.db.utils.OperationalError: near "EXISTS": syntax error)*

------
https://chatgpt.com/codex/tasks/task_e_68bb6d230c7c832ca8cddc3a16f7d7e3