### PR TITLE
chore: centralize CSP hosts and document env vars

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -83,12 +83,16 @@ ENABLE_TWITTER_EMBEDS = os.environ.get("ENABLE_TWITTER_EMBEDS", "0") in (
     "True",
 )
 
-EMBED_WHITELIST = [
-    "https://www.youtube-nocookie.com",
-    "https://rumble.com",
+# CSP whitelists
+_csp_frame_src = ["https://www.youtube-nocookie.com", "https://rumble.com"]
+_csp_img_src = [
+    "https://i.ytimg.com",
+    "https://*.rumble.com",
+    "https://*.rumblecdn.com",
 ]
 if ENABLE_TWITTER_EMBEDS:
-    EMBED_WHITELIST.append("https://platform.twitter.com")
+    _csp_frame_src.append("https://platform.twitter.com")
+    _csp_img_src.append("https://*.twimg.com")
 
 # Simple per-user rate limits
 RATE_POSTS_PER_DAY_NEW = int(os.getenv("RATE_POSTS_PER_DAY_NEW", "10"))
@@ -118,17 +122,9 @@ if not DEBUG:
             "default-src": ("'self'",),
             "script-src": ("'self'",),
             "style-src": ("'self'", "'unsafe-inline'"),
-            "img-src": (
-                "'self'",
-                "https:",
-                "https://*.twimg.com",
-                "https://i.ytimg.com",
-                "https://*.rumble.com",
-                "https://*.rumblecdn.com",
-                "data:",
-            ),
+            "img-src": tuple(["'self'", "https:"] + _csp_img_src + ["data:"]),
             "connect-src": ("'self'",),
-            "frame-src": tuple(["'self'"] + EMBED_WHITELIST),
+            "frame-src": tuple(["'self'"] + _csp_frame_src),
             "frame-ancestors": ("'self'",),
             "upgrade-insecure-requests": True,
             "base-uri": ("'self'",),

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -14,13 +14,20 @@ The `ASTROTURF_WATCH` environment variable (default `1`) controls all
 astroturf-detection features. Set `ASTROTURF_WATCH=0` to hide engagement
 chips and block transparency pages; related endpoints will return 404.
 
-Set `ENABLE_TWITTER_EMBEDS=True` via Fly secrets or environment variables to allow tweet embeds to render properly.
+Set `ENABLE_TWITTER_EMBEDS=True` via Fly secrets or environment variables to
+allow tweet embeds to render properly and include Twitter in the CSP.
 
 ```bash
 fly secrets set ENABLE_TWITTER_EMBEDS=True
 ```
 
 `fly.toml` includes this flag in the `[env]` section so tweets render in production.
+
+### CSP / Hosts
+
+Define public domains with `DJANGO_ALLOWED_HOSTS` (comma-separated) so Django
+and the CSP allowlist match your deployment URLs. Additional trusted origins
+for form posts can be added with `DJANGO_CSRF_TRUSTED`.
 
 ### Moderation
 


### PR DESCRIPTION
## Summary
- centralize frame and image host lists in `CONTENT_SECURITY_POLICY`
- document `ENABLE_TWITTER_EMBEDS`, `DJANGO_ALLOWED_HOSTS`, and `DJANGO_CSRF_TRUSTED`

## Testing
- `pytest` *(fails: layout grid, link trail slash, rate limit enforced)*

------
https://chatgpt.com/codex/tasks/task_e_68bb7a28b8c4832ca765ed9abe0647f9