### PR TITLE
feat: add video embed builder and templates

### DIFF
--- a/core/templatetags/embed.py
+++ b/core/templatetags/embed.py
@@ -1,0 +1,11 @@
+from django import template
+
+from ..utils.embed_builder import build_embed_iframe as _build_embed_iframe
+
+register = template.Library()
+
+
+@register.simple_tag
+def build_embed_iframe(url):
+    """Template tag wrapper for :func:`build_embed_iframe`."""
+    return _build_embed_iframe(url)

--- a/core/tests/test_embed_builder.py
+++ b/core/tests/test_embed_builder.py
@@ -1,0 +1,16 @@
+from core.utils.embed_builder import build_embed_iframe
+
+def test_build_embed_iframe_youtube():
+    html = build_embed_iframe("https://youtu.be/abc123")
+    assert html and "https://www.youtube.com/embed/abc123" in html
+
+def test_build_embed_iframe_rumble():
+    html = build_embed_iframe("https://rumble.com/v1abcd")
+    assert html and "https://rumble.com/embed/v1abcd" in html
+
+def test_build_embed_iframe_x():
+    html = build_embed_iframe("https://twitter.com/user/status/123")
+    assert html and "https://platform.twitter.com/embed/Tweet.html?id=123" in html
+
+def test_build_embed_iframe_unknown():
+    assert build_embed_iframe("https://example.com/video") is None

--- a/core/utils/embed_builder.py
+++ b/core/utils/embed_builder.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+"""Utilities for building provider-specific embed iframes."""
+
+import re
+from urllib.parse import parse_qs, urlparse
+
+from django.utils.safestring import mark_safe
+
+from .video_urls import canonicalize_video_url
+
+
+_DEF_IFRAME_ATTRS = (
+    'loading="lazy" '
+    'allowfullscreen '
+    'referrerpolicy="no-referrer" '
+    'width="640" height="360"'
+)
+
+
+def _iframe(src: str) -> str:
+    """Return a safe iframe element for ``src``."""
+    html = f'<iframe src="{src}" {_DEF_IFRAME_ATTRS}></iframe>'
+    return mark_safe(html)
+
+
+def build_embed_iframe(url: str | None) -> str | None:
+    """Return iframe HTML for ``url`` or ``None`` if not embeddable.
+
+    The URL is first canonicalised to simplify provider detection. Only a
+    small set of well-known providers are supported. Unknown providers
+    return ``None`` which allows callers to fall back to a link card.
+    """
+    if not url:
+        return None
+
+    canon = canonicalize_video_url(url)
+    parsed = urlparse(canon)
+    domain = parsed.netloc.lower()
+
+    if domain == "youtube.com":
+        vid = parse_qs(parsed.query).get("v", [None])[0]
+        if vid:
+            return _iframe(f"https://www.youtube.com/embed/{vid}")
+        return None
+
+    if domain == "rumble.com":
+        slug = parsed.path.lstrip("/")
+        if re.fullmatch(r"v[0-9a-z]+", slug):
+            return _iframe(f"https://rumble.com/embed/{slug}")
+        return None
+
+    if domain == "x.com":
+        m = re.search(r"/status/(\d+)", parsed.path)
+        if m:
+            tweet_id = m.group(1)
+            src = f"https://platform.twitter.com/embed/Tweet.html?id={tweet_id}"
+            return _iframe(src)
+        return None
+
+    return None

--- a/templates/partials/post_thumbnail.html
+++ b/templates/partials/post_thumbnail.html
@@ -1,17 +1,23 @@
-{% load thumbnails %}
-{% if post.thumbnail_url %}
+{% load thumbnails embed %}
+{% build_embed_iframe post.content_url as iframe %}
+{% if iframe %}
+  <div class="thumb" style="aspect-ratio:16/9;">
+    {{ iframe }}
+    {% if post.provider_name %}<span class="thumb-label">{{ post.provider_name }}</span>{% endif %}
+  </div>
+{% elif post.thumbnail_url %}
   {% with src=post.thumbnail_url alt=post.thumbnail_alt|default:post.title %}
-    <a href="{{ post.content_url }}" target="_blank" rel="noopener noreferrer" class="thumb" style="aspect-ratio:16/9;">
-      <img src="{{ src }}" alt="{{ alt }}" loading="lazy" decoding="async" referrerpolicy="no-referrer" width="640" height="360">
-      {% if post.provider_name %}<span class="thumb-label">{{ post.provider_name }}</span>{% endif %}
-    </a>
+  <a href="{{ post.content_url }}" target="_blank" rel="noopener noreferrer" class="thumb" style="aspect-ratio:16/9;">
+    <img src="{{ src }}" alt="{{ alt }}" loading="lazy" decoding="async" referrerpolicy="no-referrer" width="640" height="360">
+    {% if post.provider_name %}<span class="thumb-label">{{ post.provider_name }}</span>{% endif %}
+  </a>
   {% endwith %}
 {% else %}
   {% svg_placeholder post.title as ph %}
   {% with src=ph.src alt=ph.alt %}
-    <a href="{{ post.content_url }}" target="_blank" rel="noopener noreferrer" class="thumb" style="aspect-ratio:16/9;">
-      <img src="{{ src }}" alt="{{ alt }}" loading="lazy" decoding="async" referrerpolicy="no-referrer" width="640" height="360">
-      {% if post.provider_name %}<span class="thumb-label">{{ post.provider_name }}</span>{% endif %}
-    </a>
+  <a href="{{ post.content_url }}" target="_blank" rel="noopener noreferrer" class="thumb" style="aspect-ratio:16/9;">
+    <img src="{{ src }}" alt="{{ alt }}" loading="lazy" decoding="async" referrerpolicy="no-referrer" width="640" height="360">
+    {% if post.provider_name %}<span class="thumb-label">{{ post.provider_name }}</span>{% endif %}
+  </a>
   {% endwith %}
 {% endif %}

--- a/tests/test_rumble_thumbnail.py
+++ b/tests/test_rumble_thumbnail.py
@@ -1,7 +1,8 @@
+from django.core.cache import cache
 from core.utils import thumbnails
 
-
 def test_resolve_thumbnail_rumble(monkeypatch):
+    cache.clear()
     monkeypatch.setattr(thumbnails, "fetch_og_image", lambda url: None)
     monkeypatch.setattr(
         thumbnails, "rumble_fallback_thumb", lambda url: "https://rumble.example/thumb.jpg"
@@ -12,8 +13,8 @@ def test_resolve_thumbnail_rumble(monkeypatch):
     assert src == "https://rumble.example/thumb.jpg"
     assert alt == "label"
 
-
 def test_resolve_thumbnail_rumble_rejects_http(monkeypatch):
+    cache.clear()
     monkeypatch.setattr(thumbnails, "fetch_og_image", lambda url: None)
     monkeypatch.setattr(
         thumbnails, "rumble_fallback_thumb", lambda url: "http://rumble.example/thumb.jpg"


### PR DESCRIPTION
## Summary
- add embed builder utility and template tag for YouTube, Rumble, and X URLs
- render iframe embeds in post thumbnails when available
- clear cache in Rumble thumbnail tests and add unit tests for embed builder

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bcb89ad528832ca74c7f9285d3407d