### PR TITLE
Render embeds in feed cards

### DIFF
--- a/core/tests/test_feed_card_embed.py
+++ b/core/tests/test_feed_card_embed.py
@@ -1,0 +1,36 @@
+from unittest.mock import patch
+
+from django.contrib.auth import get_user_model
+from django.template.loader import render_to_string
+from django.test import TestCase, RequestFactory
+
+from ..models import Community, Post
+
+
+class FeedCardEmbedTests(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.user = User.objects.create_user("alice", password="pw")
+        self.community = Community.objects.create(
+            slug="t", name="Test", title="Test", created_by=self.user
+        )
+        self.factory = RequestFactory()
+
+    @patch("core.templatetags.embeds._build_embed_html")
+    def test_feed_card_renders_embed_html(self, mock_build):
+        mock_build.return_value = "<div class='post-embed'>stub</div>"
+        post = Post.objects.create(
+            community=self.community,
+            author=self.user,
+            post_type="link",
+            title="Embed",
+            content_url="https://example.com/video",
+        )
+        request = self.factory.get("/")
+        html = render_to_string(
+            "partials/feed_card.html",
+            {"post": post, "show_vote_widget": False},
+            request=request,
+        )
+        mock_build.assert_called_once_with(post.content_url)
+        self.assertIn("post-embed", html)

--- a/templates/partials/feed_card.html
+++ b/templates/partials/feed_card.html
@@ -1,29 +1,30 @@
 {% load url_domain astro_filters embeds %}
 <article class="post-card" data-testid="post-card">
-{% with detail_url=post.get_absolute_url|default:None embed_html=post.content_url|build_embed_html %}
+{% with detail_url=post.get_absolute_url|default:None %}
   {% if not detail_url %}{% url 'post_detail_id' post.pk as detail_url %}{% endif %}
-
-  {% if embed_html %}
-    <div class="thumb" style="aspect-ratio:16/9;">
-      {{ embed_html|safe }}
-    </div>
-  {% elif post.image_thumb or post.image %}
-    <a href="{{ detail_url }}" class="thumb" style="aspect-ratio:16/9;" aria-label="Open post">
-      {% if post.image_thumb %}
-        <img
-          src="{{ post.image_thumb.url }}"
-          alt="{{ post.title }}"
-          loading="lazy" decoding="async"
-          width="640" height="360">
-      {% else %}
-        <img
-          src="{{ post.image.url }}"
-          alt="{{ post.title }}"
-          loading="lazy" decoding="async"
-          width="640" height="360">
-      {% endif %}
-    </a>
-  {% endif %}
+  {% with post.content_url|build_embed_html as embed_html %}
+    {% if embed_html %}
+      <div class="thumb" style="aspect-ratio:16/9;">
+        {{ embed_html|safe }}
+      </div>
+    {% elif post.image_thumb or post.image %}
+      <a href="{{ detail_url }}" class="thumb" style="aspect-ratio:16/9;" aria-label="Open post">
+        {% if post.image_thumb %}
+          <img
+            src="{{ post.image_thumb.url }}"
+            alt="{{ post.title }}"
+            loading="lazy" decoding="async"
+            width="640" height="360">
+        {% else %}
+          <img
+            src="{{ post.image.url }}"
+            alt="{{ post.title }}"
+            loading="lazy" decoding="async"
+            width="640" height="360">
+        {% endif %}
+      </a>
+    {% endif %}
+  {% endwith %}
   <div class="post-meta">
     <a href="{% url 'community' post.community.slug %}">r/{{ post.community.slug }}</a> · {{ post.author.username }} · {{ post.created_at|timesince }} ago
   </div>


### PR DESCRIPTION
## Summary
- compute `embed_html` in `feed_card` template using `build_embed_html`
- render embed markup in the thumbnail area when present
- test feed cards render embeds when available

## Testing
- `pytest core/tests/test_feed_card_embed.py -q`
- `pytest -q` *(fails: test_homepage_layout, CommentLinkTests.test_post_detail_comment_links, RateLimitTests.test_limit_enforced)*

------
https://chatgpt.com/codex/tasks/task_e_68bb7fa99508832cb53af80239288fd4