### PR TITLE
Canonicalize thumbnail failure cache keys

### DIFF
--- a/core/management/commands/backfill_thumbs.py
+++ b/core/management/commands/backfill_thumbs.py
@@ -11,6 +11,7 @@ from datetime import timedelta
 from core import http_client
 from core.models import Post, _make_thumb
 from core.utils.thumbnails import resolve_thumbnail
+from core.utils.video_urls import canonicalize_video_url
 
 
 class Command(BaseCommand):
@@ -68,7 +69,7 @@ class Command(BaseCommand):
             if connection.vendor == "sqlite":
                 def worker_sync(post):
                     try:
-                        fail_key = f"thumbfail:{post.content_url}"
+                        fail_key = f"thumbfail:{canonicalize_video_url(post.content_url or '')}"
                         if cache.get(fail_key):
                             return 0
                         src, alt = resolve_thumbnail(
@@ -90,7 +91,7 @@ class Command(BaseCommand):
             else:
                 async def worker(post):
                     try:
-                        fail_key = f"thumbfail:{post.content_url}"
+                        fail_key = f"thumbfail:{canonicalize_video_url(post.content_url or '')}"
                         if cache.get(fail_key):
                             return 0
                         src, alt = await asyncio.to_thread(

--- a/core/tests/tests_backfill_thumbs_command.py
+++ b/core/tests/tests_backfill_thumbs_command.py
@@ -73,3 +73,30 @@ def test_backfill_thumbs_rejects_http(monkeypatch):
     call_command("backfill_thumbs", limit=1, days=365)
     post.refresh_from_db()
     assert not post.thumbnail_url
+
+
+@pytest.mark.django_db
+def test_backfill_thumbs_canonicalizes_fail_key(monkeypatch):
+    cache.clear()
+    User = get_user_model()
+    user = User.objects.create_user("alice", password="pw")
+    com = Community.objects.create(slug="t", name="Test", title="Test", created_by=user)
+    post = Post.objects.create(
+        community=com,
+        author=user,
+        post_type="link",
+        title="Link",
+        content_url="https://youtu.be/abc123?t=1",
+    )
+
+    cache.set("thumbfail:https://youtube.com/watch?v=abc123", True, 60)
+
+    calls = []
+
+    def fake_resolve(url, label, fetch_remote=False):
+        calls.append(url)
+        return None, "alt"
+
+    monkeypatch.setattr(thumbnails, "resolve_thumbnail", fake_resolve)
+    call_command("backfill_thumbs", limit=1, days=365)
+    assert calls == []

--- a/core/utils/thumbnails.py
+++ b/core/utils/thumbnails.py
@@ -130,7 +130,7 @@ def x_fallback_thumb(url: str) -> str | None:
         resp.raise_for_status()
     except Exception:
         return None
-    match = re.search(r"https://pbs\.twimg\.com/media/[^"]+", resp.text)
+    match = re.search(r'https://pbs\.twimg\.com/media/[^"]+', resp.text)
     if match:
         return html.unescape(match.group(0))
     return None
@@ -165,22 +165,22 @@ def resolve_thumbnail(url: str, label: str, fetch_remote: bool = False) -> tuple
     SVG placeholder.
     """
 
-    url = canonicalize_video_url(url)
+    canon_url = canonicalize_video_url(url)
 
-    success_key = f"{_THUMB_KEY_PREFIX}{url}"
+    success_key = f"{_THUMB_KEY_PREFIX}{canon_url}"
     cached = cache.get(success_key)
     if cached:
         return cached, label
 
-    fail_key = f"{_FAIL_KEY_PREFIX}{url}"
+    fail_key = f"{_FAIL_KEY_PREFIX}{canon_url}"
     if cache.get(fail_key):
         return svg_placeholder(label)
 
     thumb = None
     if fetch_remote:
-        thumb = fetch_og_image(url)
+        thumb = fetch_og_image(canon_url)
     if not thumb:
-        thumb = _provider_fallback(url, fetch_remote)
+        thumb = _provider_fallback(canon_url, fetch_remote)
 
     if thumb and thumb.startswith("https://"):
         cache.set(success_key, thumb, _THUMB_TTL)


### PR DESCRIPTION
## Summary
- Canonicalize video URLs when generating thumbnail failure cache keys
- Normalize post URLs in backfill command before checking `thumbfail:` cache keys
- Test backfill command respects canonicalized failure keys

## Testing
- `pytest core/tests/tests_thumbnail_utils.py core/tests/tests_backfill_thumbs_command.py -q`
- `pytest core/tests/tests_clear_thumb_fails_command.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bcb7ab9e98832c8460ea90d44f2d75