### PR TITLE
Add tests for Twitter CSP and http client User-Agent

### DIFF
--- a/core/tests/test_http_client.py
+++ b/core/tests/test_http_client.py
@@ -1,0 +1,27 @@
+import requests
+
+from core import http_client
+
+
+def test_get_session_sets_browser_user_agent(monkeypatch):
+    captured = []
+
+    def fake_request(self, method, url, **kwargs):
+        captured.append(self.headers.get("User-Agent"))
+
+        class DummyResp:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {}
+
+        return DummyResp()
+
+    monkeypatch.setattr(requests.Session, "request", fake_request)
+    http_client._SESSION = None
+    http_client.fetch_json("https://example.com")
+    http_client.fetch_html("https://example.com")
+    assert len(captured) == 2
+    assert all(h.startswith("Mozilla/5.0") for h in captured)
+    http_client._SESSION = None

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,10 @@
+import importlib
+
+
+def test_twimg_in_csp_when_twitter_enabled(monkeypatch):
+    monkeypatch.setenv("ENABLE_TWITTER_EMBEDS", "1")
+    from config import settings as conf_settings
+    importlib.reload(conf_settings)
+    assert any("twimg.com" in h for h in conf_settings.CSP_IMG_SRC)
+    monkeypatch.delenv("ENABLE_TWITTER_EMBEDS", raising=False)
+    importlib.reload(conf_settings)


### PR DESCRIPTION
## Summary
- test settings include Twitter img host when ENABLE_TWITTER_EMBEDS is set
- test http client uses browser-like User-Agent for JSON and HTML fetches

## Testing
- `python manage.py test` *(fails: System check identified issue csp.E001)*
- `pytest tests/test_settings.py core/tests/test_http_client.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb9ab772c0832cba925ccdb220a558