### PR TITLE
Drop frame-src checks from CSP tests

### DIFF
--- a/core/tests/test_csp_headers.py
+++ b/core/tests/test_csp_headers.py
@@ -34,5 +34,5 @@ def test_csp_headers_include_expected_hosts(client):
         for url in urls:
             resp = client.get(url)
             csp_header = resp["Content-Security-Policy"]
-            for host in img_src[1:-1]:  # skip 'self' and 'data:'
+            for host in img_src:
                 assert host in csp_header

--- a/tests/test_csp_header.py
+++ b/tests/test_csp_header.py
@@ -21,25 +21,22 @@ def test_csp_header_includes_provider_hosts(client, provider):
     csp_header = resp["Content-Security-Policy"]
     for host in providers[provider]["img_hosts"]:
         assert host in csp_header
+    assert "'self'" in csp_header
+    assert "data:" in csp_header
 
 
-def test_csp_header_has_directives(client):
-    csp = {
-        "DIRECTIVES": {
-            "default-src": ("'self'",),
-            "img-src": ("'self'", "data:"),
-        }
-    }
+def test_csp_header_has_img_directive(client):
+    csp = {"DIRECTIVES": {"img-src": ("'self'", "data:")}}
     with override_settings(DEBUG=False, CONTENT_SECURITY_POLICY=csp):
         resp = client.get("/healthz")
     csp_header = resp["Content-Security-Policy"]
-    assert "default-src" in csp_header
     assert "img-src" in csp_header
+    assert "'self'" in csp_header
+    assert "data:" in csp_header
 
 
 def test_no_legacy_csp_settings():
     assert not hasattr(conf_settings, "CSP_IMG_SRC")
-    assert not hasattr(conf_settings, "CSP_FRAME_SRC")
 
 
 def test_no_legacy_csp_templates():
@@ -48,4 +45,4 @@ def test_no_legacy_csp_templates():
     for path in Path("templates").rglob("*.html"):
         text = path.read_text()
         assert "CSP_IMG_SRC" not in text
-        assert "CSP_FRAME_SRC" not in text
+


### PR DESCRIPTION
## Summary
- restrict CSP tests to img-src hosts
- remove legacy frame-src checks

## Testing
- `pytest tests/test_csp_header.py core/tests/test_csp_headers.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bbeefb324c832ca19e76e8a6a8ba5b