### PR TITLE
Log provider request outcomes and capture deploy checks

### DIFF
--- a/core/http_client.py
+++ b/core/http_client.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import logging
+from collections import Counter, defaultdict
 from typing import Optional
+from urllib.parse import urlparse
 
 import requests
 from requests.adapters import HTTPAdapter
@@ -18,6 +21,10 @@ _HEADERS = {
     ),
     "Accept-Language": "en-US,en;q=0.9",
 }
+
+logger = logging.getLogger(__name__)
+# provider -> Counter(success=, error=)
+COUNTERS: dict[str, Counter] = defaultdict(Counter)
 
 
 def get_session() -> requests.Session:
@@ -39,14 +46,24 @@ def get_session() -> requests.Session:
     return _SESSION
 
 
-def fetch_json(url: str) -> dict:
+def _log(url: str, source: str, status: int | None) -> None:
+    provider = urlparse(url).netloc
+    level = logging.INFO if status and status < 400 else logging.WARNING
+    key = "success" if status and status < 400 else "error"
+    COUNTERS[provider][key] += 1
+    logger.log(level, "provider=%s url=%s source=%s status=%s", provider, url, source, status)
+
+
+def fetch_json(url: str, source: str = "unknown") -> dict:
     """Fetch ``url`` and return the parsed JSON response."""
     resp = get_session().get(url, timeout=_TIMEOUT)
+    _log(url, source, getattr(resp, "status_code", None))
     resp.raise_for_status()
     return resp.json()
 
 
-def fetch_html(url: str) -> requests.Response:
+def fetch_html(url: str, source: str = "unknown") -> requests.Response:
     """Fetch ``url`` and return the raw response object."""
     resp = get_session().get(url, timeout=_TIMEOUT)
+    _log(url, source, getattr(resp, "status_code", None))
     return resp

--- a/core/oembed.py
+++ b/core/oembed.py
@@ -52,7 +52,7 @@ def fetch_oembed(url: str) -> dict:
     cache_ok = True
     if endpoint:
         try:
-            data = fetch_json(endpoint)
+            data = fetch_json(endpoint, source="oembed")
             html = data.get("html", "")
             thumb = data.get("thumbnail_url")
             clean = bleach.clean(
@@ -93,7 +93,7 @@ def fetch_oembed(url: str) -> dict:
         # Fallback simple link card
         title = None
         try:
-            resp = fetch_html(url)
+            resp = fetch_html(url, source="oembed")
             resp.raise_for_status()
             match = re.search(r"<title>(.*?)</title>", resp.text, re.IGNORECASE | re.DOTALL)
             if match:

--- a/core/tests/test_http_client.py
+++ b/core/tests/test_http_client.py
@@ -10,6 +10,8 @@ def test_get_session_sets_browser_user_agent(monkeypatch):
         captured.append(self.headers.get("User-Agent"))
 
         class DummyResp:
+            status_code = 200
+
             def raise_for_status(self):
                 pass
 
@@ -25,3 +27,32 @@ def test_get_session_sets_browser_user_agent(monkeypatch):
     assert len(captured) == 2
     assert all(h.startswith("Mozilla/5.0") for h in captured)
     http_client._SESSION = None
+
+
+def test_logging_and_counters(monkeypatch, caplog):
+    http_client.COUNTERS.clear()
+
+    class DummyResp:
+        status_code = 200
+
+        def json(self):
+            return {}
+
+        def raise_for_status(self):
+            pass
+
+    session = http_client.get_session()
+    monkeypatch.setattr(session, "get", lambda url, timeout: DummyResp())
+    with caplog.at_level("INFO"):
+        http_client.fetch_json("https://example.com/data", source="test")
+    assert http_client.COUNTERS["example.com"]["success"] == 1
+    assert "provider=example.com" in caplog.text
+
+    class BadResp:
+        status_code = 404
+
+    monkeypatch.setattr(session, "get", lambda url, timeout: BadResp())
+    with caplog.at_level("WARNING"):
+        http_client.fetch_html("https://example.com/miss", source="test")
+    assert http_client.COUNTERS["example.com"]["error"] == 1
+    assert "status=404" in caplog.text

--- a/core/utils/thumbnails.py
+++ b/core/utils/thumbnails.py
@@ -25,7 +25,7 @@ def scrape_og_image(url: str) -> tuple[Optional[str], Optional[int]]:
     domain = urlparse(url).netloc
     status = None
     try:
-        resp = fetch_html(url)
+        resp = fetch_html(url, source="og-image")
         status = resp.status_code
         resp.raise_for_status()
     except Exception:

--- a/docs/validation/deploy-check.txt
+++ b/docs/validation/deploy-check.txt
@@ -1,0 +1,11 @@
+System check identified some issues:
+
+WARNINGS:
+?: (security.W004) You have not set a value for the SECURE_HSTS_SECONDS setting. If your entire site is served only over SSL, you may want to consider setting a value and enabling HTTP Strict Transport Security. Be sure to read the documentation first; enabling HSTS carelessly can cause serious, irreversible problems.
+?: (security.W008) Your SECURE_SSL_REDIRECT setting is not set to True. Unless your site should be available over both SSL and non-SSL connections, you may want to either set this setting True or configure a load balancer or reverse-proxy server to redirect all connections to HTTPS.
+?: (security.W009) Your SECRET_KEY has less than 50 characters, less than 5 unique characters, or it's prefixed with 'django-insecure-' indicating that it was generated automatically by Django. Please generate a long and random value, otherwise many of Django's security-critical features will be vulnerable to attack.
+?: (security.W012) SESSION_COOKIE_SECURE is not set to True. Using a secure-only session cookie makes it more difficult for network traffic sniffers to hijack user sessions.
+?: (security.W016) You have 'django.middleware.csrf.CsrfViewMiddleware' in your MIDDLEWARE, but you have not set CSRF_COOKIE_SECURE to True. Using a secure-only CSRF cookie makes it more difficult for network traffic sniffers to steal the CSRF token.
+?: (security.W018) You should not have DEBUG set to True in deployment.
+
+System check identified 6 issues (0 silenced).

--- a/docs/validation/rumble.txt
+++ b/docs/validation/rumble.txt
@@ -1,0 +1,7 @@
+Retrying (Retry(total=1, connect=None, read=None, redirect=None, status=None)) after connection broken by 'OSError('Tunnel connection failed: 403 Forbidden')': /api/oembed.json?url=https%3A%2F%2Frumble.com%2Fvxyz-test.html
+Retrying (Retry(total=0, connect=None, read=None, redirect=None, status=None)) after connection broken by 'OSError('Tunnel connection failed: 403 Forbidden')': /api/oembed.json?url=https%3A%2F%2Frumble.com%2Fvxyz-test.html
+Retrying (Retry(total=1, connect=None, read=None, redirect=None, status=None)) after connection broken by 'OSError('Tunnel connection failed: 403 Forbidden')': /vxyz-test.html
+Retrying (Retry(total=0, connect=None, read=None, redirect=None, status=None)) after connection broken by 'OSError('Tunnel connection failed: 403 Forbidden')': /vxyz-test.html
+22 objects imported automatically (use -v 2 for details).
+
+<div class="link-card"><a href="https://rumble.com/vxyz-test.html" rel="noopener nofollow">rumble.com</a></div>

--- a/docs/validation/x.txt
+++ b/docs/validation/x.txt
@@ -1,0 +1,7 @@
+Retrying (Retry(total=1, connect=None, read=None, redirect=None, status=None)) after connection broken by 'OSError('Tunnel connection failed: 403 Forbidden')': /oembed?omit_script=1&url=https%3A%2F%2Fx.com%2Fjack%2Fstatus%2F20
+Retrying (Retry(total=0, connect=None, read=None, redirect=None, status=None)) after connection broken by 'OSError('Tunnel connection failed: 403 Forbidden')': /oembed?omit_script=1&url=https%3A%2F%2Fx.com%2Fjack%2Fstatus%2F20
+Retrying (Retry(total=1, connect=None, read=None, redirect=None, status=None)) after connection broken by 'OSError('Tunnel connection failed: 403 Forbidden')': /jack/status/20
+Retrying (Retry(total=0, connect=None, read=None, redirect=None, status=None)) after connection broken by 'OSError('Tunnel connection failed: 403 Forbidden')': /jack/status/20
+22 objects imported automatically (use -v 2 for details).
+
+<div class="link-card"><a href="https://x.com/jack/status/20" rel="noopener nofollow">x.com</a></div>

--- a/docs/validation/youtube.txt
+++ b/docs/validation/youtube.txt
@@ -1,0 +1,7 @@
+Retrying (Retry(total=1, connect=None, read=None, redirect=None, status=None)) after connection broken by 'OSError('Tunnel connection failed: 403 Forbidden')': /oembed?format=json&url=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3DdQw4w9WgXcQ
+Retrying (Retry(total=0, connect=None, read=None, redirect=None, status=None)) after connection broken by 'OSError('Tunnel connection failed: 403 Forbidden')': /oembed?format=json&url=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3DdQw4w9WgXcQ
+Retrying (Retry(total=1, connect=None, read=None, redirect=None, status=None)) after connection broken by 'OSError('Tunnel connection failed: 403 Forbidden')': /watch?v=dQw4w9WgXcQ
+Retrying (Retry(total=0, connect=None, read=None, redirect=None, status=None)) after connection broken by 'OSError('Tunnel connection failed: 403 Forbidden')': /watch?v=dQw4w9WgXcQ
+22 objects imported automatically (use -v 2 for details).
+
+<div class="link-card"><a href="https://www.youtube.com/watch?v=dQw4w9WgXcQ" rel="noopener nofollow">www.youtube.com</a></div>


### PR DESCRIPTION
## Summary
- track per-provider request success and error counts with structured logging
- route oEmbed and OG-image lookups through the logging helper
- record deploy checks and embed smoke test output under `docs/validation/`

## Testing
- `python manage.py check --deploy`
- `pytest core/tests/test_http_client.py`
- ⚠️ `pytest` *(fails: ModuleNotFoundError: No module named 'config')*


------
https://chatgpt.com/codex/tasks/task_e_68bbaa45a4c0832c87f47fbf06c164a7