### PR TITLE
docs: remove frame-src reference

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -20,14 +20,14 @@ Define public domains with `DJANGO_ALLOWED_HOSTS` (comma-separated) so Django
 and the CSP allowlist match your deployment URLs. Additional trusted origins
 for form posts can be added with `DJANGO_CSRF_TRUSTED`.
 
-The production CSP restricts external media to a small, documented set:
+The production CSP allows external images only from a small, documented set:
 
 * `https://i.ytimg.com` – YouTube thumbnails.
 * `https://*.twimg.com` – images in tweet thumbnails.
 * `https://*.rumblecdn.com`, `https://*.rumble.com`, and `https://*.rmbl.ws` – Rumble thumbnails.
 * `data:` – inline SVG placeholders.
 
-Frames inherit `default-src 'self'`; no external origins are allowed.
+Other resource types are restricted to `'self'`.
 
 ### Moderation
 


### PR DESCRIPTION
## Summary
- clarify deployment docs to reflect img-src-only CSP policy

## Testing
- `pytest -q` *(fails: core/tests/test_oembed.py::test_backfill_thumbs_populates_thumbnail_url)*

------
https://chatgpt.com/codex/tasks/task_e_68bbf95c8aa8832ca4826379b1788f6e