### PR TITLE
docs: clarify video thumbnail interactions

### DIFF
--- a/docs/video-thumbnail-spec.md
+++ b/docs/video-thumbnail-spec.md
@@ -12,7 +12,19 @@ No embeds anywhere; thumbnail card only on feed and detail.
 - Provider label
 
 ## Click behavior
-- Opens provider in a new tab (`target="_blank"`) with `rel="noreferrer noopener"`.
+- **Feed:**
+  - Title → post detail.
+  - Thumbnail → external provider (`target="_blank"`, `rel="noopener noreferrer"`).
+- **Post detail:**
+  - Thumbnail → external provider (`target="_blank"`, `rel="noopener noreferrer"`).
+
+## Caching & timeouts
+- Outbound fetches use the shared HTTP client (browser UA, timeouts, retries).
+- Cache successful metadata with a short TTL; never cache errors (`Cache-Control: no-store`).
+- See [UI Flow](UI-Flow.md) and [UI Contract V3](UI-contract-V3.md) for integration details.
+
+## Acceptance hooks
+- Feed cards expose `data-testid="post-card"` for V3 acceptance tests.
 
 ## See also (authoritative sources)
 - [UI Contract V3](UI-contract-V3.md)


### PR DESCRIPTION
## Summary
- document feed vs detail click behavior for video thumbnails
- note shared-client caching/timeout rules and acceptance hooks

## Testing
- `pytest` *(fails: Requested setting INSTALLED_APPS, but settings are not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68bbf02e2330832cb1f9c1b7d83e917d