### PR TITLE
docs: switch video embeds to thumbnails only

### DIFF
--- a/docs/UI-Flow.md
+++ b/docs/UI-Flow.md
@@ -43,7 +43,7 @@
 
 * Title (H1)
 * Meta: **by** {username} **in** {community} · {timeago}
-* **Media priority:** gallery → uploaded image → embed preview (YouTube/Rumble/X) → plain link
+* **Media priority:** gallery → uploaded image → link thumbnail (YouTube/Rumble/X) → plain link
 * Body (optional; require media **or** body)
 * **Actions row:** ▲ score ▼ · **Astro chip** (green/amber/red)
 * **Comment composer:** empty box + Cancel/Comment buttons (auth-gated)
@@ -71,12 +71,13 @@
 
 1. **Home feed** → click a **community** (e.g., `r/brisbane`) → **Community feed**
 2. Click a **post title/thumb** → **Post detail**
-3. Attempt to **comment** → redirect to **Login** → back to **Post detail** after auth
+3. Click the **video thumbnail** → provider opens in new tab
+4. Attempt to **comment** → redirect to **Login** → back to **Post detail** after auth
 
 ### B) Engaging as an authenticated user
 
 1. **Home**/**Community** → vote on cards; click to **Post detail**
-2. In **Post detail**: media shows at top; body below; actions row includes astro chip
+2. In **Post detail**: static thumbnail at top; clicking opens provider in new tab; body below; actions row includes astro chip
 3. **Comment:** write + submit; thread updates; reply at any depth
 
 ### C) Submitting content
@@ -92,6 +93,7 @@
 flowchart LR
   A[Home /] -->|click community| B[Community /r/<slug>/]
   B -->|click post| C[Post detail /r/<c>/comments/<id>/<slug>/]
+  C -->|click thumbnail| X[Provider site (new tab)]
   C -->|comment (guest)| D[Login /accounts/login/]
   D -->|success| C
   C -->|submit comment| C
@@ -103,12 +105,13 @@ flowchart LR
 flowchart TB
   subgraph PostDetail
     P1[Title + meta]
-    P2[Media: gallery→image→embed]
+    P2[Media: gallery→image→thumbnail]
     P3[Body (optional)]
     P4[Actions: ▲ score ▼ + Astro chip]
     P5[Composer]
     P6[Thread: nested comments]
     P1 --> P2 --> P3 --> P4 --> P5 --> P6
+    P2 --> L[Provider opens in new tab]
   end
 ```
 
@@ -167,4 +170,9 @@ flowchart TB
 
 * v3.0 (today): initial sitemap, flows, comment contract, preview contract, routes & selectors
 * (append entries as flows change)
+
+## See also (authoritative sources)
+- [Video thumbnail spec](video-thumbnail-spec.md)
+- [UI Contract V3](UI-contract-V3.md)
+- [Wireframes](wireframes/README.md)
 

--- a/docs/UI-contract-V3.md
+++ b/docs/UI-contract-V3.md
@@ -37,7 +37,7 @@
 - Hook: `data-testid="submit-form"`
 
 ## Post Detail
-- OP card: full content
+- OP card: full content with static thumbnail only (no embed)
 - Comment input
 - Comments list: author/time/body/actions
 
@@ -55,6 +55,11 @@
 - Right sidebar with Account/Login, Submit, Astro
 - Feed with `data-testid="post-card"`
 - Submit form with `data-testid="submit-form"`
-- Post detail shows post + comments
+- Post detail shows post + comments; media is static thumbnail only (no embed)
 - Footer: Terms · Privacy · About
+
+## See also (authoritative sources)
+- [Video thumbnail spec](video-thumbnail-spec.md)
+- [UI Flow](UI-Flow.md)
+- [Wireframes](wireframes/README.md)
 

--- a/docs/video-thumbnail-spec.md
+++ b/docs/video-thumbnail-spec.md
@@ -1,13 +1,20 @@
-# Feature Spec: Video Thumbnails & Previews (YouTube, X, Rumble)
+# Feature Spec: Video Thumbnails (YouTube, X, Rumble)
 
 ## Goal
-Link posts from YouTube, X (Twitter), and Rumble show a reliable thumbnail and safe preview card in the feed, with click-to-play embeds on the detail page.
----
-## Steps
-1. **Unified Fetching** – all oEmbed + OG scrapes use a single HTTP client with browser-like UA, retries, and timeouts.
-2. **Provider Map** – one settings dict for YouTube/X/Rumble (img_hosts, frame_hosts), gated by ENABLE_* flags.
-3. **CSP v4+** – compute img-src and frame-src from the provider map; remove legacy keys.
-4. **Thumbnail Priority** – oEmbed thumbnail_url → provider default → OG image → fallback SVG.
-5. **Rendering** – feed shows card with thumbnail + play overlay; detail page lazy-loads iframe.
-6. **Cache & Headers** – cache successful results; don’t cache errors; set Cache-Control: no-store for error responses.
-7. **Validation** – run manage.py check --deploy locally; smoke-test one link per provider; ensure no CSP errors in console.
+No embeds anywhere; thumbnail card only on feed and detail.
+
+## Thumbnail requirements
+- 16:9 crop (`aspect-ratio: 16/9`)
+- `object-fit: cover`
+- Rounded corners
+- Lazy loading
+- Alt text
+- Provider label
+
+## Click behavior
+- Opens provider in a new tab (`target="_blank"`) with `rel="noreferrer noopener"`.
+
+## See also (authoritative sources)
+- [UI Contract V3](UI-contract-V3.md)
+- [UI Flow](UI-Flow.md)
+- [Wireframes](wireframes/README.md)

--- a/docs/wireframes/README.md
+++ b/docs/wireframes/README.md
@@ -1,6 +1,6 @@
 # SureJan V3 — Wireframes
 
-This folder contains the exported **Penpot wireframes** for SureJan V3.
+This folder contains the exported **Penpot wireframes** for SureJan V3. Video previews/embeds are deprecated; all wireframes show thumbnail-only references.
 
 ## Pages covered
 - **Main Page** (`V3-Main-Page.svg/png`)
@@ -21,9 +21,14 @@ This folder contains the exported **Penpot wireframes** for SureJan V3.
   - Same left/right sidebars as other pages
 
 ## Usage
-- These wireframes are **layout references only**.  
-- All code must follow the authoritative spec in `docs/V3-onepager.md` and `docs/UI-contract-V3.md`.  
+- These wireframes are **layout references only**.
+- All code must follow the authoritative spec in `docs/V3-onepager.md` and `docs/UI-contract-V3.md`.
 - If wireframes or layout change, update this folder and the spec files in the **same PR**.
+
+## See also (authoritative sources)
+- [Video thumbnail spec](../video-thumbnail-spec.md)
+- [UI Contract V3](../UI-contract-V3.md)
+- [UI Flow](../UI-Flow.md)
 
 ## Export formats
 - `.svg` → scalable vector reference for dev/design


### PR DESCRIPTION
## Summary
- clarify video specs: no embeds, thumbnail card only with provider link
- state post detail uses static thumbnail and remove embed previews from flow
- deprecate video embeds in wireframes and cross-link docs as authorities

## Testing
- `make test` *(fails: Ran 149 tests, failures=7, errors=55, skipped=2)*

------
https://chatgpt.com/codex/tasks/task_e_68bbbc97b20c832ca7d6b145773f302f