### PR TITLE
chore: tighten frame CSP

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -137,7 +137,6 @@ if not DEBUG:
     for provider in EMBED_PROVIDERS.values():
         _img_src.extend(provider["img_hosts"])
     _img_src.append("data:")
-    _frame_src = ["'self'"]
 
     CONTENT_SECURITY_POLICY = {
         "DIRECTIVES": {
@@ -146,7 +145,7 @@ if not DEBUG:
             "style-src": ("'self'", "'unsafe-inline'"),
             "img-src": tuple(_img_src),
             "connect-src": ("'self'",),
-            "frame-src": tuple(_frame_src),
+            "frame-src": ("'self'",),
             "frame-ancestors": ("'self'",),
             "upgrade-insecure-requests": True,
             "base-uri": ("'self'",),

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -35,7 +35,7 @@ The production CSP restricts external media to a small, documented set:
 * `https://*.rumblecdn.com`, `https://*.rumble.com`, and `https://*.rmbl.ws` – Rumble thumbnails.
 * `data:` – inline SVG placeholders.
 
-Frames are restricted to `'self'`; no external frame hosts are allowed.
+Frames: `frame-src` is `'self'`; no external origins are allowed.
 
 ### Moderation
 

--- a/docs/policies/runtime-observability.md
+++ b/docs/policies/runtime-observability.md
@@ -32,6 +32,7 @@ All fetch/render operations log structured events:
 
 * Enable `/_csp-report` endpoint.
 * Log `{directive, blocked_uri, document_uri, user_agent}`.
+* No external frame origins: `frame-src` is always `'self'`.
 
 **Why:** catch real-world CSP breaks in prod (e.g. twimg host not whitelisted).
 


### PR DESCRIPTION
## Summary
- lock frame-src to 'self'
- document that no external frame origins are required

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bbc6ba4b64832c8e84f027c0005d64