### PR TITLE
Fix feed card thumbnail link

### DIFF
--- a/core/tests/test_links.py
+++ b/core/tests/test_links.py
@@ -96,3 +96,23 @@ class PostLinkTests(TestCase):
         request = self.factory.get("/")
         html = render_to_string("core/partials/post_row.html", {"post": self.post}, request=request)
         self.assertIn(f'href="{user_url}"', html)
+
+    def test_feed_card_embed_thumb_links_to_content_url(self):
+        post = Post.objects.create(
+            community=self.community,
+            author=self.user,
+            post_type="link",
+            title="Link",
+            content_url="https://example.com/article",
+        )
+        post.embed_thumb = "https://example.com/thumb.jpg"
+        request = self.factory.get("/")
+        html = render_to_string("partials/feed_card.html", {"post": post}, request=request)
+        detail_url = post.get_absolute_url()
+        self.assertIn(
+            f'href="{post.content_url}" target="_blank" rel="noopener noreferrer"',
+            html,
+        )
+        self.assertNotIn(f'href="{detail_url}" class="thumb"', html)
+        self.assertIn(f'href="{detail_url}"', html)
+        self.assertIn(f'href="{detail_url}#comments"', html)

--- a/templates/partials/feed_card.html
+++ b/templates/partials/feed_card.html
@@ -3,7 +3,7 @@
 {% with detail_url=post.get_absolute_url|default:None %}
   {% if not detail_url %}{% url 'post_detail_id' post.pk as detail_url %}{% endif %}
   {% if post.embed_thumb %}
-    <a href="{{ detail_url }}" class="thumb" style="aspect-ratio:16/9;" aria-label="Open post">
+    <a href="{{ post.content_url }}" target="_blank" rel="noopener noreferrer" class="thumb" style="aspect-ratio:16/9;" aria-label="Open post">
       <img
         src="{{ post.embed_thumb }}"
         alt="{{ post.embed_thumb_alt }}"


### PR DESCRIPTION
## Summary
- open embedded thumbnails to the external content in a new tab
- test feed card embedding link behavior

## Testing
- `pytest -q` *(fails: core/tests/test_oembed.py::test_backfill_thumbs_populates_thumbnail_url)*

------
https://chatgpt.com/codex/tasks/task_e_68bbe7485cac832c971388897a0540ff