### PR TITLE
Link embed thumbnails to content URL

### DIFF
--- a/core/tests/test_links.py
+++ b/core/tests/test_links.py
@@ -116,3 +116,21 @@ class PostLinkTests(TestCase):
         self.assertNotIn(f'href="{detail_url}" class="thumb"', html)
         self.assertIn(f'href="{detail_url}"', html)
         self.assertIn(f'href="{detail_url}#comments"', html)
+
+    def test_post_row_embed_thumb_links_to_content_url(self):
+        post = Post.objects.create(
+            community=self.community,
+            author=self.user,
+            post_type="link",
+            title="Link",
+            content_url="https://example.com/article",
+        )
+        post.embed_thumb = "https://example.com/thumb.jpg"
+        request = self.factory.get("/")
+        html = render_to_string("core/partials/post_row.html", {"post": post}, request=request)
+        detail_url = post.get_absolute_url()
+        self.assertIn(f'href="{post.content_url}" class="thumb"', html)
+        self.assertIn('target="_blank" rel="noopener noreferrer"', html)
+        self.assertNotIn(f'href="{detail_url}" class="thumb"', html)
+        self.assertIn(f'href="{detail_url}"', html)
+        self.assertIn(f'href="{detail_url}#comments"', html)

--- a/templates/core/partials/post_row.html
+++ b/templates/core/partials/post_row.html
@@ -1,7 +1,7 @@
 <article id="post-{{ post.pk }}" class="post-card" data-testid="post-card">
   {% with detail_url=post.get_absolute_url %}
     {% if post.embed_thumb %}
-    <a href="{{ detail_url }}" class="thumb" style="aspect-ratio:16/9;" aria-label="Open post">
+    <a href="{{ post.content_url }}" class="thumb" style="aspect-ratio:16/9;" aria-label="Open post" target="_blank" rel="noopener noreferrer">
       <img src="{{ post.embed_thumb }}" alt="{{ post.embed_thumb_alt }}" width="640" height="360" loading="lazy" decoding="async" referrerpolicy="no-referrer">
     </a>
     {% elif post.image_thumb or post.image %}


### PR DESCRIPTION
## Summary
- Open embed thumbnails in post rows directly to their external content in a new tab
- Add regression test ensuring embedded thumbnails link externally while image posts still link to detail view

## Testing
- `pytest -q` *(fails: core/tests/test_oembed.py::test_backfill_thumbs_populates_thumbnail_url - AssertionError: assert '' != '')*

------
https://chatgpt.com/codex/tasks/task_e_68bbe8b3b550832c9bfb87b622b074f4