### PR TITLE
Simplify post previews and remove unused embeds

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -282,24 +282,6 @@ body.layout-root {
   object-fit:cover;        /* fill the frame */
 }
 
-.play-overlay{
-  position:absolute;
-  inset:0;
-  display:flex;
-  align-items:center;
-  justify-content:center;
-  background:rgba(0,0,0,0.35);
-  pointer-events:none;
-}
-.play-overlay::before{
-  content:"";
-  width:0;
-  height:0;
-  border-left:24px solid #fff;
-  border-top:14px solid transparent;
-  border-bottom:14px solid transparent;
-}
-
 /* Post detail media */
 .post-media{ margin:16px 0; }
 .post-media img{

--- a/templates/core/partials/post_row.html
+++ b/templates/core/partials/post_row.html
@@ -1,15 +1,15 @@
 <article id="post-{{ post.pk }}" class="post-card" data-testid="post-card">
   {% with detail_url=post.get_absolute_url %}
     {% if post.embed_thumb %}
-    <a href="{{ detail_url }}" class="thumb">
-      <img src="{{ post.embed_thumb }}" alt="{{ post.embed_thumb_alt }}" width="120" height="120" loading="lazy" decoding="async" referrerpolicy="no-referrer">
+    <a href="{{ detail_url }}" class="thumb" style="aspect-ratio:16/9;" aria-label="Open post">
+      <img src="{{ post.embed_thumb }}" alt="{{ post.embed_thumb_alt }}" width="640" height="360" loading="lazy" decoding="async" referrerpolicy="no-referrer">
     </a>
     {% elif post.image_thumb or post.image %}
-    <a href="{{ detail_url }}" class="thumb">
+    <a href="{{ detail_url }}" class="thumb" style="aspect-ratio:16/9;" aria-label="Open post">
       {% if post.image_thumb %}
-      <img src="{{ post.image_thumb.url }}" alt="" width="120" height="120" loading="lazy" decoding="async">
+      <img src="{{ post.image_thumb.url }}" alt="{{ post.title }}" width="640" height="360" loading="lazy" decoding="async" referrerpolicy="no-referrer">
       {% else %}
-      <img src="{{ post.image.url }}" alt="" width="120" height="120" loading="lazy" decoding="async">
+      <img src="{{ post.image.url }}" alt="{{ post.title }}" width="640" height="360" loading="lazy" decoding="async" referrerpolicy="no-referrer">
       {% endif %}
     </a>
     {% endif %}

--- a/templates/core/post_detail.html
+++ b/templates/core/post_detail.html
@@ -17,38 +17,30 @@
     </div>
   </header>
 
-{% comment %} Media priority: gallery → upload → link thumbnail {% endcomment %}
-{% if images %}
-  <div class="post-gallery">
-    {% for link in images %}
-      <figure class="post-media">
-        <img
-          src="{{ link.url|default:link }}"
-          alt="{{ post.title }}"
-          loading="lazy" decoding="async" referrerpolicy="no-referrer"
-          onerror="this.onerror=null; this.closest('figure').remove()"
-        >
-      </figure>
-    {% endfor %}
-  </div>
-{% elif post.image %}
-  <figure class="post-media">
+{% if post.embed_thumb %}
+  <a href="{{ post.content_url }}" target="_blank" rel="noreferrer noopener" class="thumb" style="aspect-ratio:16/9;" aria-label="Open content">
     <img
-      src="{{ post.image.url }}"
-      alt="{{ post.title }}"
+      src="{{ post.embed_thumb }}"
+      alt="{{ post.embed_thumb_alt }}"
       loading="lazy" decoding="async" referrerpolicy="no-referrer"
-      onerror="this.onerror=null; this.closest('figure').remove()"
-    >
-  </figure>
-{% elif post.thumbnail_url %}
-  <figure class="post-media">
-    <img
-      src="{{ post.thumbnail_url }}"
-      alt="{{ post.thumbnail_alt|default:post.title }}"
-      loading="lazy" decoding="async" referrerpolicy="no-referrer"
-      onerror="this.onerror=null; this.closest('figure').remove()"
-    >
-  </figure>
+      width="640" height="360">
+  </a>
+{% elif post.image_thumb or post.image %}
+  <a href="{{ post.content_url }}" target="_blank" rel="noreferrer noopener" class="thumb" style="aspect-ratio:16/9;" aria-label="Open content">
+    {% if post.image_thumb %}
+      <img
+        src="{{ post.image_thumb.url }}"
+        alt="{{ post.title }}"
+        loading="lazy" decoding="async" referrerpolicy="no-referrer"
+        width="640" height="360">
+    {% else %}
+      <img
+        src="{{ post.image.url }}"
+        alt="{{ post.title }}"
+        loading="lazy" decoding="async" referrerpolicy="no-referrer"
+        width="640" height="360">
+    {% endif %}
+  </a>
 {% endif %}
 
   {% if post.body %}

--- a/templates/partials/feed_card.html
+++ b/templates/partials/feed_card.html
@@ -9,7 +9,6 @@
         alt="{{ post.embed_thumb_alt }}"
         loading="lazy" decoding="async" referrerpolicy="no-referrer"
         width="640" height="360">
-      <span class="play-overlay" aria-hidden="true"></span>
     </a>
   {% elif post.image_thumb or post.image %}
     <a href="{{ detail_url }}" class="thumb" style="aspect-ratio:16/9;" aria-label="Open post">
@@ -17,13 +16,13 @@
         <img
           src="{{ post.image_thumb.url }}"
           alt="{{ post.title }}"
-          loading="lazy" decoding="async"
+          loading="lazy" decoding="async" referrerpolicy="no-referrer"
           width="640" height="360">
       {% else %}
         <img
           src="{{ post.image.url }}"
           alt="{{ post.title }}"
-          loading="lazy" decoding="async"
+          loading="lazy" decoding="async" referrerpolicy="no-referrer"
           width="640" height="360">
       {% endif %}
     </a>


### PR DESCRIPTION
## Summary
- unify feed and row thumbnails with no-referrer images and no play overlay
- show feed-style thumbnail on post detail linking to content
- drop obsolete play-overlay CSS

## Testing
- `pytest` *(fails: Requested setting INSTALLED_APPS, but settings are not configured)*
- `python manage.py test` *(fails: Missing staticfiles manifest entries)*

------
https://chatgpt.com/codex/tasks/task_e_68bbc5775540832cb3957005a6a526a9