### PR TITLE
Remove unused initEmbeds hook

### DIFF
--- a/static/js/post_submit_preview.js
+++ b/static/js/post_submit_preview.js
@@ -25,7 +25,6 @@ document.addEventListener('DOMContentLoaded', () => {
           }
           const html = await resp.text();
           linkPreview.innerHTML = html;
-          if (window.initEmbeds) window.initEmbeds(linkPreview);
         } catch (e) {
           linkPreview.innerHTML = '';
         }


### PR DESCRIPTION
## Summary
- remove leftover `initEmbeds` call from link preview script

## Testing
- `python manage.py test 2>&1 | tail -n 20` *(fails: failures=6, errors=42)*

------
https://chatgpt.com/codex/tasks/task_e_68bbecd66460832cbf6b38eb1e5bdf90