### PR TITLE
feat: toggle video embeds

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -82,17 +82,32 @@ ENABLE_TWITTER_EMBEDS = os.environ.get("ENABLE_TWITTER_EMBEDS", "0") in (
     "true",
     "True",
 )
+ENABLE_YOUTUBE_EMBEDS = os.environ.get("ENABLE_YOUTUBE_EMBEDS", "1") in (
+    "1",
+    "true",
+    "True",
+)
+ENABLE_RUMBLE_EMBEDS = os.environ.get("ENABLE_RUMBLE_EMBEDS", "1") in (
+    "1",
+    "true",
+    "True",
+)
 
 # CSP whitelists
-_csp_frame_src = [
-    "https://www.youtube-nocookie.com",
-    "https://rumble.com",
-]
-_csp_img_src = [
-    "https://i.ytimg.com",
-    "https://*.rumble.com",
-    "https://*.rumblecdn.com",
-]
+_csp_frame_src: list[str] = []
+_csp_img_src: list[str] = []
+
+if ENABLE_YOUTUBE_EMBEDS:
+    _csp_frame_src.append("https://www.youtube-nocookie.com")
+    _csp_img_src.append("https://i.ytimg.com")
+
+if ENABLE_RUMBLE_EMBEDS:
+    _csp_frame_src.append("https://rumble.com")
+    _csp_img_src += [
+        "https://*.rumble.com",
+        "https://*.rumblecdn.com",
+    ]
+
 if ENABLE_TWITTER_EMBEDS:
     _csp_frame_src.append("https://platform.twitter.com")
     _csp_img_src.append("https://*.twimg.com")

--- a/core/utils/embeds.py
+++ b/core/utils/embeds.py
@@ -24,16 +24,18 @@ def build_embed_html(url: str) -> str:
     parsed = urlparse(url)
     domain = parsed.netloc.lower()
 
+    link_card = (
+        f'<div class="link-card"><a href="{escape(url)}" '
+        f'rel="noopener nofollow">{escape(parsed.netloc)}</a></div>'
+    )
+
     try:
         data = fetch_oembed(url)
     except Exception:
         data = {}
 
     if data.get("type") != "embed":
-        return (
-            f'<div class="link-card"><a href="{escape(url)}" '
-            f'rel="noopener nofollow">{escape(parsed.netloc)}</a></div>'
-        )
+        return link_card
 
     html = data.get("html", "")
 
@@ -44,6 +46,8 @@ def build_embed_html(url: str) -> str:
     placeholder_label = "Preview"
     vid = None
     if "youtube" in domain:
+        if not getattr(settings, "ENABLE_YOUTUBE_EMBEDS", True):
+            return link_card
         for pattern in [r"v=([\w-]+)", r"be/([\w-]+)", r"embed/([\w-]+)"]:
             m = re.search(pattern, url)
             if m:
@@ -54,13 +58,12 @@ def build_embed_html(url: str) -> str:
             if m:
                 vid = m.group(1)
         if not vid:
-            return (
-                f'<div class="link-card"><a href="{escape(url)}" '
-                f'rel="noopener nofollow">{escape(parsed.netloc)}</a></div>'
-            )
+            return link_card
         src = f"https://www.youtube-nocookie.com/embed/{vid}"
         placeholder_label = "YouTube preview"
     elif "rumble.com" in domain:
+        if not getattr(settings, "ENABLE_RUMBLE_EMBEDS", True):
+            return link_card
         # 1) Try to read iframe src from the provider HTML (support " and ' quotes)
         m = re.search(r"src=['\"]([^'\"]+)['\"]", html or "")
         src = m.group(1) if m else ""
@@ -75,30 +78,18 @@ def build_embed_html(url: str) -> str:
 
         # If still no usable src, degrade to a plain link card
         if not src:
-            return (
-                f'<div class="link-card"><a href="{escape(url)}" '
-                f'rel="noopener nofollow">{escape(parsed.netloc)}</a></div>'
-            )
+            return link_card
         placeholder_label = "Rumble preview"
     elif "twitter.com" in domain or "x.com" in domain:
         if not getattr(settings, "ENABLE_TWITTER_EMBEDS", False):
-            return (
-                f'<div class="link-card"><a href="{escape(url)}" '
-                f'rel="noopener nofollow">{escape(parsed.netloc)}</a></div>'
-            )
+            return link_card
         m = re.search(r"status/(\d+)", url)
         if not m:
-            return (
-                f'<div class="link-card"><a href="{escape(url)}" '
-                f'rel="noopener nofollow">{escape(parsed.netloc)}</a></div>'
-            )
+            return link_card
         src = f"https://platform.twitter.com/embed/Tweet.html?id={m.group(1)}"
         placeholder_label = "Tweet preview"
     else:
-        return (
-            f'<div class="link-card"><a href="{escape(url)}" '
-            f'rel="noopener nofollow">{escape(parsed.netloc)}</a></div>'
-        )
+        return link_card
     if not thumb and "youtube" in domain and vid:
         thumb = f"https://i.ytimg.com/vi/{vid}/hqdefault.jpg"
         thumb_alt = placeholder_label

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -14,8 +14,14 @@ The `ASTROTURF_WATCH` environment variable (default `1`) controls all
 astroturf-detection features. Set `ASTROTURF_WATCH=0` to hide engagement
 chips and block transparency pages; related endpoints will return 404.
 
-Set `ENABLE_TWITTER_EMBEDS=True` via Fly secrets or environment variables to
-allow tweet embeds to render properly and include Twitter in the CSP.
+Embed providers can be toggled via environment variables:
+
+* `ENABLE_YOUTUBE_EMBEDS` (default `1`)
+* `ENABLE_RUMBLE_EMBEDS` (default `1`)
+* `ENABLE_TWITTER_EMBEDS` (default `0`)
+
+For example, to allow tweet embeds to render properly and include Twitter in
+the CSP:
 
 ```bash
 fly secrets set ENABLE_TWITTER_EMBEDS=True


### PR DESCRIPTION
## Summary
- add flags to enable/disable YouTube and Rumble embeds, keeping Twitter flag
- gate embed HTML generation on provider flags
- document ENABLE_*_EMBEDS variables and defaults

## Testing
- `pytest` *(fails: test_layout.py::test_homepage_layout, test_links.py::CommentLinkTests::test_post_detail_comment_links, test_rate_limit_counter.py::RateLimitTests::test_limit_enforced, test_thumbnails.py::test_scraper_returns_og_image_url)*

------
https://chatgpt.com/codex/tasks/task_e_68bb8a2a0d80832ca1c10ad7e77e798b