### PR TITLE
test: expand embed and CSP coverage

### DIFF
--- a/core/tests/test_feed_thumbnails.py
+++ b/core/tests/test_feed_thumbnails.py
@@ -52,6 +52,8 @@ class FeedThumbnailTests(TestCase):
             const code = fs.readFileSync('static/js/embeds.js', 'utf8');
             eval(code);
             window.initEmbeds(document);
+            const before = document.querySelector('iframe');
+            console.log(before ? before.outerHTML : '');
             const link = document.querySelector('a');
             link.dispatchEvent(new window.Event('click', { bubbles: true }));
             const iframe = document.querySelector('iframe');
@@ -59,7 +61,9 @@ class FeedThumbnailTests(TestCase):
             """
         )
         result = subprocess.run(["node", "-e", script], capture_output=True, text=True, check=True)
-        out = result.stdout.strip()
-        self.assertIn("<iframe", out)
-        self.assertIn('allowfullscreen', out)
-        self.assertIn('referrerpolicy="no-referrer"', out)
+        lines = result.stdout.splitlines()
+        self.assertEqual(len(lines), 2)
+        self.assertNotIn('<iframe', lines[0])
+        self.assertIn('<iframe', lines[1])
+        self.assertIn('allowfullscreen', lines[1])
+        self.assertIn('referrerpolicy="no-referrer"', lines[1])

--- a/core/tests/test_oembed.py
+++ b/core/tests/test_oembed.py
@@ -33,6 +33,7 @@ class OEmbedTests(TestCase):
     def test_fetch_oembed_removes_scripts(self):
         sample_html = '<iframe src="https://youtube.com/embed/abc"></iframe><script>alert(1)</script>'
         resp = _mock_json_response({"html": sample_html})
+        http_client._SESSION = None
         session = http_client.get_session()
         session.get = Mock(return_value=resp)
         with patch("core.http_client.get_session", return_value=session):
@@ -48,7 +49,7 @@ class OEmbedTests(TestCase):
         url = "https://www.youtube.com/watch?v=abc"
         cache.clear()
         sample_html = "<iframe></iframe>"
-        with patch("core.http_client.fetch_json", return_value={"html": sample_html}) as mock_json:
+        with patch("core.oembed.fetch_json", return_value={"html": sample_html}) as mock_json:
             fetch_oembed(url)
             fetch_oembed(url)
         self.assertEqual(mock_json.call_count, 1)
@@ -58,8 +59,19 @@ class OEmbedTests(TestCase):
         cache.clear()
         def raise_http_error(*args, **kwargs):
             raise requests.HTTPError(response=Mock(status_code=500))
-        with patch("core.http_client.fetch_json", side_effect=raise_http_error) as mock_json, \
-             patch("core.http_client.fetch_html", return_value=_mock_html_response("<title>t</title>")):
+        with patch("core.oembed.fetch_json", side_effect=raise_http_error) as mock_json, \
+             patch("core.oembed.fetch_html", return_value=_mock_html_response("<title>t</title>")):
             fetch_oembed(url)
             fetch_oembed(url)
         self.assertEqual(mock_json.call_count, 2)
+
+    def test_fetch_oembed_logs_provider_host(self):
+        http_client.COUNTERS.clear()
+        cache.clear()
+        resp = _mock_json_response({"html": "<iframe></iframe>"})
+        http_client._SESSION = None
+        session = http_client.get_session()
+        session.get = Mock(return_value=resp)
+        with patch("core.http_client.get_session", return_value=session):
+            fetch_oembed("https://www.youtube.com/watch?v=xyz")
+        self.assertEqual(http_client.COUNTERS["www.youtube.com"]["success"], 1)

--- a/core/tests/test_thumbnails.py
+++ b/core/tests/test_thumbnails.py
@@ -1,6 +1,9 @@
-from unittest.mock import patch
 import os
+from unittest.mock import Mock, patch
+
 from django.core.cache import cache
+
+from core import http_client
 from core.utils import thumbnails
 
 
@@ -55,3 +58,18 @@ def test_fetch_og_image_no_cache_on_error():
             assert thumbnails.fetch_og_image(url) is None
             assert thumbnails.fetch_og_image(url) is None
     assert mock_scrape.call_count == 2
+
+
+def test_scrape_og_image_logs_provider_and_ua():
+    http_client.COUNTERS.clear()
+    resp = Mock()
+    resp.status_code = 200
+    resp.text = "<html></html>"
+    resp.raise_for_status = lambda: None
+    session = http_client.get_session()
+    session.get = Mock(return_value=resp)
+    with patch('core.http_client.get_session', return_value=session):
+        thumbnails.scrape_og_image('https://example.com/post')
+    headers = session.headers
+    assert headers['User-Agent'].startswith('Mozilla/5.0')
+    assert http_client.COUNTERS['example.com']['success'] == 1

--- a/tests/test_csp_header.py
+++ b/tests/test_csp_header.py
@@ -29,6 +29,31 @@ def test_csp_header_includes_provider_hosts(client, provider):
         assert host in csp_header
 
 
+def test_csp_header_has_directives(client):
+    csp = {
+        "DIRECTIVES": {
+            "default-src": ("'self'",),
+            "img-src": ("'self'", "data:"),
+            "frame-src": ("'self'",),
+        }
+    }
+    with override_settings(DEBUG=False, CONTENT_SECURITY_POLICY=csp):
+        resp = client.get("/healthz")
+    csp_header = resp["Content-Security-Policy"]
+    assert "default-src" in csp_header
+    assert "img-src" in csp_header
+    assert "frame-src" in csp_header
+
+
 def test_no_legacy_csp_settings():
     assert not hasattr(conf_settings, "CSP_IMG_SRC")
     assert not hasattr(conf_settings, "CSP_FRAME_SRC")
+
+
+def test_no_legacy_csp_templates():
+    from pathlib import Path
+
+    for path in Path("templates").rglob("*.html"):
+        text = path.read_text()
+        assert "CSP_IMG_SRC" not in text
+        assert "CSP_FRAME_SRC" not in text


### PR DESCRIPTION
## Summary
- extend oEmbed tests for provider host logging and cache behavior
- assert scraper uses browser headers and logs provider domains
- guard against stale CSP settings and verify directives
- ensure embed iframes render only after click

## Testing
- `pytest core/tests/test_oembed.py core/tests/test_thumbnails.py core/tests/test_feed_thumbnails.py tests/test_csp_header.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bbab7af744832c83e10e1cdf8cb73c