### PR TITLE
Refactor post thumbnails

### DIFF
--- a/core/templatetags/thumbnails.py
+++ b/core/templatetags/thumbnails.py
@@ -1,0 +1,14 @@
+from django import template
+from ..utils.thumbnails import svg_placeholder as _svg_placeholder
+
+register = template.Library()
+
+@register.simple_tag
+def svg_placeholder(label, alt=None):
+    """Return SVG placeholder data for templates.
+
+    Returns a dict with ``src`` and ``alt`` keys suitable for use with
+    ``as`` in templates.
+    """
+    src, alt_text = _svg_placeholder(label, alt)
+    return {"src": src, "alt": alt_text}

--- a/templates/core/post_detail.html
+++ b/templates/core/post_detail.html
@@ -17,15 +17,8 @@
     </div>
   </header>
 
-{% if post.embed_thumb %}
-  <a href="{{ post.content_url }}" target="_blank" rel="noreferrer noopener" class="thumb" style="aspect-ratio:16/9;" aria-label="Open content">
-    <img
-      src="{{ post.embed_thumb }}"
-      alt="{{ post.embed_thumb_alt }}"
-      loading="lazy" decoding="async" referrerpolicy="no-referrer"
-      width="640" height="360">
-    {% if post.link_domain %}<span class="thumb-label">{{ post.provider_name }}</span>{% endif %}
-  </a>
+{% if post.post_type == 'link' %}
+  {% include "partials/post_thumbnail.html" with post=post detail_url=post_url %}
 {% elif post.image_thumb or post.image %}
   <a href="{{ post.content_url }}" target="_blank" rel="noreferrer noopener" class="thumb" style="aspect-ratio:16/9;" aria-label="Open content">
     {% if post.image_thumb %}
@@ -41,7 +34,7 @@
         loading="lazy" decoding="async" referrerpolicy="no-referrer"
         width="640" height="360">
     {% endif %}
-    {% if post.link_domain %}<span class="thumb-label">{{ post.provider_name }}</span>{% endif %}
+    {% if post.provider_name %}<span class="thumb-label">{{ post.provider_name }}</span>{% endif %}
   </a>
 {% endif %}
 

--- a/templates/partials/feed_card.html
+++ b/templates/partials/feed_card.html
@@ -2,15 +2,8 @@
 <article class="post-card" data-testid="post-card">
 {% with detail_url=post.get_absolute_url|default:None %}
   {% if not detail_url %}{% url 'post_detail_id' post.pk as detail_url %}{% endif %}
-  {% if post.embed_thumb %}
-    <a href="{{ post.content_url }}" target="_blank" rel="noopener noreferrer" class="thumb" style="aspect-ratio:16/9;" aria-label="Open post">
-      <img
-        src="{{ post.embed_thumb }}"
-        alt="{{ post.embed_thumb_alt }}"
-        loading="lazy" decoding="async" referrerpolicy="no-referrer"
-        width="640" height="360">
-      {% if post.link_domain %}<span class="thumb-label">{{ post.provider_name }}</span>{% endif %}
-    </a>
+  {% if post.post_type == 'link' %}
+    {% include "partials/post_thumbnail.html" with post=post detail_url=detail_url %}
   {% elif post.image_thumb or post.image %}
     <a href="{{ detail_url }}" class="thumb" style="aspect-ratio:16/9;" aria-label="Open post">
       {% if post.image_thumb %}

--- a/templates/partials/post_thumbnail.html
+++ b/templates/partials/post_thumbnail.html
@@ -1,0 +1,12 @@
+{% load thumbnails %}
+{% if post.embed_thumb %}
+  {% with src=post.embed_thumb alt=post.embed_thumb_alt %}
+{% else %}
+  {% svg_placeholder post.title as ph %}
+  {% with src=ph.src alt=ph.alt %}
+{% endif %}
+<a href="{{ post.content_url }}" target="_blank" rel="noopener noreferrer" class="thumb" style="aspect-ratio:16/9;" aria-label="Open content">
+  <img src="{{ src }}" alt="{{ alt }}" loading="lazy" decoding="async" referrerpolicy="no-referrer" width="640" height="360">
+  {% if post.provider_name %}<span class="thumb-label">{{ post.provider_name }}</span>{% endif %}
+</a>
+{% endwith %}


### PR DESCRIPTION
## Summary
- add `svg_placeholder` template tag for inline placeholders
- introduce `partials/post_thumbnail.html` for reusable thumbnail markup
- use the new thumbnail partial in feed cards and post detail pages

## Testing
- `python manage.py test` *(fails: Missing staticfiles manifest entry for 'css/app.css')*

------
https://chatgpt.com/codex/tasks/task_e_68bc0206d290832cb51404ef2c7c16b1