### PR TITLE
Display provider labels on thumbnails

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -164,6 +164,13 @@ class Post(models.Model):
         text = re.sub(r"\s+", " ", text).strip()
         return Truncator(text).chars(180)
 
+    @property
+    def provider_name(self) -> str:
+        """Return a human-friendly name for the linked content provider."""
+        from .utils.providers import provider_from_domain
+
+        return provider_from_domain(self.link_domain)
+
     def get_absolute_url(self):
         return reverse("post_detail", args=[self.community.slug, self.pk, self.slug])
 

--- a/core/utils/providers.py
+++ b/core/utils/providers.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+"""Utilities for determining media provider names from domains."""
+
+# Mapping of known domains to their provider display names.
+_PROVIDER_MAP = {
+    "youtube.com": "YouTube",
+    "youtu.be": "YouTube",
+    "x.com": "X",
+    "twitter.com": "X",
+    "rumble.com": "Rumble",
+}
+
+
+def provider_from_domain(domain: str) -> str:
+    """Return a human-friendly provider name for ``domain``.
+
+    If the domain is not recognised, the domain itself is returned.
+    ``None`` or empty strings return an empty string.
+    """
+    if not domain:
+        return ""
+    domain = domain.lower().split(":", 1)[0]
+    if domain.startswith("www."):
+        domain = domain[4:]
+    for key, name in _PROVIDER_MAP.items():
+        if domain == key or domain.endswith("." + key):
+            return name
+    return domain

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -282,6 +282,35 @@ body.layout-root {
   object-fit:cover;        /* fill the frame */
 }
 
+/* Provider label overlay */
+.thumb-label{
+  position:absolute;
+  top:8px;
+  left:8px;
+  background:rgba(0,0,0,0.6);
+  color:#fff;
+  padding:2px 6px;
+  font-size:12px;
+  font-weight:600;
+  border-radius:4px;
+}
+
+/* Post detail thumbnail */
+.post-detail .thumb{
+  display:block;
+  border-radius:12px;
+  overflow:hidden;
+  background:#f2f2f2;
+  aspect-ratio:16/9;
+  position:relative;
+}
+.post-detail .thumb img{
+  display:block;
+  width:100%;
+  height:100%;
+  object-fit:cover;
+}
+
 /* Post detail media */
 .post-media{ margin:16px 0; }
 .post-media img{

--- a/templates/core/partials/post_row.html
+++ b/templates/core/partials/post_row.html
@@ -3,6 +3,7 @@
     {% if post.embed_thumb %}
     <a href="{{ post.content_url }}" class="thumb" style="aspect-ratio:16/9;" aria-label="Open post" target="_blank" rel="noopener noreferrer">
       <img src="{{ post.embed_thumb }}" alt="{{ post.embed_thumb_alt }}" width="640" height="360" loading="lazy" decoding="async" referrerpolicy="no-referrer">
+      {% if post.link_domain %}<span class="thumb-label">{{ post.provider_name }}</span>{% endif %}
     </a>
     {% elif post.image_thumb or post.image %}
     <a href="{{ detail_url }}" class="thumb" style="aspect-ratio:16/9;" aria-label="Open post">
@@ -11,6 +12,7 @@
       {% else %}
       <img src="{{ post.image.url }}" alt="{{ post.title }}" width="640" height="360" loading="lazy" decoding="async" referrerpolicy="no-referrer">
       {% endif %}
+      {% if post.link_domain %}<span class="thumb-label">{{ post.provider_name }}</span>{% endif %}
     </a>
     {% endif %}
     <div class="post-meta">

--- a/templates/core/post_detail.html
+++ b/templates/core/post_detail.html
@@ -24,6 +24,7 @@
       alt="{{ post.embed_thumb_alt }}"
       loading="lazy" decoding="async" referrerpolicy="no-referrer"
       width="640" height="360">
+    {% if post.link_domain %}<span class="thumb-label">{{ post.provider_name }}</span>{% endif %}
   </a>
 {% elif post.image_thumb or post.image %}
   <a href="{{ post.content_url }}" target="_blank" rel="noreferrer noopener" class="thumb" style="aspect-ratio:16/9;" aria-label="Open content">
@@ -40,6 +41,7 @@
         loading="lazy" decoding="async" referrerpolicy="no-referrer"
         width="640" height="360">
     {% endif %}
+    {% if post.link_domain %}<span class="thumb-label">{{ post.provider_name }}</span>{% endif %}
   </a>
 {% endif %}
 

--- a/templates/partials/feed_card.html
+++ b/templates/partials/feed_card.html
@@ -9,6 +9,7 @@
         alt="{{ post.embed_thumb_alt }}"
         loading="lazy" decoding="async" referrerpolicy="no-referrer"
         width="640" height="360">
+      {% if post.link_domain %}<span class="thumb-label">{{ post.provider_name }}</span>{% endif %}
     </a>
   {% elif post.image_thumb or post.image %}
     <a href="{{ detail_url }}" class="thumb" style="aspect-ratio:16/9;" aria-label="Open post">
@@ -25,6 +26,7 @@
           loading="lazy" decoding="async" referrerpolicy="no-referrer"
           width="640" height="360">
       {% endif %}
+      {% if post.link_domain %}<span class="thumb-label">{{ post.provider_name }}</span>{% endif %}
     </a>
   {% endif %}
   <div class="post-meta">

--- a/tests/test_provider_utils.py
+++ b/tests/test_provider_utils.py
@@ -1,0 +1,13 @@
+from core.utils.providers import provider_from_domain
+
+
+def test_provider_from_domain_known():
+    assert provider_from_domain("www.youtube.com") == "YouTube"
+    assert provider_from_domain("youtu.be") == "YouTube"
+    assert provider_from_domain("twitter.com") == "X"
+    assert provider_from_domain("subdomain.rumble.com") == "Rumble"
+
+
+def test_provider_from_domain_unknown():
+    assert provider_from_domain("example.com") == "example.com"
+    assert provider_from_domain("") == ""


### PR DESCRIPTION
## Summary
- map known domains to provider names
- expose Post.provider_name property
- overlay provider name on feed, post list and detail thumbnails

## Testing
- `python manage.py test` *(fails: Missing staticfiles manifest entry for 'css/app.css')*
- `python -m pytest tests/test_provider_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68bbeada7b6c832c9681646e1723a3de