### PR TITLE
Cache Rumble thumbnails in backfill command

### DIFF
--- a/core/management/commands/backfill_thumbs.py
+++ b/core/management/commands/backfill_thumbs.py
@@ -10,7 +10,7 @@ from datetime import timedelta
 
 from core import http_client
 from core.models import Post, _make_thumb
-from core.utils.thumbnails import resolve_thumbnail
+from core.utils.thumbnails import resolve_thumbnail, cache_remote_image
 from core.utils.video_urls import canonicalize_video_url
 
 
@@ -35,6 +35,11 @@ class Command(BaseCommand):
             default=10,
             help="Number of concurrent thumbnail fetches",
         )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Fetch thumbnails without saving changes",
+        )
 
     def handle(self, *args, **opts):
         qs_img = (
@@ -49,6 +54,28 @@ class Command(BaseCommand):
             .exclude(content_url="")
             .order_by("-created_at")
         )
+        qs_rumble = (
+            Post.objects.filter(post_type="link", created_at__gte=cutoff)
+            .exclude(thumbnail_url__isnull=True)
+            .exclude(thumbnail_url="")
+            .filter(
+                Q(thumbnail_url__icontains="rmbl.ws")
+                | Q(thumbnail_url__icontains="rumblecdn.com")
+            )
+        )
+        converted = 0
+        for p in qs_rumble.iterator():
+            try:
+                canon = canonicalize_video_url(p.content_url or "")
+                cached = cache_remote_image(p.thumbnail_url or "", canon)
+                if cached:
+                    converted += 1
+                    if not opts["dry_run"]:
+                        p.thumbnail_url = cached
+                        p.save(update_fields=["thumbnail_url"])
+                        connection.commit()
+            except Exception as e:
+                self.stderr.write(f"Post {p.id}: {e}")
         count = 0
         for p in qs_img.iterator():
             try:
@@ -122,4 +149,4 @@ class Command(BaseCommand):
                     return sum(await asyncio.gather(*(run(p) for p in posts)))
 
                 count += asyncio.run(runner())
-        self.stdout.write(f"Backfilled {count} thumbnails")
+        self.stdout.write(f"Backfilled {count} thumbnails; converted {converted} thumbnails")

--- a/core/tests/tests_backfill_thumbs_command.py
+++ b/core/tests/tests_backfill_thumbs_command.py
@@ -166,3 +166,43 @@ def test_backfill_thumbs_uses_fallback_after_og(monkeypatch):
     assert post.thumbnail_url == "https://fallback.example.com/thumb.jpg"
     assert order == ["og", "fb"]
     assert cache.get("thumb:https://rumble.com/v1abcd") == "https://fallback.example.com/thumb.jpg"
+
+
+@pytest.mark.django_db
+def test_backfill_thumbs_caches_rumble_thumbnails(monkeypatch):
+    cache.clear()
+    User = get_user_model()
+    user = User.objects.create_user("alice", password="pw")
+    com = Community.objects.create(slug="t", name="Test", title="Test", created_by=user)
+    post = Post.objects.create(
+        community=com,
+        author=user,
+        post_type="link",
+        title="Link",
+        content_url="https://rumble.com/v1abc",
+        thumbnail_url="https://sp.rmbl.ws/s8/1/v1abc.jpg",
+    )
+
+    from core.management.commands import backfill_thumbs
+
+    def fake_cache(remote_url, canon_url):
+        return "/media/thumbs/cache.jpg"
+
+    monkeypatch.setattr(backfill_thumbs, "cache_remote_image", fake_cache)
+    call_command("backfill_thumbs", days=365)
+    post.refresh_from_db()
+    assert post.thumbnail_url == "/media/thumbs/cache.jpg"
+
+    post.thumbnail_url = "https://sp.rmbl.ws/s8/1/v1abc.jpg"
+    post.save(update_fields=["thumbnail_url"])
+    calls: list[str] = []
+
+    def fake_cache2(remote_url, canon_url):
+        calls.append(remote_url)
+        return "/media/thumbs/cache2.jpg"
+
+    monkeypatch.setattr(backfill_thumbs, "cache_remote_image", fake_cache2)
+    call_command("backfill_thumbs", days=365, dry_run=True)
+    post.refresh_from_db()
+    assert post.thumbnail_url == "https://sp.rmbl.ws/s8/1/v1abc.jpg"
+    assert calls == ["https://sp.rmbl.ws/s8/1/v1abc.jpg"]


### PR DESCRIPTION
## Summary
- convert Rumble CDN thumbnail URLs to cached local images
- add `--dry-run` option and log number of conversions
- cover new behavior with tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bccf29abc8832ca476fbc62c5a2041