### PR TITLE
Add shared HTTP client and switch callers

### DIFF
--- a/core/http_client.py
+++ b/core/http_client.py
@@ -1,0 +1,52 @@
+"""Shared HTTP client utilities."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+_SESSION: Optional[requests.Session] = None
+_TIMEOUT = 5  # seconds
+_HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/125.0.0.0 Safari/537.36"
+    ),
+    "Accept-Language": "en-US,en;q=0.9",
+}
+
+
+def get_session() -> requests.Session:
+    """Return a module-level session with retry and default headers."""
+    global _SESSION
+    if _SESSION is None:
+        session = requests.Session()
+        session.headers.update(_HEADERS)
+        retries = Retry(
+            total=2,
+            backoff_factor=0.5,
+            status_forcelist=[500, 502, 503, 504],
+            allowed_methods=["GET", "HEAD", "OPTIONS"],
+        )
+        adapter = HTTPAdapter(max_retries=retries)
+        session.mount("http://", adapter)
+        session.mount("https://", adapter)
+        _SESSION = session
+    return _SESSION
+
+
+def fetch_json(url: str) -> dict:
+    """Fetch ``url`` and return the parsed JSON response."""
+    resp = get_session().get(url, timeout=_TIMEOUT)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def fetch_html(url: str) -> requests.Response:
+    """Fetch ``url`` and return the raw response object."""
+    resp = get_session().get(url, timeout=_TIMEOUT)
+    return resp

--- a/core/oembed.py
+++ b/core/oembed.py
@@ -9,7 +9,8 @@ from django.conf import settings
 from django.core.cache import cache
 
 import bleach
-import requests
+
+from .http_client import fetch_html, fetch_json
 
 
 _CACHE_KEY_PREFIX = "oembed:"
@@ -48,9 +49,7 @@ def fetch_oembed(url: str) -> dict:
     result = None
     if endpoint:
         try:
-            resp = requests.get(endpoint, timeout=5)
-            resp.raise_for_status()
-            data = resp.json()
+            data = fetch_json(endpoint)
             html = data.get("html", "")
             thumb = data.get("thumbnail_url")
             clean = bleach.clean(
@@ -89,7 +88,7 @@ def fetch_oembed(url: str) -> dict:
         # Fallback simple link card
         title = None
         try:
-            resp = requests.get(url, timeout=5)
+            resp = fetch_html(url)
             resp.raise_for_status()
             match = re.search(r"<title>(.*?)</title>", resp.text, re.IGNORECASE | re.DOTALL)
             if match:

--- a/core/utils/thumbnails.py
+++ b/core/utils/thumbnails.py
@@ -10,7 +10,12 @@ from urllib.parse import urlparse
 from django.core.cache import cache
 import requests
 
-OG_IMAGE_RE = re.compile(r"<meta\s+property=['\"]og:image['\"]\s+content=['\"]([^'\"]+)['\"]", re.IGNORECASE)
+from ..http_client import fetch_html
+
+OG_IMAGE_RE = re.compile(
+    r"<meta\s+property=['\"]og:image['\"]\s+content=['\"]([^'\"]+)['\"]",
+    re.IGNORECASE,
+)
 
 # Headers used when scraping remote pages for OpenGraph images. A modern
 # desktop User-Agent and Accept-Language help avoid some bot protections.
@@ -34,7 +39,7 @@ def scrape_og_image(url: str) -> Optional[str]:
     domain = urlparse(url).netloc
     status = None
     try:
-        resp = requests.get(url, timeout=REQUEST_TIMEOUT, headers=REQUEST_HEADERS)
+        resp = fetch_html(url)
         status = resp.status_code
         resp.raise_for_status()
     except Exception:


### PR DESCRIPTION
## Summary
- add reusable HTTP session with browser headers, short timeouts and retries
- use shared client in oEmbed and thumbnail utilities instead of direct requests

## Testing
- `pytest` *(fails: Requested setting INSTALLED_APPS, but settings are not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68bb98bc4b84832ca4183ce5de50172c