### PR TITLE
Cache Rumble thumbnails locally

### DIFF
--- a/core/utils/thumbnails.py
+++ b/core/utils/thumbnails.py
@@ -272,6 +272,15 @@ def resolve_thumbnail(url: str, label: str, fetch_remote: bool = False) -> tuple
                 thumb = None
     if not thumb and not direct_og:
         thumb = _provider_fallback(canon_url, fetch_remote)
+        if thumb and "rumble.com" in domain:
+            if thumb.startswith("https://"):
+                cached = cache_remote_image(thumb, canon_url)
+                if cached:
+                    thumb = cached
+                else:
+                    thumb = None
+            else:
+                thumb = None
 
     if thumb and (thumb.startswith("https://") or thumb.startswith(settings.MEDIA_URL)):
         cache.set(success_key, thumb, _THUMB_TTL)

--- a/docs/rumble-thumbnail-cache.md
+++ b/docs/rumble-thumbnail-cache.md
@@ -1,0 +1,15 @@
+# Rumble thumbnail caching
+
+SureJan downloads poster images for Rumble links and stores them under
+`MEDIA_ROOT/thumbs/` to avoid hotlinking `sp.rmbl.ws`.
+
+## Configuration
+
+* Set `RUMBLE_DIRECT_OG=1` to fetch Rumble's OpenGraph thumbnails directly.
+  The fallback CDN thumbnail is cached in the same location.
+* Ensure `MEDIA_ROOT` and `MEDIA_URL` are configured to serve media files.
+  `THUMB_CACHE_DIR` controls the cache directory and defaults to
+  `MEDIA_ROOT/thumbs`.
+
+Run `python manage.py backfill_thumbs` to populate thumbnails for recent
+posts after enabling the feature.

--- a/templates/partials/post_thumbnail.html
+++ b/templates/partials/post_thumbnail.html
@@ -1,6 +1,7 @@
 {% load thumbnails %}
 {% if post.thumbnail_url %}
   {% with src=post.thumbnail_url alt=post.thumbnail_alt|default:post.title %}
+  {# ``thumbnail_url`` points to a cached file under MEDIA_URL/thumbs/ when available #}
   <a href="{{ post.content_url }}" target="_blank" rel="noopener noreferrer" class="thumb" style="aspect-ratio:16/9;">
     <img src="{{ src }}" alt="{{ alt }}" loading="lazy" decoding="async" referrerpolicy="no-referrer" width="640" height="360">
     {% if post.provider_name %}<span class="thumb-label">{{ post.provider_name }}</span>{% endif %}

--- a/tests/test_rumble_thumbnail.py
+++ b/tests/test_rumble_thumbnail.py
@@ -8,17 +8,51 @@ from core.utils import thumbnails
 from core.utils.video_urls import canonicalize_video_url
 
 
-def test_resolve_thumbnail_rumble(monkeypatch):
+def test_resolve_thumbnail_rumble(monkeypatch, tmp_path):
     cache.clear()
+    remote_url = "https://sp.rmbl.ws/s8/1/testslug.jpg"
+
     monkeypatch.setattr(thumbnails, "fetch_og_image", lambda url: None)
-    monkeypatch.setattr(
-        thumbnails, "rumble_fallback_thumb", lambda url: "https://rumble.example/thumb.jpg"
-    )
-    src, alt = thumbnails.resolve_thumbnail(
-        "https://rumble.com/v1", "label", fetch_remote=True
-    )
-    assert src == "https://rumble.example/thumb.jpg"
-    assert alt == "label"
+    monkeypatch.setattr(thumbnails, "rumble_fallback_thumb", lambda url: remote_url)
+
+    class Resp:
+        status_code = 200
+        headers = {"Content-Type": "image/jpeg"}
+        content = b"img"
+
+        def raise_for_status(self):
+            pass
+
+    calls = []
+
+    def fake_fetch_html(url, source="unknown"):
+        calls.append(url)
+        return Resp()
+
+    monkeypatch.setattr(thumbnails, "fetch_html", fake_fetch_html)
+
+    url = "https://rumble.com/v1"
+    canon = canonicalize_video_url(url)
+    digest = hashlib.sha256(canon.encode("utf-8")).hexdigest()
+
+    with override_settings(
+        MEDIA_ROOT=tmp_path / "media",
+        THUMB_CACHE_DIR=tmp_path / "media" / "thumbs",
+        MEDIA_URL="/media/",
+    ):
+        expected = settings.THUMB_CACHE_DIR / f"{digest}.jpg"
+
+        src, alt = thumbnails.resolve_thumbnail(url, "label", fetch_remote=True)
+        assert src.startswith(settings.MEDIA_URL)
+        assert src.endswith(expected.name)
+        assert expected.exists()
+        assert alt == "label"
+        assert calls == [remote_url]
+
+        calls.clear()
+        src2, _ = thumbnails.resolve_thumbnail(url, "label", fetch_remote=True)
+        assert src2 == src
+        assert calls == []
 
 def test_resolve_thumbnail_rumble_rejects_http(monkeypatch):
     cache.clear()


### PR DESCRIPTION
## Summary
- cache Rumble thumbnails under `MEDIA_ROOT/thumbs` to avoid hotlinking
- annotate thumbnail template to use cached media path
- document local Rumble thumbnail caching and settings

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bcd2203858832c8b601a280d4c1d52