### PR TITLE
docs: clarify feed link behavior

### DIFF
--- a/docs/policies/video-previews.md
+++ b/docs/policies/video-previews.md
@@ -14,3 +14,7 @@
 - Observability:
   - Structured logs `{provider, url, source, status}`.
 - Drift checks must run in CI before merge.
+
+## Click behavior
+
+Feed title → post detail; thumbnail → external provider (new tab).


### PR DESCRIPTION
## Summary
- document feed click behavior mapping: title links to post detail; thumbnail opens provider in new tab

## Testing
- `pytest` *(fails: django.core.exceptions.ImproperlyConfigured: Requested setting INSTALLED_APPS, but settings are not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68bbf6db07b8832c8db6b5e22daabd09