### PR TITLE
Expand CSP image host patterns

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -99,14 +99,19 @@ ENABLE_RUMBLE_EMBEDS = False
 
 EMBED_PROVIDERS = {
     "YOUTUBE": {
-        "img_hosts": ["https://i.ytimg.com"],
+        "img_hosts": ["https://*.ytimg.com"],
     },
     "X": {
-        "img_hosts": ["https://*.twimg.com"],
+        "img_hosts": [
+            "https://*.twimg.com",
+            "https://pbs.twimg.com",
+        ],
     },
     "RUMBLE": {
         "img_hosts": [
+            "https://rumblecdn.com",
             "https://*.rumblecdn.com",
+            "https://i.rmbl.ws",
             "https://*.rmbl.ws",
         ],
     },

--- a/core/tests/test_csp_headers.py
+++ b/core/tests/test_csp_headers.py
@@ -29,10 +29,22 @@ def test_csp_headers_include_expected_hosts(client):
     for p in conf_settings.EMBED_PROVIDERS.values():
         img_src.extend(p["img_hosts"])
     img_src.append("data:")
+    expected_hosts = [
+        "'self'",
+        "https://*.ytimg.com",
+        "https://*.twimg.com",
+        "https://pbs.twimg.com",
+        "https://rumblecdn.com",
+        "https://*.rumblecdn.com",
+        "https://i.rmbl.ws",
+        "https://*.rmbl.ws",
+        "data:",
+    ]
+    assert img_src == expected_hosts
     csp = {"DIRECTIVES": {"img-src": tuple(img_src)}}
     with override_settings(DEBUG=False, CONTENT_SECURITY_POLICY=csp):
         for url in urls:
             resp = client.get(url)
             csp_header = resp["Content-Security-Policy"]
-            for host in img_src:
+            for host in expected_hosts:
                 assert host in csp_header

--- a/tests/test_csp_header.py
+++ b/tests/test_csp_header.py
@@ -12,14 +12,30 @@ def _build_csp(providers):
     return {"DIRECTIVES": {"img-src": tuple(img_src)}}
 
 
-@pytest.mark.parametrize("provider", ["YOUTUBE", "X", "RUMBLE"])
-def test_csp_header_includes_provider_hosts(client, provider):
+@pytest.mark.parametrize(
+    "provider,expected_hosts",
+    [
+        ("YOUTUBE", ["https://*.ytimg.com"]),
+        ("X", ["https://*.twimg.com", "https://pbs.twimg.com"]),
+        (
+            "RUMBLE",
+            [
+                "https://rumblecdn.com",
+                "https://*.rumblecdn.com",
+                "https://i.rmbl.ws",
+                "https://*.rmbl.ws",
+            ],
+        ),
+    ],
+)
+def test_csp_header_includes_provider_hosts(client, provider, expected_hosts):
     providers = {provider: conf_settings.EMBED_PROVIDERS[provider]}
+    assert providers[provider]["img_hosts"] == expected_hosts
     csp = _build_csp(providers)
     with override_settings(DEBUG=False, EMBED_PROVIDERS=providers, CONTENT_SECURITY_POLICY=csp):
         resp = client.get("/healthz")
     csp_header = resp["Content-Security-Policy"]
-    for host in providers[provider]["img_hosts"]:
+    for host in expected_hosts:
         assert host in csp_header
     assert "'self'" in csp_header
     assert "data:" in csp_header


### PR DESCRIPTION
## Summary
- allow YouTube images from any ytimg.com subdomain
- explicitly whitelist pbs.twimg.com for X and additional Rumble hostnames
- align CSP header tests with new image host patterns

## Testing
- `pytest tests/test_csp_header.py core/tests/test_csp_headers.py`

------
https://chatgpt.com/codex/tasks/task_e_68bcbadf0a54832cb6bf2c6ae07387ae