### PR TITLE
Add browser-like headers to OG scraper and test 403 fallback

### DIFF
--- a/core/tests/test_thumbnails.py
+++ b/core/tests/test_thumbnails.py
@@ -1,6 +1,8 @@
 from unittest.mock import patch, Mock
 
-from core.utils.thumbnails import resolve_thumbnail
+import requests
+
+from core.utils.thumbnails import resolve_thumbnail, scrape_og_image, REQUEST_HEADERS
 
 
 def _mock_response(text: str) -> Mock:
@@ -10,12 +12,20 @@ def _mock_response(text: str) -> Mock:
     return resp
 
 
+def _mock_error_response(status_code: int) -> Mock:
+    resp = Mock()
+    def raise_error():
+        raise requests.HTTPError(response=Mock(status_code=status_code))
+    resp.raise_for_status = raise_error
+    return resp
+
+
 def test_scraper_returns_og_image_url():
     html = "<html><head><meta property='og:image' content='https://cdn.example/img.jpg'></head></html>"
     with patch("core.utils.thumbnails.requests.get", return_value=_mock_response(html)) as mock_get:
         url = "https://example.com"
         assert resolve_thumbnail(url, "Preview") == "https://cdn.example/img.jpg"
-        mock_get.assert_called_once_with(url, timeout=5)
+        mock_get.assert_called_once_with(url, timeout=5, headers=REQUEST_HEADERS)
 
 
 def test_placeholder_returned_when_missing():
@@ -24,3 +34,12 @@ def test_placeholder_returned_when_missing():
         result = resolve_thumbnail("https://example.com", "Tweet preview")
         assert result.startswith("data:image/svg+xml")
         assert "Tweet preview" in result
+
+
+def test_fallback_when_request_forbidden():
+    url = "https://example.com"
+    with patch("core.utils.thumbnails.requests.get", return_value=_mock_error_response(403)):
+        assert scrape_og_image(url) is None
+        result = resolve_thumbnail(url, "Forbidden")
+        assert result.startswith("data:image/svg+xml")
+        assert "Forbidden" in result

--- a/core/utils/thumbnails.py
+++ b/core/utils/thumbnails.py
@@ -8,15 +8,21 @@ import requests
 
 OG_IMAGE_RE = re.compile(r"<meta\s+property=['\"]og:image['\"]\s+content=['\"]([^'\"]+)['\"]", re.IGNORECASE)
 
+# Headers used when scraping remote pages for OpenGraph images. A realistic
+# browser-like User-Agent and Accept-Language help avoid some bot protections.
+REQUEST_HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+        "(KHTML, like Gecko) Chrome/120.0 Safari/537.36"
+    ),
+    "Accept-Language": "en-US,en;q=0.9",
+}
+
 
 def scrape_og_image(url: str) -> Optional[str]:
     """Return the first OpenGraph image URL for ``url`` if present."""
     try:
-        resp = requests.get(
-            url,
-            timeout=5,
-            headers={"User-Agent": "Mozilla/5.0 (compatible; SureJanBot/1.0)"},
-        )
+        resp = requests.get(url, timeout=5, headers=REQUEST_HEADERS)
         resp.raise_for_status()
     except Exception:
         return None


### PR DESCRIPTION
## Summary
- use realistic User-Agent and Accept-Language headers when scraping OG images
- test header usage and 403 forbidden fallback to SVG placeholder

## Testing
- `pytest -q --maxfail=1` *(fails: django.db.utils.OperationalError: near "EXISTS": syntax error)*
- `pytest core/tests/test_thumbnails.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb7377baf4832cb9f04c191d5ff25c