### PR TITLE
Add env flags for direct OG thumbnails

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -93,6 +93,23 @@ THUMBNAILS_ONLY = os.environ.get("THUMBNAILS_ONLY", "1") in (
 )
 THUMBNAIL_CACHE_SECONDS = int(os.environ.get("THUMBNAIL_CACHE_SECONDS", "3600"))
 
+# Opt-in provider-specific direct OpenGraph lookups
+YT_DIRECT_OG = os.environ.get("YT_DIRECT_OG", "0") in (
+    "1",
+    "true",
+    "True",
+)
+RUMBLE_DIRECT_OG = os.environ.get("RUMBLE_DIRECT_OG", "0") in (
+    "1",
+    "true",
+    "True",
+)
+X_DIRECT_OG = os.environ.get("X_DIRECT_OG", "0") in (
+    "1",
+    "true",
+    "True",
+)
+
 ENABLE_TWITTER_EMBEDS = False
 ENABLE_YOUTUBE_EMBEDS = False
 ENABLE_RUMBLE_EMBEDS = False

--- a/core/tests/test_embed_builder.py
+++ b/core/tests/test_embed_builder.py
@@ -1,5 +1,20 @@
 from core.utils.embed_builder import build_embed_iframe
 
+
+def test_build_embed_iframe_youtube_direct(settings):
+    settings.YT_DIRECT_OG = True
+    assert build_embed_iframe("https://youtu.be/abc123") is None
+
+
+def test_build_embed_iframe_rumble_direct(settings):
+    settings.RUMBLE_DIRECT_OG = True
+    assert build_embed_iframe("https://rumble.com/v1abcd") is None
+
+
+def test_build_embed_iframe_x_direct(settings):
+    settings.X_DIRECT_OG = True
+    assert build_embed_iframe("https://twitter.com/user/status/123") is None
+
 def test_build_embed_iframe_youtube():
     html = build_embed_iframe("https://youtu.be/abc123")
     assert html and "https://www.youtube.com/embed/abc123" in html

--- a/core/tests/tests_thumbnail_utils.py
+++ b/core/tests/tests_thumbnail_utils.py
@@ -61,3 +61,31 @@ def test_resolve_thumbnail_canonicalizes_url(monkeypatch):
     thumbnails.resolve_thumbnail("https://youtu.be/abc123?t=9", "label", fetch_remote=True)
     assert seen[0] == "https://youtube.com/watch?v=abc123"
     assert cache.get("thumbfail:https://youtube.com/watch?v=abc123")
+
+
+@pytest.mark.django_db
+def test_resolve_thumbnail_direct_skips_canon_and_fallback(settings, monkeypatch):
+    cache.clear()
+    settings.YT_DIRECT_OG = True
+    called = {
+        "canon": False,
+        "fallback": False,
+    }
+
+    def fake_canon(url):
+        called["canon"] = True
+        return url
+
+    def fake_fallback(url, fetch_remote):
+        called["fallback"] = True
+        return "https://example.com/thumb.jpg"
+
+    monkeypatch.setattr(thumbnails, "canonicalize_video_url", fake_canon)
+    monkeypatch.setattr(thumbnails, "_provider_fallback", fake_fallback)
+    monkeypatch.setattr(thumbnails, "fetch_og_image", lambda url: None)
+
+    src, alt = thumbnails.resolve_thumbnail("https://youtu.be/abc123", "label", fetch_remote=True)
+    assert src.startswith("data:image/svg+xml")
+    assert alt == thumbnails.FALLBACK_ALT
+    assert called["canon"] is False
+    assert called["fallback"] is False

--- a/core/utils/embed_builder.py
+++ b/core/utils/embed_builder.py
@@ -6,6 +6,7 @@ import re
 from urllib.parse import parse_qs, urlparse
 
 from django.utils.safestring import mark_safe
+from django.conf import settings
 
 from .video_urls import canonicalize_video_url
 
@@ -32,6 +33,25 @@ def build_embed_iframe(url: str | None) -> str | None:
     return ``None`` which allows callers to fall back to a link card.
     """
     if not url:
+        return None
+
+    raw_domain = urlparse(url).netloc.lower()
+    if (
+        (settings.YT_DIRECT_OG and ("youtube.com" in raw_domain or "youtu.be" in raw_domain))
+        or (settings.RUMBLE_DIRECT_OG and "rumble.com" in raw_domain)
+        or (
+            settings.X_DIRECT_OG
+            and raw_domain
+            in {
+                "x.com",
+                "twitter.com",
+                "mobile.twitter.com",
+                "m.twitter.com",
+                "fxtwitter.com",
+                "vxtwitter.com",
+            }
+        )
+    ):
         return None
 
     canon = canonicalize_video_url(url)

--- a/core/utils/thumbnails.py
+++ b/core/utils/thumbnails.py
@@ -8,6 +8,7 @@ from typing import Optional
 from urllib.parse import parse_qs, urlparse
 
 from django.core.cache import cache
+from django.conf import settings
 
 from ..http_client import fetch_html
 from .video_urls import canonicalize_video_url
@@ -165,7 +166,25 @@ def resolve_thumbnail(url: str, label: str, fetch_remote: bool = False) -> tuple
     SVG placeholder.
     """
 
-    canon_url = canonicalize_video_url(url)
+    domain = urlparse(url).netloc.lower()
+    direct_og = (
+        (settings.YT_DIRECT_OG and ("youtube.com" in domain or "youtu.be" in domain))
+        or (settings.RUMBLE_DIRECT_OG and "rumble.com" in domain)
+        or (
+            settings.X_DIRECT_OG
+            and domain
+            in {
+                "x.com",
+                "twitter.com",
+                "mobile.twitter.com",
+                "m.twitter.com",
+                "fxtwitter.com",
+                "vxtwitter.com",
+            }
+        )
+    )
+
+    canon_url = url if direct_og else canonicalize_video_url(url)
 
     success_key = f"{_THUMB_KEY_PREFIX}{canon_url}"
     cached = cache.get(success_key)
@@ -179,7 +198,7 @@ def resolve_thumbnail(url: str, label: str, fetch_remote: bool = False) -> tuple
     thumb = None
     if fetch_remote:
         thumb = fetch_og_image(canon_url)
-    if not thumb:
+    if not thumb and not direct_og:
         thumb = _provider_fallback(canon_url, fetch_remote)
 
     if thumb and thumb.startswith("https://"):

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -14,6 +14,10 @@ The `ASTROTURF_WATCH` environment variable (default `1`) controls all
 astroturf-detection features. Set `ASTROTURF_WATCH=0` to hide engagement
 chips and block transparency pages; related endpoints will return 404.
 
+`YT_DIRECT_OG`, `RUMBLE_DIRECT_OG`, and `X_DIRECT_OG` (all default `0`) opt a
+provider into direct OpenGraph thumbnail lookups. See
+[direct-og-rollout.md](direct-og-rollout.md) for rollout and rollback steps.
+
 ### CSP / Hosts
 
 Define public domains with `DJANGO_ALLOWED_HOSTS` (comma-separated) so Django

--- a/docs/direct-og-rollout.md
+++ b/docs/direct-og-rollout.md
@@ -1,0 +1,24 @@
+# Rollout: Direct OpenGraph thumbnails
+
+Certain providers can fetch their OpenGraph poster images directly instead of
+using deterministic CDN fallbacks. Three environment variables control this
+behaviour and default to `0` (disabled):
+
+- `YT_DIRECT_OG` – YouTube
+- `RUMBLE_DIRECT_OG` – Rumble
+- `X_DIRECT_OG` – X/Twitter
+
+When enabled (`1`), SureJan skips URL canonicalisation and provider-specific
+fallback logic for that service. Thumbnail resolution relies solely on the
+provider's OpenGraph metadata and iframe embeds are disabled.
+
+## Rollout
+
+1. Set the desired flag(s) to `1` and deploy.
+2. Run the thumbnail backfill to refresh recent posts:
+   `python manage.py backfill_thumbs --limit 50 --days 3`.
+
+## Rollback
+
+1. Reset the flag(s) to `0` and redeploy.
+2. Backfill thumbnails again if cached results need to be refreshed.


### PR DESCRIPTION
## Summary
- support YT_DIRECT_OG, RUMBLE_DIRECT_OG and X_DIRECT_OG flags
- allow resolving thumbnails without canonicalization/fallback when enabled
- document direct OG rollout procedure

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bcbba852cc832c94683f41b57990bd