### PR TITLE
Remove frame-src directive from CSP

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -145,7 +145,6 @@ if not DEBUG:
             "style-src": ("'self'", "'unsafe-inline'"),
             "img-src": tuple(_img_src),
             "connect-src": ("'self'",),
-            "frame-src": ("'self'",),
             "frame-ancestors": ("'self'",),
             "upgrade-insecure-requests": True,
             "base-uri": ("'self'",),

--- a/core/tests/test_csp_headers.py
+++ b/core/tests/test_csp_headers.py
@@ -29,7 +29,7 @@ def test_csp_headers_include_expected_hosts(client):
     for p in conf_settings.EMBED_PROVIDERS.values():
         img_src.extend(p["img_hosts"])
     img_src.append("data:")
-    csp = {"DIRECTIVES": {"img-src": tuple(img_src), "frame-src": ("'self'",)}}
+    csp = {"DIRECTIVES": {"img-src": tuple(img_src)}}
     with override_settings(DEBUG=False, CONTENT_SECURITY_POLICY=csp):
         for url in urls:
             resp = client.get(url)

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -35,7 +35,7 @@ The production CSP restricts external media to a small, documented set:
 * `https://*.rumblecdn.com`, `https://*.rumble.com`, and `https://*.rmbl.ws` – Rumble thumbnails.
 * `data:` – inline SVG placeholders.
 
-Frames: `frame-src` is `'self'`; no external origins are allowed.
+Frames inherit `default-src 'self'`; no external origins are allowed.
 
 ### Moderation
 

--- a/docs/policies/runtime-observability.md
+++ b/docs/policies/runtime-observability.md
@@ -32,7 +32,7 @@ All fetch/render operations log structured events:
 
 * Enable `/_csp-report` endpoint.
 * Log `{directive, blocked_uri, document_uri, user_agent}`.
-* No external frame origins: `frame-src` is always `'self'`.
+* No external frame origins; frames inherit `default-src 'self'`.
 
 **Why:** catch real-world CSP breaks in prod (e.g. twimg host not whitelisted).
 

--- a/tests/test_csp_header.py
+++ b/tests/test_csp_header.py
@@ -9,7 +9,7 @@ def _build_csp(providers):
     for p in providers.values():
         img_src.extend(p["img_hosts"])
     img_src.append("data:")
-    return {"DIRECTIVES": {"img-src": tuple(img_src), "frame-src": ("'self'",)}}
+    return {"DIRECTIVES": {"img-src": tuple(img_src)}}
 
 
 @pytest.mark.parametrize("provider", ["YOUTUBE", "X", "RUMBLE"])
@@ -28,7 +28,6 @@ def test_csp_header_has_directives(client):
         "DIRECTIVES": {
             "default-src": ("'self'",),
             "img-src": ("'self'", "data:"),
-            "frame-src": ("'self'",),
         }
     }
     with override_settings(DEBUG=False, CONTENT_SECURITY_POLICY=csp):
@@ -36,7 +35,6 @@ def test_csp_header_has_directives(client):
     csp_header = resp["Content-Security-Policy"]
     assert "default-src" in csp_header
     assert "img-src" in csp_header
-    assert "frame-src" in csp_header
 
 
 def test_no_legacy_csp_settings():


### PR DESCRIPTION
## Summary
- drop deprecated `frame-src` directive from CSP
- adjust CSP header tests to match
- update deployment and observability docs

## Testing
- `pytest` *(fails: core/tests/test_oembed.py::test_backfill_thumbs_populates_thumbnail_url)*
- `pytest tests/test_csp_header.py core/tests/test_csp_headers.py`


------
https://chatgpt.com/codex/tasks/task_e_68bbedd0564c832cb21910f3137d8176