### PR TITLE
Render embed HTML in feed card and guard duplicates

### DIFF
--- a/templates/partials/feed_card.html
+++ b/templates/partials/feed_card.html
@@ -20,6 +20,9 @@
       {% endif %}
     </a>
   {% endif %}
+  {% if embed_html %}
+  {{ embed_html|safe }}
+  {% endif %}
   <div class="post-meta">
     <a href="{% url 'community' post.community.slug %}">r/{{ post.community.slug }}</a> · {{ post.author.username }} · {{ post.created_at|timesince }} ago
   </div>
@@ -29,7 +32,7 @@
     {% if post.excerpt %}
     <p class="post-excerpt">{{ post.excerpt }}</p>
     {% endif %}
-    {% if post.embed_html %}
+    {% if post.embed_html and not embed_html %}
     {{ post.embed_html|safe }}
     {% endif %}
     <div class="post-actions">


### PR DESCRIPTION
## Summary
- display `embed_html` after post image in feed cards
- avoid rendering `post.embed_html` when `embed_html` is present to prevent duplicate previews

## Testing
- `pytest` *(fails: django.core.exceptions.ImproperlyConfigured: Requested setting INSTALLED_APPS, but settings are not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68bb704b6e30832c86ae684990193d90