### PR TITLE
Precompute link embeds in feed views

### DIFF
--- a/core/tests/test_feed_card_embed.py
+++ b/core/tests/test_feed_card_embed.py
@@ -1,7 +1,6 @@
 from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
-from django.template.loader import render_to_string
 from django.test import TestCase, RequestFactory
 
 from ..models import Community, Post
@@ -16,7 +15,7 @@ class FeedCardEmbedTests(TestCase):
         )
         self.factory = RequestFactory()
 
-    @patch("core.templatetags.embeds._build_embed_html")
+    @patch("core.views.build_embed_html")
     def test_feed_card_renders_embed_html(self, mock_build):
         mock_build.return_value = "<div class='post-embed'>stub</div>"
         post = Post.objects.create(
@@ -26,11 +25,10 @@ class FeedCardEmbedTests(TestCase):
             title="Embed",
             content_url="https://example.com/video",
         )
-        request = self.factory.get("/")
-        html = render_to_string(
-            "partials/feed_card.html",
-            {"post": post, "show_vote_widget": False},
-            request=request,
-        )
+        from .. import views
+
+        request = self.factory.get("/feed", HTTP_HX_REQUEST="true")
+        response = views.feed_list(request)
+        html = response.content.decode()
         mock_build.assert_called_once_with(post.content_url)
         self.assertIn("post-embed", html)

--- a/core/views.py
+++ b/core/views.py
@@ -52,6 +52,7 @@ from .services.votes import (
 )
 from . import mod
 from .http import login_required_htmx
+from .utils.embeds import build_embed_html
 
 
 def _is_banned(user):
@@ -455,6 +456,9 @@ def feed_list(request):
         paginator = Paginator(qs, size)
         page_obj = paginator.get_page(page)
         posts = list(page_obj.object_list)
+        for post in posts:
+            if post.post_type == "link":
+                post.embed_html = build_embed_html(post.content_url or "")
         ctx = {
             "posts": posts,
             "next_page": page_obj.next_page_number() if page_obj.has_next() else None,
@@ -488,6 +492,9 @@ def home(request):
     posts = list(qs[offset : offset + PAGE_SIZE + 1])
     next_page = page + 1 if len(posts) > PAGE_SIZE else None
     posts = posts[:PAGE_SIZE]
+    for post in posts:
+        if post.post_type == "link":
+            post.embed_html = build_embed_html(post.content_url or "")
 
     sort_query = ""
     if sort and sort != "hot":
@@ -624,6 +631,9 @@ def community(request, slug):
     posts = list(qs[offset : offset + PAGE_SIZE + 1])
     next_page = page + 1 if len(posts) > PAGE_SIZE else None
     posts = posts[:PAGE_SIZE]
+    for post in posts:
+        if post.post_type == "link":
+            post.embed_html = build_embed_html(post.content_url or "")
 
     sort_query = ""
     if sort and sort != "hot":

--- a/templates/partials/feed_card.html
+++ b/templates/partials/feed_card.html
@@ -1,30 +1,28 @@
-{% load url_domain astro_filters embeds %}
+{% load url_domain astro_filters %}
 <article class="post-card" data-testid="post-card">
 {% with detail_url=post.get_absolute_url|default:None %}
   {% if not detail_url %}{% url 'post_detail_id' post.pk as detail_url %}{% endif %}
-  {% with post.content_url|build_embed_html as embed_html %}
-    {% if embed_html %}
-      <div class="thumb" style="aspect-ratio:16/9;">
-        {{ embed_html|safe }}
-      </div>
-    {% elif post.image_thumb or post.image %}
-      <a href="{{ detail_url }}" class="thumb" style="aspect-ratio:16/9;" aria-label="Open post">
-        {% if post.image_thumb %}
-          <img
-            src="{{ post.image_thumb.url }}"
-            alt="{{ post.title }}"
-            loading="lazy" decoding="async"
-            width="640" height="360">
-        {% else %}
-          <img
-            src="{{ post.image.url }}"
-            alt="{{ post.title }}"
-            loading="lazy" decoding="async"
-            width="640" height="360">
-        {% endif %}
-      </a>
-    {% endif %}
-  {% endwith %}
+  {% if post.post_type == "link" and post.embed_html %}
+    <div class="thumb" style="aspect-ratio:16/9;">
+      {{ post.embed_html|safe }}
+    </div>
+  {% elif post.image_thumb or post.image %}
+    <a href="{{ detail_url }}" class="thumb" style="aspect-ratio:16/9;" aria-label="Open post">
+      {% if post.image_thumb %}
+        <img
+          src="{{ post.image_thumb.url }}"
+          alt="{{ post.title }}"
+          loading="lazy" decoding="async"
+          width="640" height="360">
+      {% else %}
+        <img
+          src="{{ post.image.url }}"
+          alt="{{ post.title }}"
+          loading="lazy" decoding="async"
+          width="640" height="360">
+      {% endif %}
+    </a>
+  {% endif %}
   <div class="post-meta">
     <a href="{% url 'community' post.community.slug %}">r/{{ post.community.slug }}</a> · {{ post.author.username }} · {{ post.created_at|timesince }} ago
   </div>


### PR DESCRIPTION
## Summary
- Build embed HTML for link posts in `feed_list`, `home`, and `community` views
- Render precomputed embeds in feed cards while skipping thumbnail images for link posts
- Update feed card tests to ensure view precomputes embed HTML

## Testing
- `python3 -m pytest core/tests/test_feed_card_embed.py::FeedCardEmbedTests::test_feed_card_renders_embed_html -vv`
- `python3 -m pytest` *(fails: core/tests/test_layout.py::test_homepage_layout, core/tests/test_links.py::CommentLinkTests::test_post_detail_comment_links, core/tests/test_rate_limit_counter.py::RateLimitTests::test_limit_enforced)*

------
https://chatgpt.com/codex/tasks/task_e_68bb86ddb0e8832c8de4d5d2871a11f8