### PR TITLE
Cache Rumble OpenGraph thumbnails

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -313,10 +313,12 @@ if USE_S3 and all(required) and not IS_BUILD:
     AWS_S3_SIGNATURE_VERSION = "s3v4"
     AWS_DEFAULT_ACL = "public-read"
     AWS_S3_OBJECT_PARAMETERS = {"CacheControl": "public, max-age=94608000"}
+    THUMB_CACHE_DIR = BASE_DIR / "media" / "thumbs"
 else:
     DEFAULT_FILE_STORAGE = "django.core.files.storage.FileSystemStorage"
     MEDIA_ROOT = BASE_DIR / "media"
     MEDIA_URL = "/media/"
+    THUMB_CACHE_DIR = MEDIA_ROOT / "thumbs"
 
 # Ensure STORAGES['default'] points to the active storage backend
 STORAGES["default"] = {"BACKEND": DEFAULT_FILE_STORAGE}

--- a/config/test_settings.py
+++ b/config/test_settings.py
@@ -19,4 +19,5 @@ STORAGES = {
 }
 
 MEDIA_ROOT = BASE_DIR / "test-media"
+THUMB_CACHE_DIR = MEDIA_ROOT / "thumbs"
 

--- a/core/utils/thumbnails.py
+++ b/core/utils/thumbnails.py
@@ -4,6 +4,7 @@ import html
 import logging
 import os
 import re
+import hashlib
 from typing import Optional
 from urllib.parse import parse_qs, urlparse
 
@@ -171,6 +172,54 @@ def _provider_fallback(url: str, fetch_remote: bool) -> str | None:
     return None
 
 
+_EXTENSION_MAP = {
+    "image/jpeg": "jpg",
+    "image/png": "png",
+    "image/gif": "gif",
+    "image/webp": "webp",
+}
+
+
+def cache_remote_image(remote_url: str, canon_url: str) -> str | None:
+    """Fetch ``remote_url`` and cache locally under a stable name.
+
+    The canonical video URL ``canon_url`` is hashed to derive the filename. A
+    previously cached file is returned without fetching the remote again.
+    On a fetch failure we return ``None`` so callers can fall back.
+    """
+
+    digest = hashlib.sha256(canon_url.encode("utf-8")).hexdigest()
+    base = settings.THUMB_CACHE_DIR / digest
+
+    for ext in _EXTENSION_MAP.values():
+        candidate = base.with_suffix(f".{ext}")
+        if candidate.exists():
+            logger.info("rumble-thumb cache %s result=hit", canon_url)
+            return f"{settings.MEDIA_URL}thumbs/{candidate.name}"
+
+    status = None
+    try:
+        resp = fetch_html(remote_url, source="rumble-thumb")
+        status = resp.status_code
+        resp.raise_for_status()
+    except Exception:
+        logger.info("rumble-thumb fetch %s status=%s result=fallback", remote_url, status or "error")
+        return None
+
+    content_type = resp.headers.get("Content-Type", "").split(";")[0].lower()
+    ext = _EXTENSION_MAP.get(content_type)
+    if not ext:
+        logger.info("rumble-thumb fetch %s status=%s result=fallback", remote_url, status)
+        return None
+
+    path = base.with_suffix(f".{ext}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "wb") as fh:
+        fh.write(resp.content)
+    logger.info("rumble-thumb fetch %s status=%s result=stored", remote_url, status)
+    return f"{settings.MEDIA_URL}thumbs/{path.name}"
+
+
 def resolve_thumbnail(url: str, label: str, fetch_remote: bool = False) -> tuple[str, str]:
     """Return thumbnail URL and alt text.
 
@@ -215,10 +264,16 @@ def resolve_thumbnail(url: str, label: str, fetch_remote: bool = False) -> tuple
     if fetch_remote:
         thumb = fetch_og_image(canon_url)
         status = getattr(fetch_og_image, "last_status", None)
+        if thumb and direct_og and "rumble.com" in domain:
+            cached = cache_remote_image(thumb, canon_url)
+            if cached:
+                thumb = cached
+            else:
+                thumb = None
     if not thumb and not direct_og:
         thumb = _provider_fallback(canon_url, fetch_remote)
 
-    if thumb and thumb.startswith("https://"):
+    if thumb and (thumb.startswith("https://") or thumb.startswith(settings.MEDIA_URL)):
         cache.set(success_key, thumb, _THUMB_TTL)
         return thumb, label
 

--- a/tests/test_rumble_thumbnail.py
+++ b/tests/test_rumble_thumbnail.py
@@ -1,5 +1,8 @@
 from django.core.cache import cache
 from core.utils import thumbnails
+from core.utils.video_urls import canonicalize_video_url
+import hashlib
+
 
 def test_resolve_thumbnail_rumble(monkeypatch):
     cache.clear()
@@ -22,5 +25,87 @@ def test_resolve_thumbnail_rumble_rejects_http(monkeypatch):
     src, alt = thumbnails.resolve_thumbnail(
         "https://rumble.com/v1", "label", fetch_remote=True
     )
+    assert src.startswith("data:image/svg+xml")
+    assert alt == thumbnails.FALLBACK_ALT
+
+
+def test_resolve_thumbnail_rumble_direct_og_cached(monkeypatch, settings, tmp_path):
+    cache.clear()
+    settings.RUMBLE_DIRECT_OG = True
+    settings.MEDIA_ROOT = tmp_path / "media"
+    settings.THUMB_CACHE_DIR = settings.MEDIA_ROOT / "thumbs"
+    settings.MEDIA_URL = "/media/"
+
+    # ensure directory clean
+    if settings.THUMB_CACHE_DIR.exists():
+        for p in settings.THUMB_CACHE_DIR.iterdir():
+            p.unlink()
+
+    remote_url = "https://sp.rmbl.ws/s8/1/testslug.jpg"
+
+    def fake_fetch_og(url):
+        thumbnails.fetch_og_image.last_status = 200
+        return remote_url
+
+    class Resp:
+        status_code = 200
+        headers = {"Content-Type": "image/jpeg"}
+        content = b"img"
+
+        def raise_for_status(self):
+            pass
+
+    calls = []
+
+    def fake_fetch_html(url, source="unknown"):
+        calls.append(url)
+        return Resp()
+
+    monkeypatch.setattr(thumbnails, "fetch_og_image", fake_fetch_og)
+    monkeypatch.setattr(thumbnails, "fetch_html", fake_fetch_html)
+
+    url = "https://rumble.com/v1abc"
+    canon = canonicalize_video_url(url)
+    digest = hashlib.sha256(canon.encode("utf-8")).hexdigest()
+    expected = settings.THUMB_CACHE_DIR / f"{digest}.jpg"
+
+    src, alt = thumbnails.resolve_thumbnail(url, "label", fetch_remote=True)
+    assert src == f"{settings.MEDIA_URL}thumbs/{expected.name}"
+    assert expected.exists()
+    assert calls == [remote_url]
+
+    src2, _ = thumbnails.resolve_thumbnail(url, "label", fetch_remote=True)
+    assert src2 == src
+    assert calls == [remote_url]
+
+
+def test_resolve_thumbnail_rumble_direct_og_error(monkeypatch, settings, tmp_path):
+    cache.clear()
+    settings.RUMBLE_DIRECT_OG = True
+    settings.MEDIA_ROOT = tmp_path / "media"
+    settings.THUMB_CACHE_DIR = settings.MEDIA_ROOT / "thumbs"
+    settings.MEDIA_URL = "/media/"
+
+    remote_url = "https://sp.rmbl.ws/s8/1/testslug.jpg"
+
+    def fake_fetch_og(url):
+        thumbnails.fetch_og_image.last_status = 200
+        return remote_url
+
+    class Resp:
+        status_code = 500
+        headers = {"Content-Type": "image/jpeg"}
+        content = b""
+
+        def raise_for_status(self):
+            raise Exception("boom")
+
+    def fake_fetch_html(url, source="unknown"):
+        return Resp()
+
+    monkeypatch.setattr(thumbnails, "fetch_og_image", fake_fetch_og)
+    monkeypatch.setattr(thumbnails, "fetch_html", fake_fetch_html)
+
+    src, alt = thumbnails.resolve_thumbnail("https://rumble.com/v1abc", "label", fetch_remote=True)
     assert src.startswith("data:image/svg+xml")
     assert alt == thumbnails.FALLBACK_ALT


### PR DESCRIPTION
## Summary
- cache remote Rumble OG thumbnails locally under MEDIA_ROOT/thumbs
- add THUMB_CACHE_DIR setting and reuse cached images when available
- test Rumble OG thumbnail caching and error fallback

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bccc730b3c832cb1ebfd1c45099fbe