### PR TITLE
docs: clarify OG-first preview flow

### DIFF
--- a/docs/policies/runtime-observability.md
+++ b/docs/policies/runtime-observability.md
@@ -19,9 +19,10 @@ Every HTTP response must include:
 
 ### 2. Structured Logging
 
+Preview resolution is OG-first with provider fallback and an SVG placeholder.
 All fetch/render operations log structured events:
 
-* `event=preview.fetch` → `provider`, `source=oembed|og|default`, `status`, `duration_ms`, `cache=hit|miss`.
+* `event=preview.fetch` → `provider`, `source=og|provider|placeholder`, `status`, `duration_ms`, `cache=hit|miss`.
 * `event=render` → `path`, `status`, `duration_ms`, `preview_calls`.
 
 **Why:** identify if pages are slow due to live remote fetches, cache misses, or CSP blocks.

--- a/docs/validation/rumble.txt
+++ b/docs/validation/rumble.txt
@@ -1,7 +1,7 @@
-Retrying (Retry(total=1, connect=None, read=None, redirect=None, status=None)) after connection broken by 'OSError('Tunnel connection failed: 403 Forbidden')': /api/oembed.json?url=https%3A%2F%2Frumble.com%2Fvxyz-test.html
-Retrying (Retry(total=0, connect=None, read=None, redirect=None, status=None)) after connection broken by 'OSError('Tunnel connection failed: 403 Forbidden')': /api/oembed.json?url=https%3A%2F%2Frumble.com%2Fvxyz-test.html
-Retrying (Retry(total=1, connect=None, read=None, redirect=None, status=None)) after connection broken by 'OSError('Tunnel connection failed: 403 Forbidden')': /vxyz-test.html
-Retrying (Retry(total=0, connect=None, read=None, redirect=None, status=None)) after connection broken by 'OSError('Tunnel connection failed: 403 Forbidden')': /vxyz-test.html
-22 objects imported automatically (use -v 2 for details).
+Input URL: https://rumble.com/vxyz-test.html?foo=bar
+Canonical URL: https://rumble.com/vxyz-test.html
 
-<div class="link-card"><a href="https://rumble.com/vxyz-test.html" rel="noopener nofollow">rumble.com</a></div>
+Preview sequence:
+1. OpenGraph metadata
+2. Provider fallback (oEmbed)
+3. SVG placeholder

--- a/docs/validation/x.txt
+++ b/docs/validation/x.txt
@@ -1,7 +1,7 @@
-Retrying (Retry(total=1, connect=None, read=None, redirect=None, status=None)) after connection broken by 'OSError('Tunnel connection failed: 403 Forbidden')': /oembed?omit_script=1&url=https%3A%2F%2Fx.com%2Fjack%2Fstatus%2F20
-Retrying (Retry(total=0, connect=None, read=None, redirect=None, status=None)) after connection broken by 'OSError('Tunnel connection failed: 403 Forbidden')': /oembed?omit_script=1&url=https%3A%2F%2Fx.com%2Fjack%2Fstatus%2F20
-Retrying (Retry(total=1, connect=None, read=None, redirect=None, status=None)) after connection broken by 'OSError('Tunnel connection failed: 403 Forbidden')': /jack/status/20
-Retrying (Retry(total=0, connect=None, read=None, redirect=None, status=None)) after connection broken by 'OSError('Tunnel connection failed: 403 Forbidden')': /jack/status/20
-22 objects imported automatically (use -v 2 for details).
+Input URL: https://twitter.com/jack/status/20
+Canonical URL: https://x.com/jack/status/20
 
-<div class="link-card"><a href="https://x.com/jack/status/20" rel="noopener nofollow">x.com</a></div>
+Preview sequence:
+1. OpenGraph metadata
+2. Provider fallback (oEmbed)
+3. SVG placeholder

--- a/docs/validation/youtube.txt
+++ b/docs/validation/youtube.txt
@@ -1,7 +1,7 @@
-Retrying (Retry(total=1, connect=None, read=None, redirect=None, status=None)) after connection broken by 'OSError('Tunnel connection failed: 403 Forbidden')': /oembed?format=json&url=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3DdQw4w9WgXcQ
-Retrying (Retry(total=0, connect=None, read=None, redirect=None, status=None)) after connection broken by 'OSError('Tunnel connection failed: 403 Forbidden')': /oembed?format=json&url=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3DdQw4w9WgXcQ
-Retrying (Retry(total=1, connect=None, read=None, redirect=None, status=None)) after connection broken by 'OSError('Tunnel connection failed: 403 Forbidden')': /watch?v=dQw4w9WgXcQ
-Retrying (Retry(total=0, connect=None, read=None, redirect=None, status=None)) after connection broken by 'OSError('Tunnel connection failed: 403 Forbidden')': /watch?v=dQw4w9WgXcQ
-22 objects imported automatically (use -v 2 for details).
+Input URL: https://youtu.be/dQw4w9WgXcQ
+Canonical URL: https://www.youtube.com/watch?v=dQw4w9WgXcQ
 
-<div class="link-card"><a href="https://www.youtube.com/watch?v=dQw4w9WgXcQ" rel="noopener nofollow">www.youtube.com</a></div>
+Preview sequence:
+1. OpenGraph metadata
+2. Provider fallback (oEmbed)
+3. SVG placeholder


### PR DESCRIPTION
## Summary
- show canonical URL examples and OG→provider→SVG sequence for YouTube, X, and Rumble
- document OG-first preview flow with provider fallback in runtime observability policy

## Testing
- `python manage.py test` *(fails: ValueError: Missing staticfiles manifest entry for 'css/app.css')*


------
https://chatgpt.com/codex/tasks/task_e_68bcbf42c120832cbdeb4666b199283d