### PR TITLE
Clarify thumbnail-only media behavior

### DIFF
--- a/docs/UI-contract-V3.md
+++ b/docs/UI-contract-V3.md
@@ -28,7 +28,9 @@
 - Anti-Astroturf → `data-testid="sidebar-astro"`
 
 ## Feed
-- Post card anatomy: meta, title (links to `/r/<c>/comments/<id>/<slug>/`), optional static thumbnail (opens provider in new tab) or body, actions
+- Post card anatomy: meta, title, optional thumbnail, body, actions
+- Title links to `/r/<c>/comments/<id>/<slug>/`
+- Media surfaces are thumbnail images only; clicking the thumbnail opens the provider in a new tab
 - Hook: `data-testid="post-card"`
 
 ## Submit Post
@@ -37,7 +39,7 @@
 - Hook: `data-testid="submit-form"`
 
 ## Post Detail
-- OP card: full content with static thumbnail; clicking opens provider in new tab
+- OP card: full content with static thumbnail only for media; clicking the thumbnail opens the provider in a new tab
 - Comment input
 - Comments list: author/time/body/actions
 

--- a/docs/V3-onepager.md
+++ b/docs/V3-onepager.md
@@ -27,7 +27,9 @@
 - Anti-Astroturf
 
 ## Main Feed
-- Post card: Title (links to `/r/<c>/comments/<id>/<slug>/`), meta, static thumbnail (opens provider in new tab), body preview, actions
+- Post card: title, meta, thumbnail, body preview, actions
+- Title links to `/r/<c>/comments/<id>/<slug>/`
+- Media surfaces are thumbnail images only; clicking the thumbnail opens the provider in a new tab
 
 ## Submit Post
 - Community selector (required)
@@ -38,7 +40,8 @@
 - Validation: Title + (Body or Media)
 
 ## Post Detail
-- Full post: title/meta, static thumbnail (click opens provider in new tab), body, actions
+- Full post: title/meta, thumbnail, body, actions
+- Media surfaces are thumbnail images only; clicking the thumbnail opens the provider in a new tab
 - Comment input
 - Comment list (flat, simple)
 


### PR DESCRIPTION
## Summary
- Note thumbnail-only media surfaces and external provider links on feed post cards
- Restate thumbnail-only media with external link on post detail

## Testing
- `python manage.py test` *(fails: Missing staticfiles manifest entry for 'css/app.css'; 6 failures, 42 errors, 2 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68bbf46ec5dc832c89a3e289a2a270cb