### PR TITLE
Enforce HTTPS thumbnails and refine Rumble support

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -102,7 +102,6 @@ EMBED_PROVIDERS = {
     },
     "RUMBLE": {
         "img_hosts": [
-            "https://*.rumble.com",
             "https://*.rumblecdn.com",
             "https://*.rmbl.ws",
         ],

--- a/core/management/commands/backfill_thumbs.py
+++ b/core/management/commands/backfill_thumbs.py
@@ -76,7 +76,7 @@ class Command(BaseCommand):
                             post.title,
                             True,
                         )
-                        if src:
+                        if src and src.startswith("https://"):
                             post.thumbnail_url = src
                             post.thumbnail_alt = alt
                             post.save(update_fields=["thumbnail_url", "thumbnail_alt"])
@@ -99,7 +99,7 @@ class Command(BaseCommand):
                             post.title,
                             True,
                         )
-                        if src:
+                        if src and src.startswith("https://"):
                             post.thumbnail_url = src
                             post.thumbnail_alt = alt
                             await sync_to_async(

--- a/core/tests/tests_backfill_thumbs_command.py
+++ b/core/tests/tests_backfill_thumbs_command.py
@@ -39,3 +39,26 @@ def test_backfill_thumbs_skips_cached_failures(monkeypatch):
     monkeypatch.setattr(thumbnails, "fetch_og_image", fake_fetch2)
     call_command("backfill_thumbs", limit=1, days=365)
     assert calls == []
+
+
+@pytest.mark.django_db
+def test_backfill_thumbs_rejects_http(monkeypatch):
+    cache.clear()
+    User = get_user_model()
+    user = User.objects.create_user("alice", password="pw")
+    com = Community.objects.create(slug="t", name="Test", title="Test", created_by=user)
+    post = Post.objects.create(
+        community=com,
+        author=user,
+        post_type="link",
+        title="Link",
+        content_url="https://example.com",
+    )
+
+    def fake_resolve(url, label, fetch_remote=False):
+        return "http://insecure/thumb.jpg", "alt"
+
+    monkeypatch.setattr(thumbnails, "resolve_thumbnail", fake_resolve)
+    call_command("backfill_thumbs", limit=1, days=365)
+    post.refresh_from_db()
+    assert not post.thumbnail_url

--- a/core/utils/thumbnails.py
+++ b/core/utils/thumbnails.py
@@ -105,7 +105,7 @@ def rumble_thumbnail(url: str) -> str | None:
     try:
         data = fetch_json(api, source="rumble-oembed")
         thumb = data.get("thumbnail_url")
-        if isinstance(thumb, str) and thumb.startswith("http"):
+        if isinstance(thumb, str) and thumb.startswith("https://"):
             return thumb
     except Exception:
         pass
@@ -125,8 +125,8 @@ def rumble_thumbnail(url: str) -> str | None:
     for pat in meta_patterns:
         m = re.search(pat, html_text, re.IGNORECASE)
         if m:
-            candidate = html.unescape(m.group(1))
-            if candidate.startswith("http"):
+            candidate = html.unescape(m.group(1)).strip()
+            if candidate.startswith("https://"):
                 return candidate
 
     for block in re.findall(
@@ -139,11 +139,11 @@ def rumble_thumbnail(url: str) -> str | None:
         except Exception:
             continue
         thumb = data.get("thumbnailUrl")
-        if isinstance(thumb, str) and thumb.startswith("http"):
+        if isinstance(thumb, str) and thumb.startswith("https://"):
             return thumb
         if isinstance(thumb, list):
             for item in thumb:
-                if isinstance(item, str) and item.startswith("http"):
+                if isinstance(item, str) and item.startswith("https://"):
                     return item
     return None
 
@@ -176,8 +176,6 @@ def resolve_thumbnail(
         if not thumb:
             cache.set(fail_key, True, _FAIL_TTL)
 
-    if thumb and thumb.startswith("http://"):
-        thumb = "https://" + thumb[len("http://") :]
-    if thumb:
+    if thumb and thumb.startswith("https://"):
         return thumb, label
     return None, svg_placeholder(label)[1]

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -24,7 +24,8 @@ The production CSP allows external images only from a small, documented set:
 
 * `https://i.ytimg.com` – YouTube thumbnails.
 * `https://*.twimg.com` – images in tweet thumbnails.
-* `https://*.rumblecdn.com`, `https://*.rumble.com`, and `https://*.rmbl.ws` – Rumble thumbnails.
+* `https://*.rumblecdn.com` and `https://*.rmbl.ws` – Rumble thumbnails.
+  Rumble embeds are disabled and no `frame-src` allowance is needed.
 * `data:` – inline SVG placeholders.
 
 Other resource types are restricted to `'self'`.

--- a/tests/fixtures/rumble/cascade.html
+++ b/tests/fixtures/rumble/cascade.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<html><head>
+<meta property="og:image:secure_url" content="http://rumble.example/secure.jpg">
+<meta property="og:image" content="data:image/png;base64,aaaa">
+<meta name="twitter:image" content="http://rumble.example/twitter.jpg">
+<script type="application/ld+json">{"thumbnailUrl": "https://rumble.example/jsonld.jpg"}</script>
+</head><body></body></html>

--- a/tests/test_rumble_thumbnail.py
+++ b/tests/test_rumble_thumbnail.py
@@ -81,3 +81,36 @@ def test_resolve_thumbnail_rumble(monkeypatch):
     )
     assert src == "https://rumble.example/thumb.jpg"
     assert alt == "label"
+
+
+def test_rumble_thumbnail_cascade_and_https(monkeypatch):
+    data = {"thumbnail_url": "http://rumble.example/insecure.jpg"}
+
+    def fake_fetch_json(url, source=""):
+        return data
+
+    html = load("cascade.html")
+
+    class Resp:
+        status_code = 200
+        text = html
+
+        def raise_for_status(self):
+            pass
+
+    monkeypatch.setattr(thumbnails, "fetch_json", fake_fetch_json)
+    monkeypatch.setattr(thumbnails, "fetch_html", lambda url, source="": Resp())
+
+    thumb = thumbnails.rumble_thumbnail("https://rumble.com/v1")
+    assert thumb == "https://rumble.example/jsonld.jpg"
+
+
+def test_resolve_thumbnail_rumble_rejects_http(monkeypatch):
+    monkeypatch.setattr(
+        thumbnails, "rumble_thumbnail", lambda url: "http://rumble.example/thumb.jpg"
+    )
+    src, alt = thumbnails.resolve_thumbnail(
+        "https://rumble.com/v1", "label", fetch_remote=True
+    )
+    assert src is None
+    assert alt == "Preview image unavailable"


### PR DESCRIPTION
## Summary
- Resolve Rumble thumbnails with strict HTTPS-only cascade: oEmbed, OpenGraph, Twitter, then JSON-LD
- Validate thumbnail URLs are HTTPS before saving or caching
- Update CSP/EMBED settings and backfill command to honor HTTPS-only rules

## Testing
- `pytest tests/test_rumble_thumbnail.py core/tests/tests_backfill_thumbs_command.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc16da7d40832cba32cbe9932e0872