### PR TITLE
Add video thumbnail tests and CSP assertions

### DIFF
--- a/core/tests/test_video_thumbnails.py
+++ b/core/tests/test_video_thumbnails.py
@@ -1,0 +1,36 @@
+import re
+import pytest
+from django.contrib.auth import get_user_model
+from django.template.loader import render_to_string
+
+from core.models import Community, Post
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "url,thumb_host",
+    [
+        ("https://www.youtube.com/watch?v=abc123", "i.ytimg.com"),
+        ("https://rumble.com/vabcde-example.html", "rumblecdn.com"),
+        ("https://x.com/user/status/1", "pbs.twimg.com"),
+    ],
+)
+def test_post_thumbnail_uses_img_not_iframe(url, thumb_host):
+    User = get_user_model()
+    user = User.objects.create_user("alice", password="pw")
+    com = Community.objects.create(slug="t", name="Test", title="Test", created_by=user)
+
+    post = Post.objects.create(
+        community=com,
+        author=user,
+        post_type="link",
+        title="Video",
+        content_url=url,
+        thumbnail_url=f"https://{thumb_host}/thumb.jpg",
+    )
+
+    html = render_to_string("partials/post_thumbnail.html", {"post": post})
+    assert "<iframe" not in html
+    imgs = re.findall(r'<img[^>]+src="([^"]+)"', html)
+    assert len(imgs) == 1
+    assert thumb_host in imgs[0]

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,13 +1,15 @@
 import importlib
 
 
-def test_twimg_in_csp_by_default(monkeypatch):
+def test_video_domains_in_csp_by_default(monkeypatch):
     monkeypatch.setenv("DJANGO_DEBUG", "0")
     monkeypatch.setenv("DJANGO_SECRET_KEY", "test")
     from config import settings as conf_settings
     importlib.reload(conf_settings)
     img_src = conf_settings.CONTENT_SECURITY_POLICY["DIRECTIVES"]["img-src"]
     assert any("twimg.com" in h for h in img_src)
+    assert any("ytimg.com" in h for h in img_src)
+    assert any("rumblecdn.com" in h for h in img_src)
     monkeypatch.delenv("DJANGO_DEBUG", raising=False)
     monkeypatch.delenv("DJANGO_SECRET_KEY", raising=False)
     importlib.reload(conf_settings)


### PR DESCRIPTION
## Summary
- cover post_thumbnail rendering for YouTube, Rumble and X links
- ensure ytimg and rumble CDN hosts are allowed in CSP defaults

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bcc78d607c832c8755347f9d40ef2f