### PR TITLE
Add request headers for OG image scraping

### DIFF
--- a/core/tests/test_thumbnails.py
+++ b/core/tests/test_thumbnails.py
@@ -47,3 +47,12 @@ def test_fallback_when_request_forbidden():
         assert src.startswith("data:image/svg+xml")
         assert "Forbidden" in src
         assert alt == "Preview image unavailable"
+
+
+def test_scrape_og_image_adds_headers():
+    html = "<html><head></head><body></body></html>"
+    with patch("core.utils.thumbnails.requests.get", return_value=_mock_response(html)) as mock_get:
+        scrape_og_image("https://example.com")
+        headers = mock_get.call_args.kwargs["headers"]
+        assert headers["User-Agent"].startswith("Mozilla/5.0")
+        assert headers["Accept-Language"] == "en-US,en;q=0.9"

--- a/core/utils/thumbnails.py
+++ b/core/utils/thumbnails.py
@@ -12,8 +12,9 @@ OG_IMAGE_RE = re.compile(r"<meta\s+property=['\"]og:image['\"]\s+content=['\"]([
 # browser-like User-Agent and Accept-Language help avoid some bot protections.
 REQUEST_HEADERS = {
     "User-Agent": (
-        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
-        "(KHTML, like Gecko) Chrome/120.0 Safari/537.36"
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/120.0.0.0 Safari/537.36"
     ),
     "Accept-Language": "en-US,en;q=0.9",
 }


### PR DESCRIPTION
## Summary
- add REQUEST_HEADERS with realistic User-Agent and Accept-Language for OG image scraping
- send these headers with requests to remote pages
- verify headers are passed in thumbnail scraping tests

## Testing
- `pytest core/tests/test_thumbnails.py`

------
https://chatgpt.com/codex/tasks/task_e_68bb7eccd998832c883e52432e1ea7b3