### PR TITLE
Add CSP header and thumbnail domain tests

### DIFF
--- a/core/tests/test_csp_headers.py
+++ b/core/tests/test_csp_headers.py
@@ -1,0 +1,43 @@
+import pytest
+from django.contrib.auth import get_user_model
+from django.test import override_settings
+from django.urls import reverse
+
+from config import settings as conf_settings
+from core.models import Community, Post
+
+
+@pytest.mark.django_db
+def test_csp_headers_include_expected_hosts(client):
+    User = get_user_model()
+    user = User.objects.create_user("author", password="pw")
+    community = Community.objects.create(
+        slug="test", name="Test", title="Test", created_by=user
+    )
+    post = Post.objects.create(
+        community=community,
+        author=user,
+        post_type="link",
+        title="Video",
+        content_url="https://www.youtube.com/watch?v=abc",
+    )
+    urls = [
+        "/",
+        reverse("post_detail", args=[community.slug, post.pk, post.slug]),
+    ]
+    csp = {
+        "DIRECTIVES": {
+            "img-src": tuple(
+                ["'self'", "https:"] + conf_settings._csp_img_src + ["data:"]
+            ),
+            "frame-src": tuple(["'self'"] + conf_settings._csp_frame_src),
+        }
+    }
+    with override_settings(DEBUG=False, CONTENT_SECURITY_POLICY=csp):
+        for url in urls:
+            resp = client.get(url)
+            csp_header = resp["Content-Security-Policy"]
+            for host in conf_settings._csp_img_src:
+                assert host in csp_header
+            for host in conf_settings._csp_frame_src:
+                assert host in csp_header

--- a/core/tests/test_post_detail_media.py
+++ b/core/tests/test_post_detail_media.py
@@ -1,4 +1,5 @@
 from unittest.mock import patch, Mock
+from urllib.parse import urlparse
 
 import requests
 
@@ -6,6 +7,7 @@ from django.contrib.auth import get_user_model
 from django.test import TestCase, override_settings
 from django.urls import reverse
 
+from config import settings as conf_settings
 from core.models import Community, Post, PostImageLink
 
 
@@ -234,6 +236,51 @@ class PostDetailMediaTests(TestCase):
             reverse("post_detail", args=[self.community.slug, post.pk, post.slug])
         )
         self.assertContains(resp, '<img src="https://pbs.twimg.com/og.jpg"')
+
+    @override_settings(ENABLE_TWITTER_EMBEDS=True)
+    @patch("core.utils.embeds.fetch_oembed")
+    def test_link_thumbnail_host_matches_csp_domains(self, mock_oembed):
+        cases = [
+            (
+                "https://pbs.twimg.com/thumb.jpg",
+                "https://x.com/user/status/123",
+            ),
+            (
+                "https://c.rumblecdn.com/og.jpg",
+                "https://rumble.com/vxyz-test.html",
+            ),
+        ]
+        for i, (thumb_url, content_url) in enumerate(cases, start=1):
+            mock_oembed.return_value = {
+                "type": "embed",
+                "html": "<blockquote></blockquote>",
+                "thumbnail_url": thumb_url,
+            }
+            post = Post.objects.create(
+                community=self.community,
+                author=self.user,
+                post_type="link",
+                title=f"Link {i}",
+                content_url=content_url,
+            )
+            resp = self.client.get(
+                reverse("post_detail", args=[self.community.slug, post.pk, post.slug])
+            )
+            self.assertContains(resp, f'src="{thumb_url}"')
+            parsed = urlparse(thumb_url)
+            host = f"{parsed.scheme}://{parsed.netloc}"
+            allowed = list(conf_settings._csp_img_src) + ["https://*.twimg.com"]
+            self.assertTrue(
+                any(
+                    host == pattern
+                    or (
+                        pattern.startswith("https://*.")
+                        and host.endswith(pattern[len("https://*."):])
+                    )
+                    for pattern in allowed
+                ),
+                f"{host} not allowed by CSP",
+            )
 
     def test_image_slideshow_renders(self):
         post = Post.objects.create(


### PR DESCRIPTION
## Summary
- test CSP headers on home and post detail to ensure allowed img-src and frame-src hosts
- verify link post thumbnails use hosts allowed by CSP

## Testing
- `pytest core/tests/test_csp_headers.py core/tests/test_post_detail_media.py tests/test_csp_header.py`

------
https://chatgpt.com/codex/tasks/task_e_68bb8d15716c832cb25446ac3807d0e7