### PR TITLE
Handle thumbnail fetch failures and cleanup cache

### DIFF
--- a/core/management/commands/backfill_thumbs.py
+++ b/core/management/commands/backfill_thumbs.py
@@ -1,6 +1,9 @@
 import asyncio
 
+from django.core.cache import cache
 from django.core.management.base import BaseCommand
+from asgiref.sync import sync_to_async
+from django.db import connection
 from django.db.models import Q
 from django.utils import timezone
 from datetime import timedelta
@@ -35,6 +38,7 @@ class Command(BaseCommand):
     def handle(self, *args, **opts):
         qs_img = (
             Post.objects.filter(image__isnull=False)
+            .exclude(image="")
             .filter(Q(image_thumb="") | Q(image_thumb__isnull=True))
         )
         cutoff = timezone.now() - timedelta(days=opts["days"])
@@ -61,33 +65,60 @@ class Command(BaseCommand):
             posts = list(qs_link[:limit])
             http_client._TIMEOUT = opts["timeout"]
 
-            async def worker(post):
-                try:
-                    src, alt = await asyncio.to_thread(
-                        resolve_thumbnail,
-                        post.content_url or "",
-                        post.title,
-                        True,
-                    )
-                    post.thumbnail_url = src
-                    post.thumbnail_alt = alt
-                    await asyncio.to_thread(
-                        post.save,
-                        update_fields=["thumbnail_url", "thumbnail_alt"],
-                    )
-                    return 1
-                except Exception as e:
-                    self.stderr.write(f"Post {post.id}: {e}")
-                    return 0
+            if connection.vendor == "sqlite":
+                def worker_sync(post):
+                    try:
+                        fail_key = f"thumbfail:{post.content_url}"
+                        if cache.get(fail_key):
+                            return 0
+                        src, alt = resolve_thumbnail(
+                            post.content_url or "",
+                            post.title,
+                            True,
+                        )
+                        if src:
+                            post.thumbnail_url = src
+                            post.thumbnail_alt = alt
+                            post.save(update_fields=["thumbnail_url", "thumbnail_alt"])
+                            return 1
+                        return 0
+                    except Exception as e:
+                        self.stderr.write(f"Post {post.id}: {e}")
+                        return 0
 
-            async def runner():
-                sem = asyncio.Semaphore(opts["concurrency"])
+                count += sum(worker_sync(p) for p in posts)
+            else:
+                async def worker(post):
+                    try:
+                        fail_key = f"thumbfail:{post.content_url}"
+                        if cache.get(fail_key):
+                            return 0
+                        src, alt = await asyncio.to_thread(
+                            resolve_thumbnail,
+                            post.content_url or "",
+                            post.title,
+                            True,
+                        )
+                        if src:
+                            post.thumbnail_url = src
+                            post.thumbnail_alt = alt
+                            await sync_to_async(
+                                post.save, thread_sensitive=True
+                            )(update_fields=["thumbnail_url", "thumbnail_alt"])
+                            return 1
+                        return 0
+                    except Exception as e:
+                        self.stderr.write(f"Post {post.id}: {e}")
+                        return 0
 
-                async def run(post):
-                    async with sem:
-                        return await worker(post)
+                async def runner():
+                    sem = asyncio.Semaphore(opts["concurrency"])
 
-                return sum(await asyncio.gather(*(run(p) for p in posts)))
+                    async def run(post):
+                        async with sem:
+                            return await worker(post)
 
-            count += asyncio.run(runner())
+                    return sum(await asyncio.gather(*(run(p) for p in posts)))
+
+                count += asyncio.run(runner())
         self.stdout.write(f"Backfilled {count} thumbnails")

--- a/core/management/commands/clear_thumb_fails.py
+++ b/core/management/commands/clear_thumb_fails.py
@@ -1,0 +1,28 @@
+from django.core.management.base import BaseCommand
+from django.core.cache import cache
+
+from core.models import Post
+
+
+class Command(BaseCommand):
+    help = "Clear SVG thumbnail placeholders and thumbnail failure cache keys"
+
+    def handle(self, *args, **opts):
+        qs = Post.objects.filter(thumbnail_url__startswith="data:image/svg+xml")
+        count = qs.count()
+        qs.update(thumbnail_url="", thumbnail_alt="")
+        self.stdout.write(f"Cleared {count} placeholder thumbnails")
+
+        deleted = 0
+        if hasattr(cache, "delete_pattern"):
+            cache.delete_pattern("thumbfail:*")
+        else:
+            try:
+                for key in list(getattr(cache, "_cache", {}).keys()):
+                    if str(key).startswith("thumbfail:"):
+                        cache.delete(key)
+                        deleted += 1
+            except Exception:
+                pass
+        if deleted:
+            self.stdout.write(f"Deleted {deleted} thumbfail cache keys")

--- a/core/tests/tests_backfill_thumbs_command.py
+++ b/core/tests/tests_backfill_thumbs_command.py
@@ -1,0 +1,41 @@
+import pytest
+from django.core.cache import cache
+from django.core.management import call_command
+from django.contrib.auth import get_user_model
+
+from core.models import Community, Post
+from core.utils import thumbnails
+
+
+@pytest.mark.django_db
+def test_backfill_thumbs_skips_cached_failures(monkeypatch):
+    cache.clear()
+    User = get_user_model()
+    user = User.objects.create_user("alice", password="pw")
+    com = Community.objects.create(slug="t", name="Test", title="Test", created_by=user)
+    post = Post.objects.create(
+        community=com,
+        author=user,
+        post_type="link",
+        title="Link",
+        content_url="https://example.com",
+    )
+
+    def fake_fetch(url):
+        return None
+
+    monkeypatch.setattr(thumbnails, "fetch_og_image", fake_fetch)
+    call_command("backfill_thumbs", limit=1, days=365)
+    post.refresh_from_db()
+    assert not post.thumbnail_url
+    assert cache.get(f"thumbfail:{post.content_url}")
+
+    calls = []
+
+    def fake_fetch2(url):
+        calls.append(url)
+        return None
+
+    monkeypatch.setattr(thumbnails, "fetch_og_image", fake_fetch2)
+    call_command("backfill_thumbs", limit=1, days=365)
+    assert calls == []

--- a/core/tests/tests_clear_thumb_fails_command.py
+++ b/core/tests/tests_clear_thumb_fails_command.py
@@ -1,0 +1,31 @@
+import pytest
+from django.core.cache import cache
+from django.core.management import call_command
+from django.contrib.auth import get_user_model
+
+from core.models import Community, Post
+
+
+@pytest.mark.django_db
+def test_clear_thumb_fails_command():
+    cache.clear()
+    User = get_user_model()
+    user = User.objects.create_user("alice", password="pw")
+    com = Community.objects.create(slug="t", name="Test", title="Test", created_by=user)
+    post = Post.objects.create(
+        community=com,
+        author=user,
+        post_type="link",
+        title="Link",
+        content_url="https://example.com",
+        thumbnail_url="data:image/svg+xml;base64,abc",
+        thumbnail_alt="Preview",
+    )
+    cache.set("thumbfail:https://example.com", True, 60)
+
+    call_command("clear_thumb_fails")
+
+    post.refresh_from_db()
+    assert post.thumbnail_url == ""
+    assert post.thumbnail_alt == ""
+    assert cache.get("thumbfail:https://example.com") is None

--- a/core/tests/tests_thumbnail_utils.py
+++ b/core/tests/tests_thumbnail_utils.py
@@ -1,0 +1,25 @@
+import pytest
+from django.core.cache import cache
+
+from core.utils import thumbnails
+
+
+@pytest.mark.django_db
+def test_resolve_thumbnail_failure_caches_and_returns_none(monkeypatch):
+    cache.clear()
+    calls = []
+
+    def fake_fetch(url):
+        calls.append(url)
+        return None
+
+    monkeypatch.setattr(thumbnails, "fetch_og_image", fake_fetch)
+    url = "https://example.com"
+    src, alt = thumbnails.resolve_thumbnail(url, "label", fetch_remote=True)
+    assert src is None
+    assert alt == thumbnails.svg_placeholder("label")[1]
+    assert cache.get(f"thumbfail:{url}")
+    calls.clear()
+    src2, _ = thumbnails.resolve_thumbnail(url, "label", fetch_remote=True)
+    assert src2 is None
+    assert calls == []

--- a/core/utils/thumbnails.py
+++ b/core/utils/thumbnails.py
@@ -98,18 +98,32 @@ def _provider_default(url: str) -> str | None:
     return None
 
 
-def resolve_thumbnail(url: str, label: str, fetch_remote: bool = False) -> tuple[str, str]:
-    """Return thumbnail URL and alt text or a placeholder.
+_FAIL_KEY_PREFIX = "thumbfail:"  # cache key prefix for failures
+_FAIL_TTL = 60  # seconds
+
+
+def resolve_thumbnail(
+    url: str, label: str, fetch_remote: bool = False
+) -> tuple[Optional[str], str]:
+    """Return thumbnail URL and alt text.
 
     When ``fetch_remote`` is ``False`` (default) only provider defaults are
     used to avoid network I/O. When ``True`` the function may perform network
-    requests to scrape OpenGraph images.
+    requests to scrape OpenGraph images. Fetch failures are cached briefly to
+    avoid repeated network requests.
     """
+
     thumb = _provider_default(url)
     if not thumb and fetch_remote:
+        fail_key = f"{_FAIL_KEY_PREFIX}{url}"
+        if cache.get(fail_key):
+            return None, svg_placeholder(label)[1]
         thumb = fetch_og_image(url)
+        if not thumb:
+            cache.set(fail_key, True, _FAIL_TTL)
+
     if thumb and thumb.startswith("http://"):
         thumb = "https://" + thumb[len("http://") :]
     if thumb:
         return thumb, label
-    return svg_placeholder(label)
+    return None, svg_placeholder(label)[1]

--- a/templates/partials/post_thumbnail.html
+++ b/templates/partials/post_thumbnail.html
@@ -1,12 +1,17 @@
 {% load thumbnails %}
 {% if post.embed_thumb %}
   {% with src=post.embed_thumb alt=post.embed_thumb_alt %}
+    <a href="{{ post.content_url }}" target="_blank" rel="noopener noreferrer" class="thumb" style="aspect-ratio:16/9;" aria-label="Open content">
+      <img src="{{ src }}" alt="{{ alt }}" loading="lazy" decoding="async" referrerpolicy="no-referrer" width="640" height="360">
+      {% if post.provider_name %}<span class="thumb-label">{{ post.provider_name }}</span>{% endif %}
+    </a>
+  {% endwith %}
 {% else %}
   {% svg_placeholder post.title as ph %}
   {% with src=ph.src alt=ph.alt %}
+    <a href="{{ post.content_url }}" target="_blank" rel="noopener noreferrer" class="thumb" style="aspect-ratio:16/9;" aria-label="Open content">
+      <img src="{{ src }}" alt="{{ alt }}" loading="lazy" decoding="async" referrerpolicy="no-referrer" width="640" height="360">
+      {% if post.provider_name %}<span class="thumb-label">{{ post.provider_name }}</span>{% endif %}
+    </a>
+  {% endwith %}
 {% endif %}
-<a href="{{ post.content_url }}" target="_blank" rel="noopener noreferrer" class="thumb" style="aspect-ratio:16/9;" aria-label="Open content">
-  <img src="{{ src }}" alt="{{ alt }}" loading="lazy" decoding="async" referrerpolicy="no-referrer" width="640" height="360">
-  {% if post.provider_name %}<span class="thumb-label">{{ post.provider_name }}</span>{% endif %}
-</a>
-{% endwith %}


### PR DESCRIPTION
## Summary
- cache failed thumbnail fetches and return no src instead of placeholder
- skip cached failures and sequentially save thumbnails for sqlite during backfill
- add command to purge SVG placeholders and failure cache entries

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc041a1978832cbaba67f2a4765e7d