### PR TITLE
Canonicalize video URLs across posts and thumbnails

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -24,6 +24,7 @@ from io import BytesIO
 import os
 
 from .ranking import recompute_post_ranks
+from .utils.video_urls import canonicalize_video_url
 
 
 MAX_BYTES = 4 * 1024 * 1024
@@ -199,6 +200,7 @@ class Post(models.Model):
         recompute = kwargs.pop("recompute_hot", True)
 
         if self.content_url:
+            self.content_url = canonicalize_video_url(self.content_url)
             self.link_domain = urlparse(self.content_url).netloc
 
         # Apply domain throttling weight on every save

--- a/core/tests/test_video_urls.py
+++ b/core/tests/test_video_urls.py
@@ -1,0 +1,49 @@
+import pytest
+
+from core.utils.video_urls import (
+    canonicalize_youtube,
+    canonicalize_rumble,
+    canonicalize_x,
+    canonicalize_video_url,
+)
+
+
+def test_canonicalize_youtube_variants():
+    urls = [
+        "https://www.youtube.com/watch?v=abc123&t=1s",
+        "https://youtu.be/abc123?si=xyz",
+        "https://youtube.com/embed/abc123",
+        "https://youtube.com/shorts/abc123?feature=share",
+    ]
+    for u in urls:
+        assert canonicalize_youtube(u) == "https://youtube.com/watch?v=abc123"
+
+
+def test_canonicalize_rumble_variants():
+    urls = [
+        "https://rumble.com/v1abcd-something.html?foo=bar",
+        "https://rumble.com/embed/v1abcd?pub=123",
+    ]
+    for u in urls:
+        assert canonicalize_rumble(u) == "https://rumble.com/v1abcd"
+
+
+def test_canonicalize_x_variants():
+    urls = [
+        "https://twitter.com/user/status/123?s=20",
+        "https://x.com/user/status/123?lang=en",
+        "https://fxtwitter.com/user/status/123",
+    ]
+    for u in urls:
+        assert canonicalize_x(u) == "https://x.com/user/status/123"
+
+
+def test_canonicalize_video_url_dispatcher():
+    assert (
+        canonicalize_video_url("https://youtu.be/abc123")
+        == "https://youtube.com/watch?v=abc123"
+    )
+    assert (
+        canonicalize_video_url("https://example.com/foo")
+        == "https://example.com/foo"
+    )

--- a/core/tests/tests_thumbnail_utils.py
+++ b/core/tests/tests_thumbnail_utils.py
@@ -23,3 +23,15 @@ def test_resolve_thumbnail_failure_caches_and_returns_none(monkeypatch):
     src2, _ = thumbnails.resolve_thumbnail(url, "label", fetch_remote=True)
     assert src2 is None
     assert calls == []
+
+
+def test_resolve_thumbnail_canonicalizes_url(monkeypatch):
+    seen = []
+
+    def fake_provider_default(url):
+        seen.append(url)
+        return None
+
+    monkeypatch.setattr(thumbnails, "_provider_default", fake_provider_default)
+    thumbnails.resolve_thumbnail("https://youtu.be/abc123?t=9", "label")
+    assert seen[0] == "https://youtube.com/watch?v=abc123"

--- a/core/utils/thumbnails.py
+++ b/core/utils/thumbnails.py
@@ -11,6 +11,7 @@ from urllib.parse import quote, urlparse
 from django.core.cache import cache
 
 from ..http_client import fetch_html, fetch_json
+from .video_urls import canonicalize_video_url
 
 OG_IMAGE_RE = re.compile(
     r"<meta\s+property=['\"]og:image['\"]\s+content=['\"]([^'\"]+)['\"]",
@@ -164,6 +165,7 @@ def resolve_thumbnail(
     avoid repeated network requests.
     """
 
+    url = canonicalize_video_url(url)
     thumb = _provider_default(url)
     if not thumb and fetch_remote:
         fail_key = f"{_FAIL_KEY_PREFIX}{url}"

--- a/core/utils/video_urls.py
+++ b/core/utils/video_urls.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+"""Utilities for canonicalising common video URLs."""
+
+import re
+from urllib.parse import parse_qs, urlparse, urlunparse
+
+
+_YT_PATTERNS = [
+    r"v=([\w-]+)",
+    r"youtu\.be/([\w-]+)",
+    r"embed/([\w-]+)",
+    r"shorts/([\w-]+)",
+]
+
+
+def canonicalize_youtube(url: str) -> str | None:
+    """Return canonical ``https://youtube.com/watch?v=...`` for YouTube URLs."""
+    parsed = urlparse(url)
+    host = parsed.netloc.lower()
+    if "youtube" not in host and "youtu.be" not in host:
+        return None
+
+    vid = None
+    if host.endswith("youtu.be"):
+        vid = parsed.path.lstrip("/")
+    else:
+        qs = parse_qs(parsed.query).get("v")
+        if qs:
+            vid = qs[0]
+        if not vid:
+            m = re.search(r"/(?:embed|shorts)/([\w-]+)", parsed.path)
+            if m:
+                vid = m.group(1)
+    if not vid:
+        return None
+    return f"https://youtube.com/watch?v={vid}"
+
+
+def canonicalize_rumble(url: str) -> str | None:
+    """Return canonical Rumble URL of the form ``https://rumble.com/v...``."""
+    parsed = urlparse(url)
+    host = parsed.netloc.lower().lstrip("www.")
+    if host != "rumble.com":
+        return None
+    path = parsed.path
+    if path.startswith("/embed/"):
+        path = "/" + path[len("/embed/"):]
+    m = re.search(r"/(v[0-9a-z]+)", path)
+    if not m:
+        return None
+    slug = m.group(1)
+    return f"https://rumble.com/{slug}"
+
+
+def canonicalize_x(url: str) -> str | None:
+    """Return canonical ``https://x.com/...`` URL for X/Twitter links."""
+    parsed = urlparse(url)
+    host = parsed.netloc.lower().lstrip("www.")
+    if host not in {
+        "x.com",
+        "twitter.com",
+        "mobile.twitter.com",
+        "m.twitter.com",
+        "fxtwitter.com",
+        "vxtwitter.com",
+    }:
+        return None
+    path = parsed.path.rstrip("/")
+    return urlunparse(("https", "x.com", path, "", "", ""))
+
+
+_CANONICALIZERS = [canonicalize_youtube, canonicalize_rumble, canonicalize_x]
+
+
+def canonicalize_video_url(url: str) -> str:
+    """Return canonical form of ``url`` for known video providers."""
+    for fn in _CANONICALIZERS:
+        result = fn(url)
+        if result:
+            return result
+    return url

--- a/core/views.py
+++ b/core/views.py
@@ -38,8 +38,6 @@ from django.utils.cache import patch_cache_control
 from django.contrib.contenttypes.models import ContentType
 from django_ratelimit.core import is_ratelimited
 from django.urls import reverse
-from urllib.parse import urlparse
-
 from .forms import CommentForm, PostForm, CommunityCreateForm
 from .models import Comment, Community, Post, RecoveryCode, Report
 from .pagination import PAGE_SIZE
@@ -52,6 +50,7 @@ from .services.votes import (
 )
 from . import mod
 from .http import login_required_htmx
+from .utils.video_urls import canonicalize_video_url
 
 
 def _is_banned(user):
@@ -539,16 +538,18 @@ def post_submit(request):
         if form.is_valid():
             post_type = form.cleaned_data["post_type"]
 
+            content_url = ""
+            if post_type == "link":
+                content_url = canonicalize_video_url(
+                    form.cleaned_data.get("content_url", "")
+                )
             post = Post(
                 community=form.cleaned_data["community"],
                 author=request.user,
                 post_type=post_type,
                 title=form.cleaned_data["title"],
                 body=form.cleaned_data.get("body", ""),
-                content_url=
-                    form.cleaned_data.get("content_url", "")
-                    if post_type == "link"
-                    else "",
+                content_url=content_url,
             )
             if post_type == "image":
                 post.image = form.cleaned_data.get("image")
@@ -793,9 +794,7 @@ def post_edit(request, pk):
         if form.is_valid():
             post = form.save(commit=False)
             if post.content_url:
-                post.link_domain = urlparse(post.content_url).netloc
-            else:
-                post.link_domain = ""
+                post.content_url = canonicalize_video_url(post.content_url)
             post.save()
             messages.success(request, "Post updated")
             return redirect(


### PR DESCRIPTION
## Summary
- add helpers for canonicalizing YouTube, Rumble, and X URLs
- normalize video URLs when saving posts and resolving thumbnails
- canonicalize submission and edit URLs before persisting

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bcb4fbaa18832c912dca1f1615a971