### PR TITLE
Add Rumble thumbnail resolution

### DIFF
--- a/core/utils/thumbnails.py
+++ b/core/utils/thumbnails.py
@@ -1,15 +1,16 @@
 from __future__ import annotations
 
 import html
+import json
 import logging
 import os
 import re
 from typing import Optional
-from urllib.parse import urlparse
+from urllib.parse import quote, urlparse
 
 from django.core.cache import cache
 
-from ..http_client import fetch_html
+from ..http_client import fetch_html, fetch_json
 
 OG_IMAGE_RE = re.compile(
     r"<meta\s+property=['\"]og:image['\"]\s+content=['\"]([^'\"]+)['\"]",
@@ -98,6 +99,55 @@ def _provider_default(url: str) -> str | None:
     return None
 
 
+def rumble_thumbnail(url: str) -> str | None:
+    """Return thumbnail URL for a Rumble video if available."""
+    api = f"https://rumble.com/api/oembed?url={quote(url, safe='')}"
+    try:
+        data = fetch_json(api, source="rumble-oembed")
+        thumb = data.get("thumbnail_url")
+        if isinstance(thumb, str) and thumb.startswith("http"):
+            return thumb
+    except Exception:
+        pass
+
+    try:
+        resp = fetch_html(url, source="rumble-page")
+        resp.raise_for_status()
+    except Exception:
+        return None
+    html_text = resp.text
+
+    meta_patterns = [
+        r"<meta[^>]+property=['\"]og:image:secure_url['\"][^>]+content=['\"]([^'\"]+)['\"]",
+        r"<meta[^>]+property=['\"]og:image['\"][^>]+content=['\"]([^'\"]+)['\"]",
+        r"<meta[^>]+name=['\"]twitter:image['\"][^>]+content=['\"]([^'\"]+)['\"]",
+    ]
+    for pat in meta_patterns:
+        m = re.search(pat, html_text, re.IGNORECASE)
+        if m:
+            candidate = html.unescape(m.group(1))
+            if candidate.startswith("http"):
+                return candidate
+
+    for block in re.findall(
+        r"<script[^>]+type=['\"]application/ld\+json['\"][^>]*>(.*?)</script>",
+        html_text,
+        re.IGNORECASE | re.DOTALL,
+    ):
+        try:
+            data = json.loads(block)
+        except Exception:
+            continue
+        thumb = data.get("thumbnailUrl")
+        if isinstance(thumb, str) and thumb.startswith("http"):
+            return thumb
+        if isinstance(thumb, list):
+            for item in thumb:
+                if isinstance(item, str) and item.startswith("http"):
+                    return item
+    return None
+
+
 _FAIL_KEY_PREFIX = "thumbfail:"  # cache key prefix for failures
 _FAIL_TTL = 60  # seconds
 
@@ -118,7 +168,11 @@ def resolve_thumbnail(
         fail_key = f"{_FAIL_KEY_PREFIX}{url}"
         if cache.get(fail_key):
             return None, svg_placeholder(label)[1]
-        thumb = fetch_og_image(url)
+        domain = urlparse(url).netloc.lower()
+        if "rumble.com" in domain:
+            thumb = rumble_thumbnail(url)
+        if not thumb:
+            thumb = fetch_og_image(url)
         if not thumb:
             cache.set(fail_key, True, _FAIL_TTL)
 

--- a/tests/fixtures/rumble/fallback.html
+++ b/tests/fixtures/rumble/fallback.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html>
+<head>
+<meta property="og:image:secure_url" content="https://rumble.example/secure.jpg">
+<meta property="og:image" content="https://rumble.example/og.jpg">
+<meta name="twitter:image" content="https://rumble.example/twitter.jpg">
+<script type="application/ld+json">
+{"thumbnailUrl": "https://rumble.example/jsonld.jpg"}
+</script>
+</head>
+<body></body>
+</html>

--- a/tests/fixtures/rumble/nothumb.html
+++ b/tests/fixtures/rumble/nothumb.html
@@ -1,0 +1,2 @@
+<!doctype html>
+<html><head></head><body></body></html>

--- a/tests/fixtures/rumble/oembed.json
+++ b/tests/fixtures/rumble/oembed.json
@@ -1,0 +1,3 @@
+{
+  "thumbnail_url": "https://rumble.example/thumb.jpg"
+}

--- a/tests/test_rumble_thumbnail.py
+++ b/tests/test_rumble_thumbnail.py
@@ -1,0 +1,83 @@
+import json
+from pathlib import Path
+
+from core.utils import thumbnails
+
+FIXTURES = Path(__file__).parent / "fixtures" / "rumble"
+
+
+def load(name: str) -> str:
+    return (FIXTURES / name).read_text()
+
+
+def test_rumble_thumbnail_oembed(monkeypatch):
+    data = json.loads(load("oembed.json"))
+
+    def fake_fetch_json(url, source=""):
+        return data
+
+    called = []
+
+    def fake_fetch_html(url, source=""):
+        called.append(url)
+        class Resp:
+            status_code = 200
+            text = ""
+            def raise_for_status(self):
+                pass
+        return Resp()
+
+    monkeypatch.setattr(thumbnails, "fetch_json", fake_fetch_json)
+    monkeypatch.setattr(thumbnails, "fetch_html", fake_fetch_html)
+
+    thumb = thumbnails.rumble_thumbnail("https://rumble.com/v1")
+    assert thumb == "https://rumble.example/thumb.jpg"
+    assert called == []
+
+
+def test_rumble_thumbnail_html_fallback(monkeypatch):
+    def fake_fetch_json(url, source=""):
+        raise Exception("boom")
+
+    html = load("fallback.html")
+
+    class Resp:
+        status_code = 200
+        text = html
+        def raise_for_status(self):
+            pass
+
+    monkeypatch.setattr(thumbnails, "fetch_json", fake_fetch_json)
+    monkeypatch.setattr(thumbnails, "fetch_html", lambda url, source="": Resp())
+
+    thumb = thumbnails.rumble_thumbnail("https://rumble.com/v1")
+    assert thumb == "https://rumble.example/secure.jpg"
+
+
+def test_rumble_thumbnail_failure(monkeypatch):
+    def fake_fetch_json(url, source=""):
+        raise Exception("boom")
+
+    html = load("nothumb.html")
+
+    class Resp:
+        status_code = 200
+        text = html
+        def raise_for_status(self):
+            pass
+
+    monkeypatch.setattr(thumbnails, "fetch_json", fake_fetch_json)
+    monkeypatch.setattr(thumbnails, "fetch_html", lambda url, source="": Resp())
+
+    assert thumbnails.rumble_thumbnail("https://rumble.com/v1") is None
+
+
+def test_resolve_thumbnail_rumble(monkeypatch):
+    monkeypatch.setattr(
+        thumbnails, "rumble_thumbnail", lambda url: "https://rumble.example/thumb.jpg"
+    )
+    src, alt = thumbnails.resolve_thumbnail(
+        "https://rumble.com/v1", "label", fetch_remote=True
+    )
+    assert src == "https://rumble.example/thumb.jpg"
+    assert alt == "label"


### PR DESCRIPTION
## Summary
- add `rumble_thumbnail` helper using Rumble oEmbed and markup fallbacks
- resolve `rumble.com` URLs with new helper
- test Rumble thumbnail success/failure cases using fixtures

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc05ea07c8832cb95a987787f29fef