### PR TITLE
Use shared HTTP client for embeds and thumbnails

### DIFF
--- a/core/oembed.py
+++ b/core/oembed.py
@@ -9,12 +9,14 @@ from django.conf import settings
 from django.core.cache import cache
 
 import bleach
+import requests
 
 from .http_client import fetch_html, fetch_json
 
 
 _CACHE_KEY_PREFIX = "oembed:"
-_CACHE_TIMEOUT = 60 * 60  # 1 hour
+# Cache successful lookups briefly; errors should not be cached.
+_CACHE_TIMEOUT = 60  # seconds
 
 
 def fetch_oembed(url: str) -> dict:
@@ -47,6 +49,7 @@ def fetch_oembed(url: str) -> dict:
             break
 
     result = None
+    cache_ok = True
     if endpoint:
         try:
             data = fetch_json(endpoint)
@@ -81,8 +84,10 @@ def fetch_oembed(url: str) -> dict:
                 strip=True,
             )
             result = {"type": "embed", "html": clean, "thumbnail_url": thumb}
+        except requests.RequestException:
+            cache_ok = False
         except Exception:
-            pass
+            cache_ok = False
 
     if not result:
         # Fallback simple link card
@@ -93,8 +98,10 @@ def fetch_oembed(url: str) -> dict:
             match = re.search(r"<title>(.*?)</title>", resp.text, re.IGNORECASE | re.DOTALL)
             if match:
                 title = match.group(1).strip()
+        except requests.RequestException:
+            cache_ok = False
         except Exception:
-            pass
+            cache_ok = False
         favicon = f"https://www.google.com/s2/favicons?domain={domain}&sz=64"
         result = {
             "type": "link",
@@ -104,5 +111,6 @@ def fetch_oembed(url: str) -> dict:
             "favicon": favicon,
         }
 
-    cache.set(key, result, _CACHE_TIMEOUT)
+    if cache_ok:
+        cache.set(key, result, _CACHE_TIMEOUT)
     return result

--- a/core/tests/test_oembed.py
+++ b/core/tests/test_oembed.py
@@ -1,19 +1,30 @@
 from unittest.mock import Mock, patch
-
 import requests
+from django.core.cache import cache
 from django.test import TestCase
 
+from core import http_client
 from core.oembed import fetch_oembed
 
 
-def _mock_response(json=None, status=200):
+def _mock_json_response(data=None, status=200):
     resp = Mock()
-    resp.json.return_value = json
-
+    resp.status_code = status
+    resp.json.return_value = data or {}
     def raise_for_status():
         if status >= 400:
-            raise requests.HTTPError()
+            raise requests.HTTPError(response=resp)
+    resp.raise_for_status = raise_for_status
+    return resp
 
+
+def _mock_html_response(text="", status=200):
+    resp = Mock()
+    resp.status_code = status
+    resp.text = text
+    def raise_for_status():
+        if status >= 400:
+            raise requests.HTTPError(response=resp)
     resp.raise_for_status = raise_for_status
     return resp
 
@@ -21,7 +32,34 @@ def _mock_response(json=None, status=200):
 class OEmbedTests(TestCase):
     def test_fetch_oembed_removes_scripts(self):
         sample_html = '<iframe src="https://youtube.com/embed/abc"></iframe><script>alert(1)</script>'
-        with patch("requests.get", return_value=_mock_response(json={"html": sample_html})):
+        resp = _mock_json_response({"html": sample_html})
+        session = http_client.get_session()
+        session.get = Mock(return_value=resp)
+        with patch("core.http_client.get_session", return_value=session):
             data = fetch_oembed("https://www.youtube.com/watch?v=abc")
         self.assertEqual(data["type"], "embed")
         self.assertNotIn("script", data["html"].lower())
+        session.get.assert_called_once()
+        headers = session.headers
+        self.assertTrue(headers["User-Agent"].startswith("Mozilla/5.0"))
+        self.assertEqual(headers["Accept-Language"], "en-US,en;q=0.9")
+
+    def test_fetch_oembed_caches_success(self):
+        url = "https://www.youtube.com/watch?v=abc"
+        cache.clear()
+        sample_html = "<iframe></iframe>"
+        with patch("core.http_client.fetch_json", return_value={"html": sample_html}) as mock_json:
+            fetch_oembed(url)
+            fetch_oembed(url)
+        self.assertEqual(mock_json.call_count, 1)
+
+    def test_fetch_oembed_no_cache_on_error(self):
+        url = "https://www.youtube.com/watch?v=abc"
+        cache.clear()
+        def raise_http_error(*args, **kwargs):
+            raise requests.HTTPError(response=Mock(status_code=500))
+        with patch("core.http_client.fetch_json", side_effect=raise_http_error) as mock_json, \
+             patch("core.http_client.fetch_html", return_value=_mock_html_response("<title>t</title>")):
+            fetch_oembed(url)
+            fetch_oembed(url)
+        self.assertEqual(mock_json.call_count, 2)

--- a/core/tests/test_post_detail_media.py
+++ b/core/tests/test_post_detail_media.py
@@ -65,10 +65,10 @@ class PostDetailMediaTests(TestCase):
         )
         self.assertContains(resp, 'src="https://cdn.example/og.jpg"')
 
-    @patch("core.utils.thumbnails.requests.get")
+    @patch("core.http_client.fetch_html")
     @patch("core.utils.embeds.fetch_oembed")
     def test_embed_uses_placeholder_when_og_fetch_fails(
-        self, mock_oembed, mock_get
+        self, mock_oembed, mock_fetch_html
     ):
         mock_oembed.return_value = {
             "type": "embed",
@@ -79,7 +79,7 @@ class PostDetailMediaTests(TestCase):
         response.raise_for_status.side_effect = requests.exceptions.HTTPError(
             "403"
         )
-        mock_get.return_value = response
+        mock_fetch_html.return_value = response
         post = Post.objects.create(
             community=self.community,
             author=self.user,
@@ -92,10 +92,10 @@ class PostDetailMediaTests(TestCase):
         )
         self.assertContains(resp, 'src="data:image/svg+xml;utf8,')
 
-    @patch("core.utils.thumbnails.requests.get")
+    @patch("core.http_client.fetch_html")
     @patch("core.utils.embeds.fetch_oembed")
     def test_embed_uses_scraped_og_image_when_available(
-        self, mock_oembed, mock_get
+        self, mock_oembed, mock_fetch_html
     ):
         mock_oembed.return_value = {
             "type": "embed",
@@ -108,7 +108,7 @@ class PostDetailMediaTests(TestCase):
             "<html><head><meta property='og:image' "
             "content='https://cdn.example/og2.jpg'></head></html>"
         )
-        mock_get.return_value = response
+        mock_fetch_html.return_value = response
         post = Post.objects.create(
             community=self.community,
             author=self.user,

--- a/core/tests/test_thumbnails.py
+++ b/core/tests/test_thumbnails.py
@@ -1,65 +1,79 @@
-from unittest.mock import patch, Mock
-
+from unittest.mock import Mock, patch
+import os
 import requests
 
-from core.utils.thumbnails import (
-    resolve_thumbnail,
-    scrape_og_image,
-    REQUEST_HEADERS,
-    REQUEST_TIMEOUT,
-)
+from django.core.cache import cache
+
+from core import http_client
+from core.utils.thumbnails import resolve_thumbnail, scrape_og_image, fetch_og_image
 
 
-def _mock_response(text: str) -> Mock:
+def _mock_response(text: str = "", status: int = 200) -> Mock:
     resp = Mock()
     resp.text = text
-    resp.raise_for_status = lambda: None
-    return resp
-
-
-def _mock_error_response(status_code: int) -> Mock:
-    resp = Mock()
-    def raise_error():
-        raise requests.HTTPError(response=Mock(status_code=status_code))
-    resp.raise_for_status = raise_error
+    resp.status_code = status
+    def raise_for_status():
+        if status >= 400:
+            raise requests.HTTPError(response=resp)
+    resp.raise_for_status = raise_for_status
     return resp
 
 
 def test_scraper_returns_og_image_url():
     html = "<html><head><meta property='og:image' content='https://cdn.example/img.jpg'></head></html>"
-    with patch("core.utils.thumbnails.requests.get", return_value=_mock_response(html)) as mock_get:
-        url = "https://example.com"
-        src, alt = resolve_thumbnail(url, "Preview")
-        assert src == "https://cdn.example/img.jpg"
-        assert alt == "Preview"
-        mock_get.assert_called_once_with(
-            url, timeout=REQUEST_TIMEOUT, headers=REQUEST_HEADERS
-        )
+    resp = _mock_response(html)
+    session = http_client.get_session()
+    session.get = Mock(return_value=resp)
+    with patch("core.http_client.get_session", return_value=session):
+        src, alt = resolve_thumbnail("https://example.com", "Preview")
+    assert src == "https://cdn.example/img.jpg"
+    assert alt == "Preview"
+    session.get.assert_called_once_with("https://example.com", timeout=http_client._TIMEOUT)
+    headers = session.headers
+    assert headers["User-Agent"].startswith("Mozilla/5.0")
+    assert headers["Accept-Language"] == "en-US,en;q=0.9"
 
 
 def test_placeholder_returned_when_missing():
     html = "<html><head></head><body>No OG tags here</body></html>"
-    with patch("core.utils.thumbnails.requests.get", return_value=_mock_response(html)):
+    resp = _mock_response(html)
+    session = http_client.get_session()
+    session.get = Mock(return_value=resp)
+    with patch("core.http_client.get_session", return_value=session):
         src, alt = resolve_thumbnail("https://example.com", "Tweet preview")
-        assert src.startswith("data:image/svg+xml")
-        assert "Tweet preview" in src
-        assert alt == "Preview image unavailable"
+    assert src.startswith("data:image/svg+xml")
+    assert "Tweet preview" in src
+    assert alt == "Preview image unavailable"
 
 
 def test_fallback_when_request_forbidden():
+    resp = _mock_response(status=403)
+    session = http_client.get_session()
+    session.get = Mock(return_value=resp)
+    with patch("core.http_client.get_session", return_value=session):
+        assert scrape_og_image("https://example.com")[0] is None
+        src, alt = resolve_thumbnail("https://example.com", "Forbidden")
+    assert src.startswith("data:image/svg+xml")
+    assert "Forbidden" in src
+    assert alt == "Preview image unavailable"
+
+
+def test_fetch_og_image_caches_success():
     url = "https://example.com"
-    with patch("core.utils.thumbnails.requests.get", return_value=_mock_error_response(403)):
-        assert scrape_og_image(url) is None
-        src, alt = resolve_thumbnail(url, "Forbidden")
-        assert src.startswith("data:image/svg+xml")
-        assert "Forbidden" in src
-        assert alt == "Preview image unavailable"
+    cache.clear()
+    with patch.dict(os.environ, {"PYTEST_CURRENT_TEST": ""}):
+        with patch("core.utils.thumbnails.scrape_og_image", return_value=("https://cdn.example/img.jpg", 200)) as mock_scrape:
+            assert fetch_og_image(url) == "https://cdn.example/img.jpg"
+            assert fetch_og_image(url) == "https://cdn.example/img.jpg"
+    assert mock_scrape.call_count == 1
 
 
-def test_scrape_og_image_adds_headers():
-    html = "<html><head></head><body></body></html>"
-    with patch("core.utils.thumbnails.requests.get", return_value=_mock_response(html)) as mock_get:
-        scrape_og_image("https://example.com")
-        headers = mock_get.call_args.kwargs["headers"]
-        assert headers["User-Agent"].startswith("Mozilla/5.0")
-        assert headers["Accept-Language"] == "en-US,en;q=0.9"
+def test_fetch_og_image_no_cache_on_error():
+    url = "https://example.com"
+    cache.clear()
+    with patch.dict(os.environ, {"PYTEST_CURRENT_TEST": ""}):
+        with patch("core.utils.thumbnails.scrape_og_image", return_value=(None, 500)) as mock_scrape:
+            assert fetch_og_image(url) is None
+            assert fetch_og_image(url) is None
+    # Called twice because error responses are not cached
+    assert mock_scrape.call_count == 2

--- a/core/utils/thumbnails.py
+++ b/core/utils/thumbnails.py
@@ -8,7 +8,6 @@ from typing import Optional
 from urllib.parse import urlparse
 
 from django.core.cache import cache
-import requests
 
 from ..http_client import fetch_html
 
@@ -17,24 +16,10 @@ OG_IMAGE_RE = re.compile(
     re.IGNORECASE,
 )
 
-# Headers used when scraping remote pages for OpenGraph images. A modern
-# desktop User-Agent and Accept-Language help avoid some bot protections.
-REQUEST_HEADERS = {
-    "User-Agent": (
-        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
-        "AppleWebKit/537.36 (KHTML, like Gecko) "
-        "Chrome/125.0.0.0 Safari/537.36"
-    ),
-    "Accept-Language": "en-US,en;q=0.9",
-}
-
-REQUEST_TIMEOUT = 5  # seconds
-
-
 logger = logging.getLogger(__name__)
 
 
-def scrape_og_image(url: str) -> Optional[str]:
+def scrape_og_image(url: str) -> tuple[Optional[str], Optional[int]]:
     """Return the first OpenGraph image URL for ``url`` if present."""
     domain = urlparse(url).netloc
     status = None
@@ -44,19 +29,20 @@ def scrape_og_image(url: str) -> Optional[str]:
         resp.raise_for_status()
     except Exception:
         logger.info("og-image fetch %s status=%s result=fallback", domain, status or "error")
-        return None
+        return None, status
 
     match = OG_IMAGE_RE.search(resp.text)
     if match:
         logger.info("og-image fetch %s status=%s result=image", domain, status)
-        return match.group(1)
+        return match.group(1), status
 
     logger.info("og-image fetch %s status=%s result=fallback", domain, status)
-    return None
+    return None, status
 
 
 _CACHE_KEY_PREFIX = "og-image:"  # cache key prefix for og image lookups
-_CACHE_TIMEOUT = 60 * 60  # 1 hour
+# Cache successful lookups briefly; errors should not be cached.
+_CACHE_TIMEOUT = 60  # seconds
 _CACHE_NONE = ""  # sentinel value for cached misses
 
 
@@ -65,14 +51,17 @@ def fetch_og_image(url: str) -> Optional[str]:
 
     # During tests we bypass caching to avoid cross-test interference.
     if os.getenv("PYTEST_CURRENT_TEST"):
-        return scrape_og_image(url)
+        return scrape_og_image(url)[0]
 
     key = f"{_CACHE_KEY_PREFIX}{url}"
     cached = cache.get(key)
     if cached is not None:
         return None if cached == _CACHE_NONE else cached
 
-    result = scrape_og_image(url)
+    result, status = scrape_og_image(url)
+    if status is None or status >= 400:
+        return result
+
     cache.set(key, result or _CACHE_NONE, _CACHE_TIMEOUT)
     return result
 


### PR DESCRIPTION
## Summary
- add browser-like shared HTTP session with retry and headers
- cache oEmbed/OG lookups briefly and skip caching on errors
- exercise shared client in unit tests and ensure caching behavior

## Testing
- `pytest` *(fails: Requested setting INSTALLED_APPS, but settings are not configured)*
- `python manage.py test` *(fails: django-csp < 4.0 settings require migration)*

------
https://chatgpt.com/codex/tasks/task_e_68bba48973c8832cabeba5b14d61be70