### PR TITLE
chore: tighten CSP media sources

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -106,6 +106,7 @@ if ENABLE_RUMBLE_EMBEDS:
     _csp_img_src += [
         "https://*.rumble.com",
         "https://*.rumblecdn.com",
+        "https://*.rmbl.ws",
     ]
 
 if ENABLE_TWITTER_EMBEDS:
@@ -140,9 +141,9 @@ if not DEBUG:
             "default-src": ("'self'",),
             "script-src": ("'self'",),
             "style-src": ("'self'", "'unsafe-inline'"),
-            "img-src": tuple(["'self'", "https:"] + _csp_img_src + ["data:"]),
+            "img-src": tuple(["'self'"] + _csp_img_src + ["data:"]),
             "connect-src": ("'self'",),
-            "frame-src": tuple(["'self'"] + _csp_frame_src),
+            "frame-src": tuple(_csp_frame_src) or ("'none'",),
             "frame-ancestors": ("'self'",),
             "upgrade-insecure-requests": True,
             "base-uri": ("'self'",),

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -35,6 +35,15 @@ Define public domains with `DJANGO_ALLOWED_HOSTS` (comma-separated) so Django
 and the CSP allowlist match your deployment URLs. Additional trusted origins
 for form posts can be added with `DJANGO_CSRF_TRUSTED`.
 
+The production CSP restricts external media to a small, documented set:
+
+* `https://i.ytimg.com` – YouTube thumbnails.
+* `https://*.twimg.com` – images in tweet embeds.
+* `https://*.rumblecdn.com`, `https://*.rumble.com`, and `https://*.rmbl.ws` – Rumble thumbnails.
+* `data:` – inline SVG placeholders.
+
+Frames may only load from `https://www.youtube-nocookie.com`, `https://rumble.com`, and `https://platform.twitter.com`.
+
 ### Moderation
 
 Staff can remove posts without deleting them, lock conversations, or


### PR DESCRIPTION
## Summary
- restrict CSP image sources to explicit embed CDNs
- limit CSP frame sources to known embed hosts
- document allowed CSP hosts and rationale

## Testing
- `python manage.py test --settings=config.test_settings` *(fails: ModuleNotFoundError: No module named 'freezegun'; FAIL: test_post_detail_comment_links; etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68bb8b19f404832cb29b551763c5e6d3