### PR TITLE
Allow additional image hosts

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -123,7 +123,7 @@ if not DEBUG:
                 "https://i.ytimg.com",
                 "https://*.twimg.com",
                 "https://*.rumble.com",
-                "https://rumblecdn.com",
+                "https://*.rumblecdn.com",
                 "data:",
             ),
             "connect-src": ("'self'",),

--- a/tests/test_csp_header.py
+++ b/tests/test_csp_header.py
@@ -10,7 +10,7 @@ def test_csp_header_includes_rumble_hosts(client):
                 "https://i.ytimg.com",
                 "https://*.twimg.com",
                 "https://*.rumble.com",
-                "https://rumblecdn.com",
+                "https://*.rumblecdn.com",
                 "data:",
             )
         }
@@ -19,4 +19,4 @@ def test_csp_header_includes_rumble_hosts(client):
         resp = client.get("/healthz")
     csp_header = resp["Content-Security-Policy"]
     assert "https://*.rumble.com" in csp_header
-    assert "https://rumblecdn.com" in csp_header
+    assert "https://*.rumblecdn.com" in csp_header


### PR DESCRIPTION
## Summary
- allow rumble CDN subdomains in CSP `img-src`
- update CSP test to expect wildcard host

## Testing
- `pytest tests/test_csp_header.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb6e0df9dc832cbf5a88112eadf724