### PR TITLE
Adjust thumbnail failure caching TTL based on status

### DIFF
--- a/core/tests/tests_thumbnail_utils.py
+++ b/core/tests/tests_thumbnail_utils.py
@@ -27,6 +27,50 @@ def test_resolve_thumbnail_failure_caches_and_returns_placeholder(monkeypatch):
 
 
 @pytest.mark.django_db
+def test_fail_ttl_generic(monkeypatch):
+    cache.clear()
+
+    def fake_fetch(url):
+        fake_fetch.last_status = 500
+        return None
+
+    monkeypatch.setattr(thumbnails, "fetch_og_image", fake_fetch)
+
+    seen = {}
+    orig_set = cache.set
+
+    def fake_set(key, value, timeout):
+        seen["timeout"] = timeout
+        return orig_set(key, value, timeout)
+
+    monkeypatch.setattr(cache, "set", fake_set)
+    thumbnails.resolve_thumbnail("https://example.com", "label", fetch_remote=True)
+    assert seen["timeout"] == thumbnails._FAIL_TTL
+
+
+@pytest.mark.django_db
+def test_fail_ttl_throttled(monkeypatch):
+    cache.clear()
+
+    def fake_fetch(url):
+        fake_fetch.last_status = 429
+        return None
+
+    monkeypatch.setattr(thumbnails, "fetch_og_image", fake_fetch)
+
+    seen = {}
+    orig_set = cache.set
+
+    def fake_set(key, value, timeout):
+        seen["timeout"] = timeout
+        return orig_set(key, value, timeout)
+
+    monkeypatch.setattr(cache, "set", fake_set)
+    thumbnails.resolve_thumbnail("https://example.com", "label", fetch_remote=True)
+    assert seen["timeout"] == thumbnails._FAIL_RETRY_TTL
+
+
+@pytest.mark.django_db
 def test_resolve_thumbnail_success_caches(monkeypatch):
     cache.clear()
     og_calls = []

--- a/core/utils/thumbnails.py
+++ b/core/utils/thumbnails.py
@@ -54,19 +54,26 @@ def fetch_og_image(url: str) -> Optional[str]:
 
     # During tests we bypass caching to avoid cross-test interference.
     if os.getenv("PYTEST_CURRENT_TEST"):
-        return scrape_og_image(url)[0]
+        result, status = scrape_og_image(url)
+        fetch_og_image.last_status = status
+        return result
 
     key = f"{_CACHE_KEY_PREFIX}{url}"
     cached = cache.get(key)
     if cached is not None:
+        fetch_og_image.last_status = None
         return None if cached == _CACHE_NONE else cached
 
     result, status = scrape_og_image(url)
+    fetch_og_image.last_status = status
     if status is None or status >= 400:
         return result
 
     cache.set(key, result or _CACHE_NONE, _CACHE_TIMEOUT)
     return result
+
+
+fetch_og_image.last_status = None  # type: ignore[attr-defined]
 
 
 def svg_placeholder(label: str, alt: str | None = None) -> tuple[str, str]:
@@ -140,7 +147,15 @@ def x_fallback_thumb(url: str) -> str | None:
 _THUMB_KEY_PREFIX = "thumb:"  # cache key prefix for successful lookups
 _THUMB_TTL = 60 * 60 * 24  # seconds
 _FAIL_KEY_PREFIX = "thumbfail:"  # cache key prefix for failures
-_FAIL_TTL = 60 * 30  # seconds
+_FAIL_TTL = 60 * 15  # seconds
+_FAIL_RETRY_TTL = 60  # seconds for throttling errors
+
+
+def _fail_ttl(status: Optional[int]) -> int:
+    """Return cache TTL for failed lookups based on ``status``."""
+    if status in {403, 429}:
+        return _FAIL_RETRY_TTL
+    return _FAIL_TTL
 
 
 def _provider_fallback(url: str, fetch_remote: bool) -> str | None:
@@ -196,8 +211,10 @@ def resolve_thumbnail(url: str, label: str, fetch_remote: bool = False) -> tuple
         return svg_placeholder(label)
 
     thumb = None
+    status = None
     if fetch_remote:
         thumb = fetch_og_image(canon_url)
+        status = getattr(fetch_og_image, "last_status", None)
     if not thumb and not direct_og:
         thumb = _provider_fallback(canon_url, fetch_remote)
 
@@ -205,5 +222,5 @@ def resolve_thumbnail(url: str, label: str, fetch_remote: bool = False) -> tuple
         cache.set(success_key, thumb, _THUMB_TTL)
         return thumb, label
 
-    cache.set(fail_key, True, _FAIL_TTL)
+    cache.set(fail_key, True, _fail_ttl(status))
     return svg_placeholder(label)


### PR DESCRIPTION
## Summary
- parameterize thumbnail failure TTL with `_fail_ttl`
- retry quickly on 403/429 by caching fails for only 60 seconds
- add tests for generic vs throttling failure TTLs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bcc0231870832c811f061e0c3aa5be