### PR TITLE
docs: add video preview governance

### DIFF
--- a/config/env.schema.json
+++ b/config/env.schema.json
@@ -1,0 +1,5 @@
+{
+  "ENABLE_YOUTUBE_EMBEDS": "bool",
+  "ENABLE_TWITTER_EMBEDS": "bool",
+  "ENABLE_RUMBLE_EMBEDS": "bool"
+}

--- a/config/provider_map.yml
+++ b/config/provider_map.yml
@@ -1,0 +1,9 @@
+youtube:
+  img_hosts: ["i.ytimg.com"]
+  frame_hosts: ["www.youtube-nocookie.com"]
+x:
+  img_hosts: ["*.twimg.com"]
+  frame_hosts: ["platform.twitter.com", "*.twitter.com", "*.x.com"]
+rumble:
+  img_hosts: ["*.rumblecdn.com", "*.rmbl.ws"]
+  frame_hosts: ["rumble.com", "*.rumble.com"]

--- a/docs/adrs/0001-video-previews-governance.md
+++ b/docs/adrs/0001-video-previews-governance.md
@@ -1,0 +1,15 @@
+# ADR 0001: Governance of Video Previews
+
+**Context**
+- Past merges caused drift (legacy CSP keys, mixed fetch paths).
+- Feature depends on strict alignment: CSP, flags, outbound client.
+
+**Decision**
+- Adopt a single provider map as SSOT for hosts and flags.
+- CSP directives computed exclusively from that map.
+- All network fetches routed through shared HTTP client.
+- CI enforces drift checks (CSP schema, snapshot parity, requests.get ban, env schema).
+
+**Consequences**
+- Changes to preview behavior require updating provider map + CSP snapshot in same PR.
+- Faster, more predictable releases.

--- a/docs/policies/video-previews.md
+++ b/docs/policies/video-previews.md
@@ -1,0 +1,16 @@
+# Policy: Video Thumbnails & Previews
+
+**Scope:** YouTube, X, Rumble link posts.
+
+- All outbound fetches go through the shared HTTP client (browser UA, timeouts, retries).
+- Provider map (`config/provider_map.yml`) is the single source of truth for hosts + flags.
+- CSP v4+ only. Directives derived from provider map; no legacy `CSP_*` settings allowed.
+- Rendering:
+  - Feed → static card with thumbnail + overlay, no iframe.
+  - Detail → click-to-play iframe, secure attributes.
+- Caching:
+  - Cache successful metadata (short TTL).
+  - Never cache errors; error responses return `Cache-Control: no-store`.
+- Observability:
+  - Structured logs `{provider, url, source, status}`.
+- Drift checks must run in CI before merge.

--- a/docs/status/video-previews.yml
+++ b/docs/status/video-previews.yml
@@ -1,0 +1,16 @@
+feature: video-previews
+version: v3
+status:
+  unified_fetching: true
+  provider_map: true
+  csp_v4: true
+  thumbnail_priority: true
+  rendering: true
+  caching: true
+  observability: true
+drift_checks:
+  csp_schema_gate: enabled
+  csp_snapshot_parity: enabled
+  requests_get_ban: enabled
+  env_schema: enabled
+  header_parity: enabled


### PR DESCRIPTION
## Summary
- document policy and ADR for video previews
- track feature status and drift checks
- seed provider map and env schema

## Testing
- `make test` *(fails: ValueError: Missing staticfiles manifest entry for 'css/app.css')*

------
https://chatgpt.com/codex/tasks/task_e_68bbb214a0cc832cbf3955bc04fc4b68