### PR TITLE
Clarify feed links and static thumbnails

### DIFF
--- a/docs/UI-Flow.md
+++ b/docs/UI-Flow.md
@@ -76,7 +76,7 @@
 
 ### B) Engaging as an authenticated user
 
-1. **Home**/**Community** → vote on cards; click title to **Post detail**
+1. **Home**/**Community** → vote on cards; click title to **Post detail** (`/r/<c>/comments/<id>/<slug>/`); click thumbnail → provider opens in new tab
 2. In **Post detail**: static thumbnail at top; clicking opens provider in new tab; body below; actions row includes astro chip
 3. **Comment:** write + submit; thread updates; reply at any depth
 

--- a/docs/UI-contract-V3.md
+++ b/docs/UI-contract-V3.md
@@ -28,7 +28,7 @@
 - Anti-Astroturf → `data-testid="sidebar-astro"`
 
 ## Feed
-- Post card anatomy: meta, title, optional media/body, actions
+- Post card anatomy: meta, title (links to `/r/<c>/comments/<id>/<slug>/`), optional static thumbnail (opens provider in new tab) or body, actions
 - Hook: `data-testid="post-card"`
 
 ## Submit Post
@@ -37,7 +37,7 @@
 - Hook: `data-testid="submit-form"`
 
 ## Post Detail
-- OP card: full content with static thumbnail only (no embed)
+- OP card: full content with static thumbnail; clicking opens provider in new tab
 - Comment input
 - Comments list: author/time/body/actions
 
@@ -55,7 +55,7 @@
 - Right sidebar with Account/Login, Submit, Astro
 - Feed with `data-testid="post-card"`
 - Submit form with `data-testid="submit-form"`
-- Post detail shows post + comments; media is static thumbnail only (no embed)
+- Post detail shows post + comments; media is static thumbnail; clicking opens provider in new tab
 - Footer: Terms · Privacy · About
 
 ## See also (authoritative sources)

--- a/docs/V3-onepager.md
+++ b/docs/V3-onepager.md
@@ -27,7 +27,7 @@
 - Anti-Astroturf
 
 ## Main Feed
-- Post card: Title, meta, optional media, body preview, actions
+- Post card: Title (links to `/r/<c>/comments/<id>/<slug>/`), meta, static thumbnail (opens provider in new tab), body preview, actions
 
 ## Submit Post
 - Community selector (required)
@@ -38,7 +38,7 @@
 - Validation: Title + (Body or Media)
 
 ## Post Detail
-- Full post (title/meta/media/body/actions)
+- Full post: title/meta, static thumbnail (click opens provider in new tab), body, actions
 - Comment input
 - Comment list (flat, simple)
 


### PR DESCRIPTION
## Summary
- Specify that feed titles link to `/r/<c>/comments/<id>/<slug>/` and thumbnails open the provider in a new tab
- Describe post detail media as a static thumbnail that links out to the provider
- Note title/thumbnail behavior in user journey for authenticated users

## Testing
- `make test` *(fails: Missing staticfiles manifest entry for 'css/app.css')*


------
https://chatgpt.com/codex/tasks/task_e_68bbf3326ca4832c9b2669b5b87c1210