### PR TITLE
Refactor CSP embed providers

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -114,16 +114,6 @@ EMBED_PROVIDERS = {
     },
 }
 
-CSP_IMG_SRC: list[str] = ["'self'"]
-CSP_FRAME_SRC: list[str] = []
-
-for provider in EMBED_PROVIDERS.values():
-    if provider["flag"]:
-        CSP_IMG_SRC.extend(provider["img_hosts"])
-        CSP_FRAME_SRC.extend(provider["frame_hosts"])
-
-CSP_IMG_SRC.append("data:")
-
 # Simple per-user rate limits
 RATE_POSTS_PER_DAY_NEW = int(os.getenv("RATE_POSTS_PER_DAY_NEW", "10"))
 RATE_COMMENTS_PER_MIN_NEW = int(os.getenv("RATE_COMMENTS_PER_MIN_NEW", "8"))
@@ -147,14 +137,23 @@ if not DEBUG:
     SECURE_HSTS_INCLUDE_SUBDOMAINS = True
     SECURE_HSTS_PRELOAD = True
     SECURE_CONTENT_TYPE_NOSNIFF = True
+
+    _img_src = ["'self'"]
+    _frame_src = ["'self'"]
+    for provider in EMBED_PROVIDERS.values():
+        if provider["flag"]:
+            _img_src.extend(provider["img_hosts"])
+            _frame_src.extend(provider["frame_hosts"])
+    _img_src.append("data:")
+
     CONTENT_SECURITY_POLICY = {
         "DIRECTIVES": {
             "default-src": ("'self'",),
             "script-src": ("'self'",),
             "style-src": ("'self'", "'unsafe-inline'"),
-            "img-src": tuple(CSP_IMG_SRC),
+            "img-src": tuple(_img_src),
             "connect-src": ("'self'",),
-            "frame-src": tuple(CSP_FRAME_SRC) or ("'none'",),
+            "frame-src": tuple(_frame_src),
             "frame-ancestors": ("'self'",),
             "upgrade-insecure-requests": True,
             "base-uri": ("'self'",),

--- a/core/tests/test_csp_headers.py
+++ b/core/tests/test_csp_headers.py
@@ -25,19 +25,19 @@ def test_csp_headers_include_expected_hosts(client):
         "/",
         reverse("post_detail", args=[community.slug, post.pk, post.slug]),
     ]
-    csp = {
-        "DIRECTIVES": {
-            "img-src": tuple(
-                ["'self'", "https:"] + conf_settings._csp_img_src + ["data:"]
-            ),
-            "frame-src": tuple(["'self'"] + conf_settings._csp_frame_src),
-        }
-    }
+    img_src = ["'self'"]
+    frame_src = ["'self'"]
+    for p in conf_settings.EMBED_PROVIDERS.values():
+        if p["flag"]:
+            img_src.extend(p["img_hosts"])
+            frame_src.extend(p["frame_hosts"])
+    img_src.append("data:")
+    csp = {"DIRECTIVES": {"img-src": tuple(img_src), "frame-src": tuple(frame_src)}}
     with override_settings(DEBUG=False, CONTENT_SECURITY_POLICY=csp):
         for url in urls:
             resp = client.get(url)
             csp_header = resp["Content-Security-Policy"]
-            for host in conf_settings._csp_img_src:
+            for host in img_src[1:-1]:  # skip 'self' and 'data:'
                 assert host in csp_header
-            for host in conf_settings._csp_frame_src:
+            for host in frame_src[1:]:  # skip 'self'
                 assert host in csp_header

--- a/core/tests/test_post_detail_media.py
+++ b/core/tests/test_post_detail_media.py
@@ -269,7 +269,12 @@ class PostDetailMediaTests(TestCase):
             self.assertContains(resp, f'src="{thumb_url}"')
             parsed = urlparse(thumb_url)
             host = f"{parsed.scheme}://{parsed.netloc}"
-            allowed = list(conf_settings._csp_img_src) + ["https://*.twimg.com"]
+            providers = {k: v.copy() for k, v in conf_settings.EMBED_PROVIDERS.items()}
+            providers["X"]["flag"] = True
+            allowed = []
+            for p in providers.values():
+                if p["flag"]:
+                    allowed.extend(p["img_hosts"])
             self.assertTrue(
                 any(
                     host == pattern

--- a/tests/test_csp_header.py
+++ b/tests/test_csp_header.py
@@ -1,31 +1,34 @@
 import pytest
 from django.test import override_settings
+
 from config import settings as conf_settings
 
 
-def test_csp_header_includes_img_src_hosts(client):
-    csp = {
-        "DIRECTIVES": {
-            "img-src": tuple(
-                ["'self'", "https:"] + conf_settings._csp_img_src + ["data:"]
-            )
-        }
-    }
-    with override_settings(DEBUG=False, CONTENT_SECURITY_POLICY=csp):
+def _build_csp(providers):
+    img_src = ["'self'"]
+    frame_src = ["'self'"]
+    for p in providers.values():
+        if p["flag"]:
+            img_src.extend(p["img_hosts"])
+            frame_src.extend(p["frame_hosts"])
+    img_src.append("data:")
+    return {"DIRECTIVES": {"img-src": tuple(img_src), "frame-src": tuple(frame_src)}}
+
+
+@pytest.mark.parametrize("provider", ["YOUTUBE", "X", "RUMBLE"])
+def test_csp_header_includes_provider_hosts(client, provider):
+    providers = {k: v.copy() for k, v in conf_settings.EMBED_PROVIDERS.items()}
+    for p in providers.values():
+        p["flag"] = False
+    providers[provider]["flag"] = True
+    csp = _build_csp(providers)
+    with override_settings(DEBUG=False, EMBED_PROVIDERS=providers, CONTENT_SECURITY_POLICY=csp):
         resp = client.get("/healthz")
     csp_header = resp["Content-Security-Policy"]
-    for host in conf_settings._csp_img_src:
+    for host in providers[provider]["img_hosts"] + providers[provider]["frame_hosts"]:
         assert host in csp_header
 
 
-def test_csp_header_includes_frame_src_hosts(client):
-    csp = {
-        "DIRECTIVES": {
-            "frame-src": tuple(["'self'"] + conf_settings._csp_frame_src)
-        }
-    }
-    with override_settings(DEBUG=False, CONTENT_SECURITY_POLICY=csp):
-        resp = client.get("/healthz")
-    csp_header = resp["Content-Security-Policy"]
-    for host in conf_settings._csp_frame_src:
-        assert host in csp_header
+def test_no_legacy_csp_settings():
+    assert not hasattr(conf_settings, "CSP_IMG_SRC")
+    assert not hasattr(conf_settings, "CSP_FRAME_SRC")

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -3,8 +3,13 @@ import importlib
 
 def test_twimg_in_csp_when_twitter_enabled(monkeypatch):
     monkeypatch.setenv("ENABLE_TWITTER_EMBEDS", "1")
+    monkeypatch.setenv("DJANGO_DEBUG", "0")
+    monkeypatch.setenv("DJANGO_SECRET_KEY", "test")
     from config import settings as conf_settings
     importlib.reload(conf_settings)
-    assert any("twimg.com" in h for h in conf_settings.CSP_IMG_SRC)
+    img_src = conf_settings.CONTENT_SECURITY_POLICY["DIRECTIVES"]["img-src"]
+    assert any("twimg.com" in h for h in img_src)
     monkeypatch.delenv("ENABLE_TWITTER_EMBEDS", raising=False)
+    monkeypatch.delenv("DJANGO_DEBUG", raising=False)
+    monkeypatch.delenv("DJANGO_SECRET_KEY", raising=False)
     importlib.reload(conf_settings)


### PR DESCRIPTION
## Summary
- define `EMBED_PROVIDERS` with image and frame hosts for YouTube, X, and Rumble and related enable flags
- build `img-src` and `frame-src` CSP directives from that map, including `'self'` and `data:`
- remove legacy `CSP_IMG_SRC` and `CSP_FRAME_SRC` variables
- add tests for provider hosts and absence of legacy keys

## Testing
- `python -m pytest tests/test_csp_header.py tests/test_settings.py core/tests/test_csp_headers.py core/tests/test_post_detail_media.py::PostDetailMediaTests::test_link_thumbnail_host_matches_csp_domains -q`


------
https://chatgpt.com/codex/tasks/task_e_68bba6dcb624832cac4a1427d41229fe