### PR TITLE
docs: clarify link behavior and drop embeds

### DIFF
--- a/docs/UI-Flow.md
+++ b/docs/UI-Flow.md
@@ -22,7 +22,7 @@
 **Key UI:**
 
 * Header logo (home), centered sort tabs (Hot · New · Top)
-* Post cards: community link, author link, timeago, image preview (thumb → image), title, excerpt, vote snippet, comments count
+* Post cards: community link, author link, timeago, static thumbnail (click → provider in new tab), title (link → `/r/<c>/comments/<id>/<slug>/`), excerpt, vote snippet, comments count
 
 ### 2) **Community feed**
 
@@ -32,7 +32,7 @@
 **Key UI:**
 
 * H1 community title, same sort tabs semantics as home
-* Post cards (same as home)
+* Post cards: community link, author link, timeago, static thumbnail (click → provider in new tab), title (link → `/r/<c>/comments/<id>/<slug>/`), excerpt, vote snippet, comments count
 
 ### 3) **Post detail**
 
@@ -43,7 +43,7 @@
 
 * Title (H1)
 * Meta: **by** {username} **in** {community} · {timeago}
-* **Media priority:** gallery → uploaded image → link thumbnail (YouTube/Rumble/X) → plain link
+* **Media priority:** gallery → uploaded image → static thumbnail (YouTube/Rumble/X; click opens provider in new tab) → plain link
 * Body (optional; require media **or** body)
 * **Actions row:** ▲ score ▼ · **Astro chip** (green/amber/red)
 * **Comment composer:** empty box + Cancel/Comment buttons (auth-gated)
@@ -70,13 +70,13 @@
 ### A) Browsing as a guest
 
 1. **Home feed** → click a **community** (e.g., `r/brisbane`) → **Community feed**
-2. Click a **post title/thumb** → **Post detail**
-3. Click the **video thumbnail** → provider opens in new tab
+2. Click a **post title** → **Post detail** (`/r/<c>/comments/<id>/<slug>/`)
+3. Click the **thumbnail** → provider opens in new tab
 4. Attempt to **comment** → redirect to **Login** → back to **Post detail** after auth
 
 ### B) Engaging as an authenticated user
 
-1. **Home**/**Community** → vote on cards; click to **Post detail**
+1. **Home**/**Community** → vote on cards; click title to **Post detail**
 2. In **Post detail**: static thumbnail at top; clicking opens provider in new tab; body below; actions row includes astro chip
 3. **Comment:** write + submit; thread updates; reply at any depth
 
@@ -92,8 +92,11 @@
 ```mermaid
 flowchart LR
   A[Home /] -->|click community| B[Community /r/<slug>/]
-  B -->|click post| C[Post detail /r/<c>/comments/<id>/<slug>/]
-  C -->|click thumbnail| X[Provider site (new tab)]
+  A -->|click post title| C[Post detail /r/<c>/comments/<id>/<slug>/]
+  A -->|click thumbnail| X[Provider site (new tab)]
+  B -->|click post title| C
+  B -->|click thumbnail| X
+  C -->|click thumbnail| X
   C -->|comment (guest)| D[Login /accounts/login/]
   D -->|success| C
   C -->|submit comment| C
@@ -105,7 +108,7 @@ flowchart LR
 flowchart TB
   subgraph PostDetail
     P1[Title + meta]
-    P2[Media: gallery→image→thumbnail]
+    P2[Media: gallery→image→static thumbnail]
     P3[Body (optional)]
     P4[Actions: ▲ score ▼ + Astro chip]
     P5[Composer]
@@ -131,7 +134,7 @@ flowchart TB
 * **Preview:** if `image_thumb` present, show that; **else** show `image`
 * **If neither:** (optional) use first `PostImageLink` if available
 * **Thumb framing:** `aspect-ratio: 16/9; object-fit: cover; border-radius: 12px`
-* **Click:** opens **Post detail** via `post.get_absolute_url` (fallback to `/p/<id>/`)
+* **Click:** thumbnail opens provider in new tab; title links to `/r/<c>/comments/<id>/<slug>/`
 
 ---
 

--- a/docs/V2-onepager.md
+++ b/docs/V2-onepager.md
@@ -6,7 +6,7 @@ Change control: If this spec changes, update this file in the same PR.
 Ship a small, fast, safe **local forum** for **4 communities** with simple posting, comments, basic voting, and first-pass anti-astroturf (**AstroShield v1**). Target: **first 500 users**.
 
 ## 2) Scope
-**In:** 4 communities (seeded) · Posts (Text/Link/Images ≤5) · Comments · Up/Down vote · Roles (Guest/User/Mod/Admin) · Mod actions (Remove/Lock/Slowmode/Domain-throttle) · AstroShield v1 · Strict CSP, consent-gated embeds · Server-rendered pages · Fly.io + Postgres · Light theme.
+**In:** 4 communities (seeded) · Posts (Text/Link/Images ≤5) · Comments · Up/Down vote · Roles (Guest/User/Mod/Admin) · Mod actions (Remove/Lock/Slowmode/Domain-throttle) · AstroShield v1 · Strict CSP, static thumbnails (no embeds) · Server-rendered pages · Fly.io + Postgres · Light theme.
 **Out:** OAuth/Social login, rich editors, DMs/notifications, appeals, pins/manual boosts, full-text search, theming/i18n, analytics, mobile app.
 
 ## 3) URLs & Navigation
@@ -58,7 +58,7 @@ Locked copy:
 - “You can delete your post within **15 minutes** of publishing.”
 
 ## 10) Safety & Privacy
-Strict **CSP allowlist**; **no third-party JS until consent**; click-to-play embeds (sandbox, referrerpolicy, youtube-nocookie). Rate limits (below).
+Strict **CSP allowlist**; **no third-party JS**; static thumbnails (provider opens in new tab). Rate limits (below).
 
 ## 11) Rate Limits (defaults; env-tunable)
 **New users (<24h):** Posts **5/day**, Comments **6/min** (sliding), Votes **10/min**.  
@@ -84,7 +84,7 @@ Fly: `release_command: python manage.py migrate --noinput`. Static via WhiteNois
 ## 14) Definition of Done (V2)
 - Hot/New/Top behave as above; Top defaults `t=all`.
 - Submit supports Text/Link/Images(≤5 uploads) with validation.
-- Detail renders safe embeds/images; comments + votes work.
+- Detail shows images or static thumbnail; clicking thumbnail opens provider in new tab; comments + votes work.
 - AstroShield chips + slowmode thresholds work; `/methods` published.
 - Mod tools (Remove/Lock/Slowmode/Domain-throttle) function.
 - CSP enforced; consent gating; rate limits enforced.
@@ -96,6 +96,6 @@ Acceptance checks are manual (no UI smoke tests). Targeted unit/integration test
 
 ## 16) Milestones (merge order)
 1) Models/migrations + seed 4 communities · 2) Routes/base views · 3) Feed cards  
-4) Post detail (safe embeds/images) · 5) Submit + validation · 6) AstroShield v1  
+4) Post detail (images or static thumbnail; provider opens in new tab) · 5) Submit + validation · 6) AstroShield v1
 7) Moderation tools · 8) Safety hardening (CSP/consent/rates) · 9) Deploy V2 (staging→prod)
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -31,7 +31,7 @@ for form posts can be added with `DJANGO_CSRF_TRUSTED`.
 The production CSP restricts external media to a small, documented set:
 
 * `https://i.ytimg.com` – YouTube thumbnails.
-* `https://*.twimg.com` – images in tweet embeds.
+* `https://*.twimg.com` – images in tweet thumbnails.
 * `https://*.rumblecdn.com`, `https://*.rumble.com`, and `https://*.rmbl.ws` – Rumble thumbnails.
 * `data:` – inline SVG placeholders.
 

--- a/docs/policies/video-previews.md
+++ b/docs/policies/video-previews.md
@@ -6,8 +6,8 @@
 - Provider map (`config/provider_map.yml`) is the single source of truth for hosts + flags.
 - CSP v4+ only. Directives derived from provider map; no legacy `CSP_*` settings allowed.
 - Rendering:
-  - Feed → static card with thumbnail + overlay, no iframe.
-  - Detail → click-to-play iframe, secure attributes.
+  - Feed → static card with thumbnail + overlay (title → `/r/<c>/comments/<id>/<slug>/`; thumbnail → provider in new tab).
+  - Detail → static thumbnail; clicking opens provider in new tab.
 - Caching:
   - Cache successful metadata (short TTL).
   - Never cache errors; error responses return `Cache-Control: no-store`.

--- a/docs/video-thumbnail-spec.md
+++ b/docs/video-thumbnail-spec.md
@@ -13,10 +13,10 @@ No embeds anywhere; thumbnail card only on feed and detail.
 
 ## Click behavior
 - **Feed:**
-  - Title → post detail.
+  - Title → `/r/<c>/comments/<id>/<slug>/`.
   - Thumbnail → external provider (`target="_blank"`, `rel="noopener noreferrer"`).
 - **Post detail:**
-  - Thumbnail → external provider (`target="_blank"`, `rel="noopener noreferrer"`).
+  - Static thumbnail; clicking opens external provider (`target="_blank"`, `rel="noopener noreferrer"`).
 
 ## Caching & timeouts
 - Outbound fetches use the shared HTTP client (browser UA, timeouts, retries).


### PR DESCRIPTION
## Summary
- document that feed card titles link to `/r/<c>/comments/<id>/<slug>/` and thumbnails open providers in a new tab
- replace Post Detail embed mentions with static thumbnails that open providers
- adjust user journeys and policies to reflect new thumbnail behavior

## Testing
- `pytest` *(fails: ImproperlyConfigured settings)*

------
https://chatgpt.com/codex/tasks/task_e_68bbf0d9043c832cb8726fd3d0d6d2e4