### PR TITLE
feat: document twitter embed flag

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -32,6 +32,12 @@ PY
   echo "Set SECRET_KEY."
 fi
 
+# Ensure ENABLE_TWITTER_EMBEDS is enabled for tweet rendering
+if ! fly secrets list 2>/dev/null | awk '{print $1}' | grep -q '^ENABLE_TWITTER_EMBEDS$'; then
+  fly secrets set ENABLE_TWITTER_EMBEDS=True >/dev/null
+  echo "Set ENABLE_TWITTER_EMBEDS=True."
+fi
+
 # Deploy using the committed Dockerfile
 fly deploy --remote-only --dockerfile Dockerfile "$@"
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -16,6 +16,12 @@ chips and block transparency pages; related endpoints will return 404.
 
 Set `ENABLE_TWITTER_EMBEDS=True` via Fly secrets or environment variables to allow tweet embeds to render properly.
 
+```bash
+fly secrets set ENABLE_TWITTER_EMBEDS=True
+```
+
+`fly.toml` includes this flag in the `[env]` section so tweets render in production.
+
 ### Moderation
 
 Staff can remove posts without deleting them, lock conversations, or


### PR DESCRIPTION
## Summary
- ensure ENABLE_TWITTER_EMBEDS secret is set during Fly deploys
- document Twitter embed flag in deployment guide

## Testing
- `make test` *(fails: near "EXISTS": syntax error)*

------
https://chatgpt.com/codex/tasks/task_e_68bb745aa394832c8b315bf1eb05a9cc