### PR TITLE
Refactor thumbnail resolution and caching

### DIFF
--- a/core/tests/tests_thumbnail_utils.py
+++ b/core/tests/tests_thumbnail_utils.py
@@ -5,7 +5,7 @@ from core.utils import thumbnails
 
 
 @pytest.mark.django_db
-def test_resolve_thumbnail_failure_caches_and_returns_none(monkeypatch):
+def test_resolve_thumbnail_failure_caches_and_returns_placeholder(monkeypatch):
     cache.clear()
     calls = []
 
@@ -16,22 +16,48 @@ def test_resolve_thumbnail_failure_caches_and_returns_none(monkeypatch):
     monkeypatch.setattr(thumbnails, "fetch_og_image", fake_fetch)
     url = "https://example.com"
     src, alt = thumbnails.resolve_thumbnail(url, "label", fetch_remote=True)
-    assert src is None
+    assert src.startswith("data:image/svg+xml")
     assert alt == thumbnails.FALLBACK_ALT
     assert cache.get(f"thumbfail:{url}")
     calls.clear()
     src2, _ = thumbnails.resolve_thumbnail(url, "label", fetch_remote=True)
-    assert src2 is None
+    assert src2.startswith("data:image/svg+xml")
+    assert calls == []
+
+
+@pytest.mark.django_db
+def test_resolve_thumbnail_success_caches(monkeypatch):
+    cache.clear()
+    calls = []
+
+    def fake_fetch(url):
+        calls.append(url)
+        return "https://example.com/thumb.jpg"
+
+    monkeypatch.setattr(thumbnails, "fetch_og_image", fake_fetch)
+    url = "https://example.com"
+    src, alt = thumbnails.resolve_thumbnail(url, "label", fetch_remote=True)
+    assert src == "https://example.com/thumb.jpg"
+    assert alt == "label"
+    assert cache.get(f"thumb:{url}") == "https://example.com/thumb.jpg"
+    calls.clear()
+    src2, _ = thumbnails.resolve_thumbnail(url, "label", fetch_remote=True)
+    assert src2 == "https://example.com/thumb.jpg"
     assert calls == []
 
 
 def test_resolve_thumbnail_canonicalizes_url(monkeypatch):
+    cache.clear()
     seen = []
 
-    def fake_provider_default(url):
+    monkeypatch.setattr(thumbnails, "fetch_og_image", lambda url: None)
+
+    def fake_youtube(url, fetch_remote=False):
         seen.append(url)
         return None
 
-    monkeypatch.setattr(thumbnails, "_provider_default", fake_provider_default)
-    thumbnails.resolve_thumbnail("https://youtu.be/abc123?t=9", "label")
+    monkeypatch.setattr(thumbnails, "youtube_fallback_thumb", fake_youtube)
+
+    thumbnails.resolve_thumbnail("https://youtu.be/abc123?t=9", "label", fetch_remote=True)
     assert seen[0] == "https://youtube.com/watch?v=abc123"
+    assert cache.get("thumbfail:https://youtube.com/watch?v=abc123")

--- a/core/utils/thumbnails.py
+++ b/core/utils/thumbnails.py
@@ -1,16 +1,15 @@
 from __future__ import annotations
 
 import html
-import json
 import logging
 import os
 import re
 from typing import Optional
-from urllib.parse import quote, urlparse
+from urllib.parse import parse_qs, urlparse
 
 from django.core.cache import cache
 
-from ..http_client import fetch_html, fetch_json
+from ..http_client import fetch_html
 from .video_urls import canonicalize_video_url
 
 OG_IMAGE_RE = re.compile(
@@ -84,101 +83,108 @@ def svg_placeholder(label: str, alt: str | None = None) -> tuple[str, str]:
     return uri, alt_text
 
 
-def _provider_default(url: str) -> str | None:
-    """Return a provider-specific default thumbnail if one can be derived."""
-    parsed = urlparse(url)
-    domain = parsed.netloc.lower()
-    if "youtube" in domain or "youtu.be" in domain:
-        patterns = [r"v=([\w-]+)", r"be/([\w-]+)", r"embed/([\w-]+)", r"shorts/([\w-]+)"]
-        vid = None
-        for pat in patterns:
-            m = re.search(pat, url)
-            if m:
-                vid = m.group(1)
-                break
-        if vid:
-            return f"https://i.ytimg.com/vi/{vid}/hqdefault.jpg"
-    return None
+def youtube_fallback_thumb(url: str, fetch_remote: bool = False) -> str | None:
+    """Return a YouTube thumbnail URL if possible.
+
+    When ``fetch_remote`` is ``True`` we try to use the higher resolution
+    ``maxresdefault.jpg`` image and fall back to ``hqdefault.jpg`` on 404.
+    Without network access we simply return the ``hqdefault.jpg`` URL.
+    """
+
+    qs = parse_qs(urlparse(url).query)
+    vid = qs.get("v", [None])[0]
+    if not vid:
+        return None
+    base = f"https://i.ytimg.com/vi/{vid}"
+    if fetch_remote:
+        hi_res = f"{base}/maxresdefault.jpg"
+        try:
+            resp = fetch_html(hi_res, source="youtube-thumb")
+            if resp.status_code != 404:
+                return hi_res
+        except Exception:
+            pass
+    return f"{base}/hqdefault.jpg"
 
 
-def rumble_thumbnail(url: str) -> str | None:
-    """Return thumbnail URL for a Rumble video if available."""
-    api = f"https://rumble.com/api/oembed?url={quote(url, safe='')}"
+def rumble_fallback_thumb(url: str) -> str | None:
+    """Return a deterministic CDN thumbnail URL for Rumble if possible."""
+
+    m = re.search(r"/(v[0-9a-z]+)", urlparse(url).path)
+    if not m:
+        return None
+    slug = m.group(1)
+    if not re.fullmatch(r"v[0-9a-z]{5,}", slug):
+        return None
+    # Rumble thumbnails appear to follow a stable pattern under sp.rmbl.ws.
+    # If this pattern changes the function should return ``None`` to avoid
+    # broken images.
+    return f"https://sp.rmbl.ws/s8/1/{slug}.jpg"
+
+
+def x_fallback_thumb(url: str) -> str | None:
+    """Scrape the X status page for a pbs.twimg.com image."""
+
     try:
-        data = fetch_json(api, source="rumble-oembed")
-        thumb = data.get("thumbnail_url")
-        if isinstance(thumb, str) and thumb.startswith("https://"):
-            return thumb
-    except Exception:
-        pass
-
-    try:
-        resp = fetch_html(url, source="rumble-page")
+        resp = fetch_html(url, source="x-thumb")
         resp.raise_for_status()
     except Exception:
         return None
-    html_text = resp.text
-
-    meta_patterns = [
-        r"<meta[^>]+property=['\"]og:image:secure_url['\"][^>]+content=['\"]([^'\"]+)['\"]",
-        r"<meta[^>]+property=['\"]og:image['\"][^>]+content=['\"]([^'\"]+)['\"]",
-        r"<meta[^>]+name=['\"]twitter:image['\"][^>]+content=['\"]([^'\"]+)['\"]",
-    ]
-    for pat in meta_patterns:
-        m = re.search(pat, html_text, re.IGNORECASE)
-        if m:
-            candidate = html.unescape(m.group(1)).strip()
-            if candidate.startswith("https://"):
-                return candidate
-
-    for block in re.findall(
-        r"<script[^>]+type=['\"]application/ld\+json['\"][^>]*>(.*?)</script>",
-        html_text,
-        re.IGNORECASE | re.DOTALL,
-    ):
-        try:
-            data = json.loads(block)
-        except Exception:
-            continue
-        thumb = data.get("thumbnailUrl")
-        if isinstance(thumb, str) and thumb.startswith("https://"):
-            return thumb
-        if isinstance(thumb, list):
-            for item in thumb:
-                if isinstance(item, str) and item.startswith("https://"):
-                    return item
+    match = re.search(r"https://pbs\.twimg\.com/media/[^"]+", resp.text)
+    if match:
+        return html.unescape(match.group(0))
     return None
 
 
+_THUMB_KEY_PREFIX = "thumb:"  # cache key prefix for successful lookups
+_THUMB_TTL = 60 * 60 * 24  # seconds
 _FAIL_KEY_PREFIX = "thumbfail:"  # cache key prefix for failures
-_FAIL_TTL = 60  # seconds
+_FAIL_TTL = 60 * 30  # seconds
 
 
-def resolve_thumbnail(
-    url: str, label: str, fetch_remote: bool = False
-) -> tuple[Optional[str], str]:
+def _provider_fallback(url: str, fetch_remote: bool) -> str | None:
+    """Return provider-specific fallback thumbnails."""
+
+    domain = urlparse(url).netloc.lower()
+    if "youtube.com" in domain:
+        return youtube_fallback_thumb(url, fetch_remote)
+    if "rumble.com" in domain:
+        return rumble_fallback_thumb(url)
+    if fetch_remote and "x.com" in domain:
+        return x_fallback_thumb(url)
+    return None
+
+
+def resolve_thumbnail(url: str, label: str, fetch_remote: bool = False) -> tuple[str, str]:
     """Return thumbnail URL and alt text.
 
-    When ``fetch_remote`` is ``False`` (default) only provider defaults are
-    used to avoid network I/O. When ``True`` the function may perform network
-    requests to scrape OpenGraph images. Fetch failures are cached briefly to
-    avoid repeated network requests.
+    The URL is first canonicalised. We then check caches for a prior
+    successful lookup or a recent failure. When ``fetch_remote`` is ``True``
+    the OpenGraph image is fetched; if that fails we fall back to
+    provider-specific heuristics. A missing thumbnail results in an inline
+    SVG placeholder.
     """
 
     url = canonicalize_video_url(url)
-    thumb = _provider_default(url)
-    if not thumb and fetch_remote:
-        fail_key = f"{_FAIL_KEY_PREFIX}{url}"
-        if cache.get(fail_key):
-            return None, FALLBACK_ALT
-        domain = urlparse(url).netloc.lower()
-        if "rumble.com" in domain:
-            thumb = rumble_thumbnail(url)
-        if not thumb:
-            thumb = fetch_og_image(url)
-        if not thumb:
-            cache.set(fail_key, True, _FAIL_TTL)
+
+    success_key = f"{_THUMB_KEY_PREFIX}{url}"
+    cached = cache.get(success_key)
+    if cached:
+        return cached, label
+
+    fail_key = f"{_FAIL_KEY_PREFIX}{url}"
+    if cache.get(fail_key):
+        return svg_placeholder(label)
+
+    thumb = None
+    if fetch_remote:
+        thumb = fetch_og_image(url)
+    if not thumb:
+        thumb = _provider_fallback(url, fetch_remote)
 
     if thumb and thumb.startswith("https://"):
+        cache.set(success_key, thumb, _THUMB_TTL)
         return thumb, label
-    return None, FALLBACK_ALT
+
+    cache.set(fail_key, True, _FAIL_TTL)
+    return svg_placeholder(label)

--- a/tests/test_rumble_thumbnail.py
+++ b/tests/test_rumble_thumbnail.py
@@ -1,80 +1,10 @@
-import json
-from pathlib import Path
-
 from core.utils import thumbnails
-
-FIXTURES = Path(__file__).parent / "fixtures" / "rumble"
-
-
-def load(name: str) -> str:
-    return (FIXTURES / name).read_text()
-
-
-def test_rumble_thumbnail_oembed(monkeypatch):
-    data = json.loads(load("oembed.json"))
-
-    def fake_fetch_json(url, source=""):
-        return data
-
-    called = []
-
-    def fake_fetch_html(url, source=""):
-        called.append(url)
-        class Resp:
-            status_code = 200
-            text = ""
-            def raise_for_status(self):
-                pass
-        return Resp()
-
-    monkeypatch.setattr(thumbnails, "fetch_json", fake_fetch_json)
-    monkeypatch.setattr(thumbnails, "fetch_html", fake_fetch_html)
-
-    thumb = thumbnails.rumble_thumbnail("https://rumble.com/v1")
-    assert thumb == "https://rumble.example/thumb.jpg"
-    assert called == []
-
-
-def test_rumble_thumbnail_html_fallback(monkeypatch):
-    def fake_fetch_json(url, source=""):
-        raise Exception("boom")
-
-    html = load("fallback.html")
-
-    class Resp:
-        status_code = 200
-        text = html
-        def raise_for_status(self):
-            pass
-
-    monkeypatch.setattr(thumbnails, "fetch_json", fake_fetch_json)
-    monkeypatch.setattr(thumbnails, "fetch_html", lambda url, source="": Resp())
-
-    thumb = thumbnails.rumble_thumbnail("https://rumble.com/v1")
-    assert thumb == "https://rumble.example/secure.jpg"
-
-
-def test_rumble_thumbnail_failure(monkeypatch):
-    def fake_fetch_json(url, source=""):
-        raise Exception("boom")
-
-    html = load("nothumb.html")
-
-    class Resp:
-        status_code = 200
-        text = html
-        def raise_for_status(self):
-            pass
-
-    monkeypatch.setattr(thumbnails, "fetch_json", fake_fetch_json)
-    monkeypatch.setattr(thumbnails, "fetch_html", lambda url, source="": Resp())
-
-    assert thumbnails.rumble_thumbnail("https://rumble.com/v1") is None
 
 
 def test_resolve_thumbnail_rumble(monkeypatch):
+    monkeypatch.setattr(thumbnails, "fetch_og_image", lambda url: None)
     monkeypatch.setattr(
-        thumbnails, "rumble_thumbnail", lambda url: "https://rumble.example/thumb.jpg"
+        thumbnails, "rumble_fallback_thumb", lambda url: "https://rumble.example/thumb.jpg"
     )
     src, alt = thumbnails.resolve_thumbnail(
         "https://rumble.com/v1", "label", fetch_remote=True
@@ -83,34 +13,13 @@ def test_resolve_thumbnail_rumble(monkeypatch):
     assert alt == "label"
 
 
-def test_rumble_thumbnail_cascade_and_https(monkeypatch):
-    data = {"thumbnail_url": "http://rumble.example/insecure.jpg"}
-
-    def fake_fetch_json(url, source=""):
-        return data
-
-    html = load("cascade.html")
-
-    class Resp:
-        status_code = 200
-        text = html
-
-        def raise_for_status(self):
-            pass
-
-    monkeypatch.setattr(thumbnails, "fetch_json", fake_fetch_json)
-    monkeypatch.setattr(thumbnails, "fetch_html", lambda url, source="": Resp())
-
-    thumb = thumbnails.rumble_thumbnail("https://rumble.com/v1")
-    assert thumb == "https://rumble.example/jsonld.jpg"
-
-
 def test_resolve_thumbnail_rumble_rejects_http(monkeypatch):
+    monkeypatch.setattr(thumbnails, "fetch_og_image", lambda url: None)
     monkeypatch.setattr(
-        thumbnails, "rumble_thumbnail", lambda url: "http://rumble.example/thumb.jpg"
+        thumbnails, "rumble_fallback_thumb", lambda url: "http://rumble.example/thumb.jpg"
     )
     src, alt = thumbnails.resolve_thumbnail(
         "https://rumble.com/v1", "label", fetch_remote=True
     )
-    assert src is None
-    assert alt == "Preview image unavailable"
+    assert src.startswith("data:image/svg+xml")
+    assert alt == thumbnails.FALLBACK_ALT


### PR DESCRIPTION
## Summary
- Canonicalize URLs and cache thumbnail results, keeping success and failure entries separate
- Add provider fallbacks for YouTube, Rumble, and X/Twitter plus SVG placeholder fallback
- Simplify rumble tests and add coverage for thumbnail caching and canonicalization

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'config')*


------
https://chatgpt.com/codex/tasks/task_e_68bcb683a7d8832ca9c60f2c94142567