### PR TITLE
Refactor thumbnail rendering for link posts

### DIFF
--- a/core/tests/test_feed_thumbnails.py
+++ b/core/tests/test_feed_thumbnails.py
@@ -38,11 +38,21 @@ def test_feed_thumbnails_are_images(client):
         thumbnail_url="https://example.com/thumb.jpg",
     )
 
+    # Link post without thumbnail should use placeholder
+    Post.objects.create(
+        community=com,
+        author=user,
+        post_type="link",
+        title="NoThumb",
+        content_url="https://example.com/article",
+    )
+
     resp = client.get("/")
     html = resp.content.decode()
     cards = re.findall(
         r"<article[^>]*data-testid=\"post-card\"[^>]*>(.*?)</article>", html, re.DOTALL
     )
-    assert len(cards) == 2
+    assert len(cards) == 3
     for card in cards:
         assert "<img" in card
+    assert "data:image/svg+xml" in html

--- a/core/tests/test_links.py
+++ b/core/tests/test_links.py
@@ -97,7 +97,7 @@ class PostLinkTests(TestCase):
         html = render_to_string("core/partials/post_row.html", {"post": self.post}, request=request)
         self.assertIn(f'href="{user_url}"', html)
 
-    def test_feed_card_embed_thumb_links_to_content_url(self):
+    def test_feed_card_thumbnail_links_to_content_url(self):
         post = Post.objects.create(
             community=self.community,
             author=self.user,
@@ -105,7 +105,7 @@ class PostLinkTests(TestCase):
             title="Link",
             content_url="https://example.com/article",
         )
-        post.embed_thumb = "https://example.com/thumb.jpg"
+        post.thumbnail_url = "https://example.com/thumb.jpg"
         request = self.factory.get("/")
         html = render_to_string("partials/feed_card.html", {"post": post}, request=request)
         detail_url = post.get_absolute_url()
@@ -117,7 +117,7 @@ class PostLinkTests(TestCase):
         self.assertIn(f'href="{detail_url}"', html)
         self.assertIn(f'href="{detail_url}#comments"', html)
 
-    def test_post_row_embed_thumb_links_to_content_url(self):
+    def test_post_row_thumbnail_links_to_content_url(self):
         post = Post.objects.create(
             community=self.community,
             author=self.user,
@@ -125,12 +125,14 @@ class PostLinkTests(TestCase):
             title="Link",
             content_url="https://example.com/article",
         )
-        post.embed_thumb = "https://example.com/thumb.jpg"
+        post.thumbnail_url = "https://example.com/thumb.jpg"
         request = self.factory.get("/")
         html = render_to_string("core/partials/post_row.html", {"post": post}, request=request)
         detail_url = post.get_absolute_url()
-        self.assertIn(f'href="{post.content_url}" class="thumb"', html)
-        self.assertIn('target="_blank" rel="noopener noreferrer"', html)
+        self.assertIn(
+            f'href="{post.content_url}" target="_blank" rel="noopener noreferrer" class="thumb"',
+            html,
+        )
         self.assertNotIn(f'href="{detail_url}" class="thumb"', html)
         self.assertIn(f'href="{detail_url}"', html)
         self.assertIn(f'href="{detail_url}#comments"', html)

--- a/core/tests/test_post_detail_media.py
+++ b/core/tests/test_post_detail_media.py
@@ -39,3 +39,24 @@ def test_post_detail_shows_thumbnail_and_link(client):
     assert f'href="{post.content_url}"' in detail_html
     assert 'target="_blank"' in detail_html
     assert 'rel="noreferrer noopener"' in detail_html
+
+
+@pytest.mark.django_db
+def test_post_detail_link_placeholder(client):
+    User = get_user_model()
+    user = User.objects.create_user("alice", password="pw")
+    com = Community.objects.create(slug="t", name="Test", title="Test", created_by=user)
+
+    post = Post.objects.create(
+        community=com,
+        author=user,
+        post_type="link",
+        title="Link",
+        content_url="https://example.com/article",
+    )
+
+    html = client.get(post.get_absolute_url()).content.decode()
+    assert "data:image/svg+xml" in html
+    assert f'href="{post.content_url}"' in html
+    assert 'target="_blank"' in html
+    assert 'rel="noopener noreferrer"' in html

--- a/core/views.py
+++ b/core/views.py
@@ -52,20 +52,6 @@ from .services.votes import (
 )
 from . import mod
 from .http import login_required_htmx
-from .utils.thumbnails import svg_placeholder
-
-
-def _attach_thumbnails(posts):
-    """Attach precomputed thumbnails to link posts without network access."""
-    for post in posts:
-        if getattr(post, "post_type", None) == "link":
-            if getattr(post, "thumbnail_url", None):
-                post.embed_thumb = post.thumbnail_url
-                post.embed_thumb_alt = getattr(post, "thumbnail_alt", "") or post.title
-            else:
-                src, alt = svg_placeholder(post.title)
-                post.embed_thumb = src
-                post.embed_thumb_alt = alt
 
 
 def _is_banned(user):
@@ -434,7 +420,6 @@ SORT_TABS = [
 def _render_posts(request, posts, next_page, show_community=False, sort_query=""):
     """Render a list of posts and optional pagination link."""
 
-    _attach_thumbnails(posts)
     html = render_to_string(
         "core/partials/post_list.html",
         {
@@ -470,7 +455,6 @@ def feed_list(request):
         paginator = Paginator(qs, size)
         page_obj = paginator.get_page(page)
         posts = list(page_obj.object_list)
-        _attach_thumbnails(posts)
         ctx = {
             "posts": posts,
             "next_page": page_obj.next_page_number() if page_obj.has_next() else None,
@@ -514,7 +498,6 @@ def home(request):
     if request.headers.get("HX-Request") == "true":
         return _render_posts(request, posts, next_page, show_community=True, sort_query=sort_query)
 
-    _attach_thumbnails(posts)
     ctx = {
         "posts": posts,
         "next_page": next_page,
@@ -652,7 +635,6 @@ def community(request, slug):
     if request.headers.get("HX-Request") == "true":
         return _render_posts(request, posts, next_page, sort_query=sort_query)
 
-    _attach_thumbnails(posts)
     context = {
         "community": community,
         "community_slug": community.slug,

--- a/templates/core/partials/post_row.html
+++ b/templates/core/partials/post_row.html
@@ -1,10 +1,7 @@
 <article id="post-{{ post.pk }}" class="post-card" data-testid="post-card">
   {% with detail_url=post.get_absolute_url %}
-    {% if post.embed_thumb %}
-    <a href="{{ post.content_url }}" class="thumb" style="aspect-ratio:16/9;" aria-label="Open post" target="_blank" rel="noopener noreferrer">
-      <img src="{{ post.embed_thumb }}" alt="{{ post.embed_thumb_alt }}" width="640" height="360" loading="lazy" decoding="async" referrerpolicy="no-referrer">
-      {% if post.link_domain %}<span class="thumb-label">{{ post.provider_name }}</span>{% endif %}
-    </a>
+    {% if post.post_type == 'link' %}
+    {% include "partials/post_thumbnail.html" with post=post %}
     {% elif post.image_thumb or post.image %}
     <a href="{{ detail_url }}" class="thumb" style="aspect-ratio:16/9;" aria-label="Open post">
       {% if post.image_thumb %}

--- a/templates/core/post_detail.html
+++ b/templates/core/post_detail.html
@@ -18,7 +18,7 @@
   </header>
 
 {% if post.post_type == 'link' %}
-  {% include "partials/post_thumbnail.html" with post=post detail_url=post_url %}
+  {% include "partials/post_thumbnail.html" with post=post %}
 {% elif post.image_thumb or post.image %}
   <a href="{{ post.content_url }}" target="_blank" rel="noreferrer noopener" class="thumb" style="aspect-ratio:16/9;" aria-label="Open content">
     {% if post.image_thumb %}

--- a/templates/partials/feed_card.html
+++ b/templates/partials/feed_card.html
@@ -3,7 +3,7 @@
 {% with detail_url=post.get_absolute_url|default:None %}
   {% if not detail_url %}{% url 'post_detail_id' post.pk as detail_url %}{% endif %}
   {% if post.post_type == 'link' %}
-    {% include "partials/post_thumbnail.html" with post=post detail_url=detail_url %}
+    {% include "partials/post_thumbnail.html" with post=post %}
   {% elif post.image_thumb or post.image %}
     <a href="{{ detail_url }}" class="thumb" style="aspect-ratio:16/9;" aria-label="Open post">
       {% if post.image_thumb %}

--- a/templates/partials/post_thumbnail.html
+++ b/templates/partials/post_thumbnail.html
@@ -1,7 +1,7 @@
 {% load thumbnails %}
-{% if post.embed_thumb %}
-  {% with src=post.embed_thumb alt=post.embed_thumb_alt %}
-    <a href="{{ post.content_url }}" target="_blank" rel="noopener noreferrer" class="thumb" style="aspect-ratio:16/9;" aria-label="Open content">
+{% if post.thumbnail_url %}
+  {% with src=post.thumbnail_url alt=post.thumbnail_alt|default:post.title %}
+    <a href="{{ post.content_url }}" target="_blank" rel="noopener noreferrer" class="thumb" style="aspect-ratio:16/9;">
       <img src="{{ src }}" alt="{{ alt }}" loading="lazy" decoding="async" referrerpolicy="no-referrer" width="640" height="360">
       {% if post.provider_name %}<span class="thumb-label">{{ post.provider_name }}</span>{% endif %}
     </a>
@@ -9,7 +9,7 @@
 {% else %}
   {% svg_placeholder post.title as ph %}
   {% with src=ph.src alt=ph.alt %}
-    <a href="{{ post.content_url }}" target="_blank" rel="noopener noreferrer" class="thumb" style="aspect-ratio:16/9;" aria-label="Open content">
+    <a href="{{ post.content_url }}" target="_blank" rel="noopener noreferrer" class="thumb" style="aspect-ratio:16/9;">
       <img src="{{ src }}" alt="{{ alt }}" loading="lazy" decoding="async" referrerpolicy="no-referrer" width="640" height="360">
       {% if post.provider_name %}<span class="thumb-label">{{ post.provider_name }}</span>{% endif %}
     </a>


### PR DESCRIPTION
## Summary
- Render link thumbnails via new `post_thumbnail.html` partial using `thumbnail_url` or an SVG placeholder
- Replace inline thumbnail markup in templates with shared partial and drop obsolete `_attach_thumbnails`
- Extend tests for thumbnail and placeholder coverage

## Testing
- `pytest core/tests/test_feed_thumbnails.py core/tests/test_post_detail_media.py core/tests/test_links.py tests/test_static_thumbnails.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bc152a1a78832c87eb84cd70b33811