### PR TITLE
Remove unused embed toggles

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -110,10 +110,6 @@ X_DIRECT_OG = os.environ.get("X_DIRECT_OG", "0") in (
     "True",
 )
 
-ENABLE_TWITTER_EMBEDS = False
-ENABLE_YOUTUBE_EMBEDS = False
-ENABLE_RUMBLE_EMBEDS = False
-
 EMBED_PROVIDERS = {
     "YOUTUBE": {
         "img_hosts": ["https://*.ytimg.com"],


### PR DESCRIPTION
## Summary
- remove ENABLE_TWITTER_EMBEDS, ENABLE_YOUTUBE_EMBEDS, and ENABLE_RUMBLE_EMBEDS constants
- keep embed provider image hosts and always add them to CSP img-src

## Testing
- `python - <<'PY'
import os
os.environ['DJANGO_DEBUG']='0'
os.environ['DJANGO_SECRET_KEY']='test'
from importlib import reload
import config.settings as settings
reload(settings)
print('frame-src:', settings.CONTENT_SECURITY_POLICY['DIRECTIVES'].get('frame-src'))
print('img-src:', settings.CONTENT_SECURITY_POLICY['DIRECTIVES']['img-src'])
PY`
- `python manage.py test` *(fails: Missing staticfiles manifest entry for 'css/app.css')*

------
https://chatgpt.com/codex/tasks/task_e_68bcc62e0c30832cb380d5c579a81621