### PR TITLE
Allow SureJan app domains in default hosts and CSRF settings

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -42,6 +42,8 @@ DEFAULT_HOSTS = [
     "surejan.fly.dev",
     f"{FLY_APP_NAME}.fly.dev",
     ".fly.dev",
+    "surejan.app",
+    "www.surejan.app",
 ]
 
 _env_hosts = os.environ.get("DJANGO_ALLOWED_HOSTS", "").strip()
@@ -54,6 +56,8 @@ CSRF_TRUSTED_ORIGINS = [
     "https://surejan.onrender.com",
     "https://surejan.fly.dev",
     f"https://{FLY_APP_NAME}.fly.dev",
+    "https://surejan.app",
+    "https://www.surejan.app",
 ]
 _extra_csrf = os.environ.get("DJANGO_CSRF_TRUSTED", "").strip()
 if _extra_csrf:

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -11,3 +11,29 @@ def test_twimg_in_csp_by_default(monkeypatch):
     monkeypatch.delenv("DJANGO_DEBUG", raising=False)
     monkeypatch.delenv("DJANGO_SECRET_KEY", raising=False)
     importlib.reload(conf_settings)
+
+
+def test_env_allowed_hosts_override(monkeypatch):
+    monkeypatch.setenv("DJANGO_DEBUG", "0")
+    monkeypatch.setenv("DJANGO_SECRET_KEY", "test")
+    monkeypatch.setenv("DJANGO_ALLOWED_HOSTS", "example.com")
+    from config import settings as conf_settings
+    importlib.reload(conf_settings)
+    assert conf_settings.ALLOWED_HOSTS == ["example.com"]
+    monkeypatch.delenv("DJANGO_ALLOWED_HOSTS", raising=False)
+    monkeypatch.delenv("DJANGO_DEBUG", raising=False)
+    monkeypatch.delenv("DJANGO_SECRET_KEY", raising=False)
+    importlib.reload(conf_settings)
+
+
+def test_env_csrf_trusted_override(monkeypatch):
+    monkeypatch.setenv("DJANGO_DEBUG", "0")
+    monkeypatch.setenv("DJANGO_SECRET_KEY", "test")
+    monkeypatch.setenv("DJANGO_CSRF_TRUSTED", "https://example.com")
+    from config import settings as conf_settings
+    importlib.reload(conf_settings)
+    assert "https://example.com" in conf_settings.CSRF_TRUSTED_ORIGINS
+    monkeypatch.delenv("DJANGO_CSRF_TRUSTED", raising=False)
+    monkeypatch.delenv("DJANGO_DEBUG", raising=False)
+    monkeypatch.delenv("DJANGO_SECRET_KEY", raising=False)
+    importlib.reload(conf_settings)


### PR DESCRIPTION
## Summary
- allow `surejan.app` and `www.surejan.app` in default host list
- trust `https://surejan.app` and `https://www.surejan.app` for CSRF
- test that `DJANGO_ALLOWED_HOSTS` and `DJANGO_CSRF_TRUSTED` env vars override defaults

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bca767db84832cad338e932000c9b2