### PR TITLE
Add thumbnail display tests and iframe smoke check

### DIFF
--- a/core/tests/test_feed_thumbnails.py
+++ b/core/tests/test_feed_thumbnails.py
@@ -1,0 +1,49 @@
+import re
+from io import BytesIO
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.core.files.uploadedfile import SimpleUploadedFile
+
+from PIL import Image
+
+from core.models import Community, Post
+
+
+@pytest.mark.django_db
+def test_feed_thumbnails_are_images(client):
+    User = get_user_model()
+    user = User.objects.create_user("alice", password="pw")
+    com = Community.objects.create(slug="t", name="Test", title="Test", created_by=user)
+
+    # Image post with uploaded picture
+    buf = BytesIO()
+    Image.new("RGB", (10, 10), "white").save(buf, format="JPEG")
+    img = SimpleUploadedFile("a.jpg", buf.getvalue(), content_type="image/jpeg")
+    Post.objects.create(
+        community=com,
+        author=user,
+        post_type="image",
+        title="Img",
+        image=img,
+    )
+
+    # Link post with explicit thumbnail
+    Post.objects.create(
+        community=com,
+        author=user,
+        post_type="link",
+        title="Link",
+        content_url="https://example.com",
+        thumbnail_url="https://example.com/thumb.jpg",
+    )
+
+    resp = client.get("/")
+    html = resp.content.decode()
+    cards = re.findall(
+        r"<article[^>]*data-testid=\"post-card\"[^>]*>(.*?)</article>", html, re.DOTALL
+    )
+    assert len(cards) == 2
+    for card in cards:
+        assert "<img" in card
+        assert "<iframe" not in card

--- a/core/tests/test_oembed.py
+++ b/core/tests/test_oembed.py
@@ -1,0 +1,23 @@
+import pytest
+from django.contrib.auth import get_user_model
+from django.core.management import call_command
+
+from core.models import Community, Post
+
+
+@pytest.mark.django_db
+def test_backfill_thumbs_populates_thumbnail_url(client):
+    User = get_user_model()
+    user = User.objects.create_user("alice", password="pw")
+    com = Community.objects.create(slug="t", name="Test", title="Test", created_by=user)
+    post = Post.objects.create(
+        community=com,
+        author=user,
+        post_type="link",
+        title="Video",
+        content_url="https://youtu.be/dQw4w9WgXcQ",
+    )
+    assert post.thumbnail_url == ""
+    call_command("backfill_thumbs", limit=10)
+    post.refresh_from_db()
+    assert post.thumbnail_url != ""

--- a/core/tests/test_post_detail_media.py
+++ b/core/tests/test_post_detail_media.py
@@ -1,0 +1,41 @@
+import re
+from io import BytesIO
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.core.files.uploadedfile import SimpleUploadedFile
+
+from PIL import Image
+
+from core.models import Community, Post
+
+
+@pytest.mark.django_db
+def test_post_detail_shows_thumbnail_and_link(client):
+    User = get_user_model()
+    user = User.objects.create_user("alice", password="pw")
+    com = Community.objects.create(slug="t", name="Test", title="Test", created_by=user)
+
+    buf = BytesIO()
+    Image.new("RGB", (10, 10), "white").save(buf, format="JPEG")
+    img = SimpleUploadedFile("a.jpg", buf.getvalue(), content_type="image/jpeg")
+    post = Post.objects.create(
+        community=com,
+        author=user,
+        post_type="image",
+        title="Img",
+        image=img,
+        content_url="https://example.com/full.jpg",
+    )
+
+    feed_html = client.get("/").content.decode()
+    feed_src = re.search(r"<img\s+src=\"([^\"]+)\"", feed_html).group(1)
+
+    detail_html = client.get(post.get_absolute_url()).content.decode()
+    detail_match = re.search(r"<img\s+src=\"([^\"]+)\"", detail_html)
+    assert detail_match
+    detail_src = detail_match.group(1)
+    assert detail_src == feed_src
+    assert f'href="{post.content_url}"' in detail_html
+    assert 'target="_blank"' in detail_html
+    assert 'rel="noreferrer noopener"' in detail_html

--- a/tests/test_no_iframes.py
+++ b/tests/test_no_iframes.py
@@ -1,0 +1,24 @@
+import pytest
+from django.contrib.auth import get_user_model
+
+from core.models import Community, Post
+
+
+@pytest.mark.django_db
+def test_no_iframes_in_rendered_pages(client):
+    User = get_user_model()
+    user = User.objects.create_user("alice", password="pw")
+    com = Community.objects.create(slug="t", name="Test", title="Test", created_by=user)
+    post = Post.objects.create(
+        community=com,
+        author=user,
+        post_type="link",
+        title="Link",
+        content_url="https://example.com",
+        thumbnail_url="https://example.com/thumb.jpg",
+    )
+
+    urls = ["/", post.get_absolute_url()]
+    for url in urls:
+        html = client.get(url).content.decode()
+        assert "<iframe" not in html


### PR DESCRIPTION
## Summary
- add feed thumbnail test ensuring images render without iframes
- test post detail thumbnail matches feed and link attributes
- repurpose oembed tests for thumbnail backfill command
- add smoke test forbidding iframe tags on pages

## Testing
- `pytest core/tests/test_feed_thumbnails.py core/tests/test_post_detail_media.py core/tests/test_oembed.py tests/test_no_iframes.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68bbc84e8e98832c9258885b00d0d7d3