### PR TITLE
Increase thumbnail request timeout

### DIFF
--- a/core/utils/thumbnails.py
+++ b/core/utils/thumbnails.py
@@ -23,7 +23,7 @@ REQUEST_HEADERS = {
     "Accept-Language": "en-US,en;q=0.9",
 }
 
-REQUEST_TIMEOUT = 4  # seconds
+REQUEST_TIMEOUT = 5  # seconds
 
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary
- extend OG image fetch timeout to 5 seconds

## Testing
- `pytest core/tests/test_thumbnails.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68bb93ea3710832c9e6d68f1eb209ead