### PR TITLE
docs: clarify wireframe media guidance

### DIFF
--- a/docs/wireframes/README.md
+++ b/docs/wireframes/README.md
@@ -2,6 +2,8 @@
 
 This folder contains the exported **Penpot wireframes** for SureJan V3. Video previews/embeds are deprecated; all wireframes show thumbnail-only references.
 
+These wireframes depict thumbnail-only media and implementers must follow `docs/V3-onepager.md` and `docs/UI-contract-V3.md`.
+
 ## Pages covered
 - **Main Page** (`V3-Main-Page.svg/png`)
   - Header 128px tall (Logo → Home, Tabs Hot/New/Top, Account/Login)


### PR DESCRIPTION
## Summary
- clarify that wireframes show thumbnail-only media and implementation must follow `V3-onepager.md` and `UI-contract-V3.md`

## Testing
- `make test` *(fails: Missing staticfiles manifest entry for 'css/app.css')*

------
https://chatgpt.com/codex/tasks/task_e_68bbf5c2dec4832cb4fe60a715138c53