### PR TITLE
Ensure single link previews and accessible thumbnails

### DIFF
--- a/core/tests/test_thumbnails.py
+++ b/core/tests/test_thumbnails.py
@@ -24,22 +24,26 @@ def test_scraper_returns_og_image_url():
     html = "<html><head><meta property='og:image' content='https://cdn.example/img.jpg'></head></html>"
     with patch("core.utils.thumbnails.requests.get", return_value=_mock_response(html)) as mock_get:
         url = "https://example.com"
-        assert resolve_thumbnail(url, "Preview") == "https://cdn.example/img.jpg"
+        src, alt = resolve_thumbnail(url, "Preview")
+        assert src == "https://cdn.example/img.jpg"
+        assert alt == "Preview"
         mock_get.assert_called_once_with(url, timeout=5, headers=REQUEST_HEADERS)
 
 
 def test_placeholder_returned_when_missing():
     html = "<html><head></head><body>No OG tags here</body></html>"
     with patch("core.utils.thumbnails.requests.get", return_value=_mock_response(html)):
-        result = resolve_thumbnail("https://example.com", "Tweet preview")
-        assert result.startswith("data:image/svg+xml")
-        assert "Tweet preview" in result
+        src, alt = resolve_thumbnail("https://example.com", "Tweet preview")
+        assert src.startswith("data:image/svg+xml")
+        assert "Tweet preview" in src
+        assert alt == "Preview image unavailable"
 
 
 def test_fallback_when_request_forbidden():
     url = "https://example.com"
     with patch("core.utils.thumbnails.requests.get", return_value=_mock_error_response(403)):
         assert scrape_og_image(url) is None
-        result = resolve_thumbnail(url, "Forbidden")
-        assert result.startswith("data:image/svg+xml")
-        assert "Forbidden" in result
+        src, alt = resolve_thumbnail(url, "Forbidden")
+        assert src.startswith("data:image/svg+xml")
+        assert "Forbidden" in src
+        assert alt == "Preview image unavailable"

--- a/core/utils/embeds.py
+++ b/core/utils/embeds.py
@@ -36,6 +36,7 @@ def build_embed_html(url: str) -> str:
     html = data.get("html", "")
 
     thumb = data.get("thumbnail_url") or fetch_og_image(url)
+    thumb_alt = "Preview image unavailable"
 
     src = ""
     placeholder_label = "Preview"
@@ -98,8 +99,11 @@ def build_embed_html(url: str) -> str:
         )
     if not thumb and "youtube" in domain and vid:
         thumb = f"https://i.ytimg.com/vi/{vid}/hqdefault.jpg"
+        thumb_alt = placeholder_label
     if not thumb:
-        thumb = svg_placeholder(placeholder_label)
+        thumb, thumb_alt = svg_placeholder(placeholder_label, placeholder_label)
+    else:
+        thumb_alt = placeholder_label
     if thumb.startswith("http://"):
         thumb = "https://" + thumb[len("http://") :]
 
@@ -108,7 +112,7 @@ def build_embed_html(url: str) -> str:
         'style="position:relative;padding-top:56.25%;overflow:hidden;">'
         f'<a href="{escape(url)}" rel="noopener nofollow" '
         'style="position:absolute;top:0;left:0;width:100%;height:100%;display:block;">'
-        f'<img src="{escape(thumb)}" alt="" loading="lazy" decoding="async" '
+        f'<img src="{escape(thumb)}" alt="{escape(thumb_alt)}" loading="lazy" decoding="async" '
         'referrerpolicy="no-referrer" style="width:100%;height:100%;object-fit:cover;">'
         '</a></div>'
     )

--- a/core/utils/thumbnails.py
+++ b/core/utils/thumbnails.py
@@ -42,10 +42,11 @@ def fetch_og_image(url: str) -> Optional[str]:
     return scrape_og_image(url)
 
 
-def svg_placeholder(label: str) -> str:
-    """Return a small inline SVG placeholder data URI with ``label`` text."""
+def svg_placeholder(label: str, alt: str | None = None) -> tuple[str, str]:
+    """Return a small inline SVG placeholder and its alt text."""
     text = html.escape(label or "")
-    return (
+    alt_text = alt or "Preview image unavailable"
+    uri = (
         "data:image/svg+xml;utf8,"
         "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1200 675'>"
         "<rect width='1200' height='675' fill='%23e5e5e5'/>"
@@ -53,8 +54,12 @@ def svg_placeholder(label: str) -> str:
         f"font-family='system-ui, sans-serif' font-size='40' fill='%23666'>{text}</text>"
         "</svg>"
     )
+    return uri, alt_text
 
 
-def resolve_thumbnail(url: str, label: str) -> str:
-    """Return OG image for ``url`` or a placeholder SVG when missing."""
-    return scrape_og_image(url) or svg_placeholder(label)
+def resolve_thumbnail(url: str, label: str) -> tuple[str, str]:
+    """Return OG image and alt text or a placeholder when missing."""
+    og = scrape_og_image(url)
+    if og:
+        return og, label
+    return svg_placeholder(label)

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -272,12 +272,12 @@ body.layout-root {
   border-radius:12px;
   overflow:hidden;
   background:#f2f2f2;
+  aspect-ratio:16/9;      /* prevents layout shift */
 }
 .post-card .thumb img{
   display:block;
   width:100%;
-  height:auto;
-  aspect-ratio:16/9;      /* prevents layout shift */
+  height:100%;
   object-fit:cover;        /* fill the frame */
 }
 

--- a/templates/partials/feed_card.html
+++ b/templates/partials/feed_card.html
@@ -3,8 +3,12 @@
 {% with detail_url=post.get_absolute_url|default:None embed_html=post.content_url|build_embed_html %}
   {% if not detail_url %}{% url 'post_detail_id' post.pk as detail_url %}{% endif %}
 
-  {% if post.image_thumb or post.image %}
-    <a href="{{ detail_url }}" class="thumb" aria-label="Open post">
+  {% if embed_html %}
+    <div class="thumb" style="aspect-ratio:16/9;">
+      {{ embed_html|safe }}
+    </div>
+  {% elif post.image_thumb or post.image %}
+    <a href="{{ detail_url }}" class="thumb" style="aspect-ratio:16/9;" aria-label="Open post">
       {% if post.image_thumb %}
         <img
           src="{{ post.image_thumb.url }}"
@@ -19,9 +23,6 @@
           width="640" height="360">
       {% endif %}
     </a>
-  {% endif %}
-  {% if embed_html %}
-  {{ embed_html|safe }}
   {% endif %}
   <div class="post-meta">
     <a href="{% url 'community' post.community.slug %}">r/{{ post.community.slug }}</a> · {{ post.author.username }} · {{ post.created_at|timesince }} ago


### PR DESCRIPTION
## Summary
- Render only one thumbnail for link posts and wrap media previews in a `.thumb` container
- Generate SVG placeholders with configurable alt text and default to "Preview image unavailable"
- Adjust feed card CSS to keep thumbnail aspect ratios consistent

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb772af454832c8ed6689a719fe8e1