### PR TITLE
Cache Rumble thumbnails and canonicalize URLs

### DIFF
--- a/core/management/commands/backfill_thumbs.py
+++ b/core/management/commands/backfill_thumbs.py
@@ -66,8 +66,7 @@ class Command(BaseCommand):
         converted = 0
         for p in qs_rumble.iterator():
             try:
-                canon = canonicalize_video_url(p.content_url or "")
-                cached = cache_remote_image(p.thumbnail_url or "", canon)
+                cached = cache_remote_image(p.thumbnail_url or "")
                 if cached:
                     converted += 1
                     if not opts["dry_run"]:

--- a/core/tests/test_video_urls.py
+++ b/core/tests/test_video_urls.py
@@ -2,7 +2,7 @@ import pytest
 
 from core.utils.video_urls import (
     canonicalize_youtube,
-    canonicalize_rumble,
+    canonicalize_rumble_url,
     canonicalize_x,
     canonicalize_video_url,
 )
@@ -20,12 +20,14 @@ def test_canonicalize_youtube_variants():
 
 
 def test_canonicalize_rumble_variants():
-    urls = [
-        "https://rumble.com/v1abcd-something.html?foo=bar",
-        "https://rumble.com/embed/v1abcd?pub=123",
-    ]
-    for u in urls:
-        assert canonicalize_rumble(u) == "https://rumble.com/v1abcd"
+    assert (
+        canonicalize_rumble_url("https://rumble.com/v1abcd-something.html?foo=bar")
+        == "https://rumble.com/v1abcd-something.html"
+    )
+    assert (
+        canonicalize_rumble_url("https://rumble.com/embed/v1abcd?pub=123")
+        == "https://rumble.com/v1abcd.html"
+    )
 
 
 def test_canonicalize_x_variants():
@@ -45,7 +47,7 @@ def test_canonicalize_video_url_dispatcher():
     )
     assert (
         canonicalize_video_url("https://rumble.com/embed/v1abcd")
-        == "https://rumble.com/v1abcd"
+        == "https://rumble.com/v1abcd.html"
     )
     assert (
         canonicalize_video_url("https://twitter.com/user/status/123")

--- a/core/tests/tests_backfill_thumbs_command.py
+++ b/core/tests/tests_backfill_thumbs_command.py
@@ -165,7 +165,10 @@ def test_backfill_thumbs_uses_fallback_after_og(monkeypatch):
     post.refresh_from_db()
     assert post.thumbnail_url == "https://fallback.example.com/thumb.jpg"
     assert order == ["og", "fb"]
-    assert cache.get("thumb:https://rumble.com/v1abcd") == "https://fallback.example.com/thumb.jpg"
+    assert (
+        cache.get("thumb:https://rumble.com/v1abcd.html")
+        == "https://fallback.example.com/thumb.jpg"
+    )
 
 
 @pytest.mark.django_db
@@ -185,21 +188,21 @@ def test_backfill_thumbs_caches_rumble_thumbnails(monkeypatch):
 
     from core.management.commands import backfill_thumbs
 
-    def fake_cache(remote_url, canon_url):
-        return "/media/thumbs/cache.jpg"
+    def fake_cache(origin_url):
+        return "/media/thumbs/rumble/cache.jpg"
 
     monkeypatch.setattr(backfill_thumbs, "cache_remote_image", fake_cache)
     call_command("backfill_thumbs", days=365)
     post.refresh_from_db()
-    assert post.thumbnail_url == "/media/thumbs/cache.jpg"
+    assert post.thumbnail_url == "/media/thumbs/rumble/cache.jpg"
 
     post.thumbnail_url = "https://sp.rmbl.ws/s8/1/v1abc.jpg"
     post.save(update_fields=["thumbnail_url"])
     calls: list[str] = []
 
-    def fake_cache2(remote_url, canon_url):
-        calls.append(remote_url)
-        return "/media/thumbs/cache2.jpg"
+    def fake_cache2(origin_url):
+        calls.append(origin_url)
+        return "/media/thumbs/rumble/cache2.jpg"
 
     monkeypatch.setattr(backfill_thumbs, "cache_remote_image", fake_cache2)
     call_command("backfill_thumbs", days=365, dry_run=True)

--- a/core/tests/tests_thumbnail_utils.py
+++ b/core/tests/tests_thumbnail_utils.py
@@ -138,7 +138,10 @@ def test_resolve_thumbnail_falls_back_after_og(monkeypatch):
     assert src == "https://fallback.example/thumb.jpg"
     assert alt == "label"
     assert order == ["og", "fb"]
-    assert cache.get("thumb:https://rumble.com/v1abcd") == "https://fallback.example/thumb.jpg"
+    assert (
+        cache.get("thumb:https://rumble.com/v1abcd.html")
+        == "https://fallback.example/thumb.jpg"
+    )
 
 
 @pytest.mark.django_db

--- a/core/utils/thumbnails.py
+++ b/core/utils/thumbnails.py
@@ -24,23 +24,27 @@ logger = logging.getLogger(__name__)
 
 def scrape_og_image(url: str) -> tuple[Optional[str], Optional[int]]:
     """Return the first OpenGraph image URL for ``url`` if present."""
-    domain = urlparse(url).netloc
+    provider = urlparse(url).netloc
     status = None
+    image = None
+    result = "og_missing"
     try:
         resp = fetch_html(url, source="og-image")
         status = resp.status_code
         resp.raise_for_status()
+        match = OG_IMAGE_RE.search(resp.text)
+        if match:
+            image = match.group(1)
+            result = "og_found"
     except Exception:
-        logger.info("og-image fetch %s status=%s result=fallback", domain, status or "error")
-        return None, status
-
-    match = OG_IMAGE_RE.search(resp.text)
-    if match:
-        logger.info("og-image fetch %s status=%s result=image", domain, status)
-        return match.group(1), status
-
-    logger.info("og-image fetch %s status=%s result=fallback", domain, status)
-    return None, status
+        if status == 403:
+            result = "http_403"
+        else:
+            result = f"http_{status}" if status else "error"
+    logger.info(
+        "provider=%s result=%s origin_image_url=%s", provider, result, image or ""
+    )
+    return image, status
 
 
 _CACHE_KEY_PREFIX = "og-image:"  # cache key prefix for og image lookups
@@ -175,49 +179,64 @@ def _provider_fallback(url: str, fetch_remote: bool) -> str | None:
 _EXTENSION_MAP = {
     "image/jpeg": "jpg",
     "image/png": "png",
-    "image/gif": "gif",
     "image/webp": "webp",
 }
 
 
-def cache_remote_image(remote_url: str, canon_url: str) -> str | None:
-    """Fetch ``remote_url`` and cache locally under a stable name.
+def cache_remote_image(origin_url: str) -> str | None:
+    """Fetch ``origin_url`` and cache locally under a stable name.
 
-    The canonical video URL ``canon_url`` is hashed to derive the filename. A
-    previously cached file is returned without fetching the remote again.
-    On a fetch failure we return ``None`` so callers can fall back.
+    The origin URL is hashed to derive the filename. A previously cached file is
+    returned without fetching the remote again. On a fetch failure we return
+    ``None`` so callers can fall back.
     """
 
-    digest = hashlib.sha256(canon_url.encode("utf-8")).hexdigest()
-    base = settings.THUMB_CACHE_DIR / digest
+    digest = hashlib.sha1(origin_url.encode("utf-8")).hexdigest()
+    base = settings.THUMB_CACHE_DIR / "rumble" / digest
 
     for ext in _EXTENSION_MAP.values():
         candidate = base.with_suffix(f".{ext}")
         if candidate.exists():
-            logger.info("rumble-thumb cache %s result=hit", canon_url)
-            return f"{settings.MEDIA_URL}thumbs/{candidate.name}"
+            logger.info("rumble-thumb cache %s result=hit", origin_url)
+            return f"{settings.MEDIA_URL}thumbs/rumble/{candidate.name}"
 
     status = None
     try:
-        resp = fetch_html(remote_url, source="rumble-thumb")
+        resp = fetch_html(origin_url, source="rumble-thumb")
         status = resp.status_code
         resp.raise_for_status()
     except Exception:
-        logger.info("rumble-thumb fetch %s status=%s result=fallback", remote_url, status or "error")
+        logger.info(
+            "rumble-thumb fetch %s status=%s result=fallback", origin_url, status or "error"
+        )
         return None
 
     content_type = resp.headers.get("Content-Type", "").split(";")[0].lower()
+    if not content_type.startswith("image/"):
+        logger.info(
+            "rumble-thumb fetch %s status=%s result=fallback", origin_url, status
+        )
+        return None
+    if len(resp.content) > 5 * 1024 * 1024:
+        logger.info(
+            "rumble-thumb fetch %s status=%s result=too_large", origin_url, status
+        )
+        return None
     ext = _EXTENSION_MAP.get(content_type)
     if not ext:
-        logger.info("rumble-thumb fetch %s status=%s result=fallback", remote_url, status)
+        logger.info(
+            "rumble-thumb fetch %s status=%s result=fallback", origin_url, status
+        )
         return None
 
     path = base.with_suffix(f".{ext}")
     path.parent.mkdir(parents=True, exist_ok=True)
     with open(path, "wb") as fh:
         fh.write(resp.content)
-    logger.info("rumble-thumb fetch %s status=%s result=stored", remote_url, status)
-    return f"{settings.MEDIA_URL}thumbs/{path.name}"
+    logger.info(
+        "rumble-thumb fetch %s status=%s result=stored", origin_url, status
+    )
+    return f"{settings.MEDIA_URL}thumbs/rumble/{path.name}"
 
 
 def resolve_thumbnail(url: str, label: str, fetch_remote: bool = False) -> tuple[str, str]:
@@ -265,7 +284,7 @@ def resolve_thumbnail(url: str, label: str, fetch_remote: bool = False) -> tuple
         thumb = fetch_og_image(canon_url)
         status = getattr(fetch_og_image, "last_status", None)
         if thumb and direct_og and "rumble.com" in domain:
-            cached = cache_remote_image(thumb, canon_url)
+            cached = cache_remote_image(thumb)
             if cached:
                 thumb = cached
             else:
@@ -274,7 +293,7 @@ def resolve_thumbnail(url: str, label: str, fetch_remote: bool = False) -> tuple
         thumb = _provider_fallback(canon_url, fetch_remote)
         if thumb and "rumble.com" in domain:
             if thumb.startswith("https://"):
-                cached = cache_remote_image(thumb, canon_url)
+                cached = cache_remote_image(thumb)
                 if cached:
                     thumb = cached
                 else:

--- a/core/utils/video_urls.py
+++ b/core/utils/video_urls.py
@@ -37,19 +37,26 @@ def canonicalize_youtube(url: str) -> str | None:
     return f"https://youtube.com/watch?v={vid}"
 
 
-def canonicalize_rumble(url: str) -> str | None:
-    """Return canonical Rumble URL of the form ``https://rumble.com/v...``."""
-    parsed = urlparse(url)
-    host = parsed.netloc.lower().lstrip("www.")
-    if host != "rumble.com":
+def is_rumble_url(url: str) -> bool:
+    """Return ``True`` if ``url`` points to rumble.com."""
+    host = urlparse(url).netloc.lower().lstrip("www.")
+    return host == "rumble.com"
+
+
+def canonicalize_rumble_url(url: str) -> str | None:
+    """Return canonical ``https://rumble.com/v...-slug.html`` for Rumble URLs."""
+    if not is_rumble_url(url):
         return None
+    parsed = urlparse(url)
     path = parsed.path
     if path.startswith("/embed/"):
         path = "/" + path[len("/embed/"):]
-    m = re.search(r"/(v[0-9a-z]+)", path)
+    m = re.search(r"/(v[0-9a-z]+(?:-[\w-]+)?)", path)
     if not m:
         return None
     slug = m.group(1)
+    if not slug.endswith(".html"):
+        slug += ".html"
     return f"https://rumble.com/{slug}"
 
 
@@ -70,7 +77,7 @@ def canonicalize_x(url: str) -> str | None:
     return urlunparse(("https", "x.com", path, "", "", ""))
 
 
-_CANONICALIZERS = [canonicalize_youtube, canonicalize_rumble, canonicalize_x]
+_CANONICALIZERS = [canonicalize_youtube, canonicalize_rumble_url, canonicalize_x]
 
 
 def canonicalize_video_url(url: str) -> str:

--- a/tests/test_rumble_thumbnail.py
+++ b/tests/test_rumble_thumbnail.py
@@ -5,7 +5,6 @@ from django.core.cache import cache
 from django.test import override_settings
 
 from core.utils import thumbnails
-from core.utils.video_urls import canonicalize_video_url
 
 
 def test_resolve_thumbnail_rumble(monkeypatch, tmp_path):
@@ -32,15 +31,14 @@ def test_resolve_thumbnail_rumble(monkeypatch, tmp_path):
     monkeypatch.setattr(thumbnails, "fetch_html", fake_fetch_html)
 
     url = "https://rumble.com/v1"
-    canon = canonicalize_video_url(url)
-    digest = hashlib.sha256(canon.encode("utf-8")).hexdigest()
+    digest = hashlib.sha1(remote_url.encode("utf-8")).hexdigest()
 
     with override_settings(
         MEDIA_ROOT=tmp_path / "media",
         THUMB_CACHE_DIR=tmp_path / "media" / "thumbs",
         MEDIA_URL="/media/",
     ):
-        expected = settings.THUMB_CACHE_DIR / f"{digest}.jpg"
+        expected = settings.THUMB_CACHE_DIR / "rumble" / f"{digest}.jpg"
 
         src, alt = thumbnails.resolve_thumbnail(url, "label", fetch_remote=True)
         assert src.startswith(settings.MEDIA_URL)
@@ -93,8 +91,7 @@ def test_resolve_thumbnail_rumble_direct_og_cached(monkeypatch, tmp_path):
     monkeypatch.setattr(thumbnails, "fetch_html", fake_fetch_html)
 
     url = "https://rumble.com/v1abc"
-    canon = canonicalize_video_url(url)
-    digest = hashlib.sha256(canon.encode("utf-8")).hexdigest()
+    digest = hashlib.sha1(remote_url.encode("utf-8")).hexdigest()
 
     with override_settings(
         RUMBLE_DIRECT_OG=True,
@@ -102,7 +99,7 @@ def test_resolve_thumbnail_rumble_direct_og_cached(monkeypatch, tmp_path):
         THUMB_CACHE_DIR=tmp_path / "media" / "thumbs",
         MEDIA_URL="/media/",
     ):
-        expected = settings.THUMB_CACHE_DIR / f"{digest}.jpg"
+        expected = settings.THUMB_CACHE_DIR / "rumble" / f"{digest}.jpg"
 
         src, _ = thumbnails.resolve_thumbnail(url, "label", fetch_remote=True)
         assert src.startswith(settings.MEDIA_URL)


### PR DESCRIPTION
## Summary
- Normalize Rumble links to canonical `https://rumble.com/v{id}-slug.html` and add helper to detect Rumble URLs
- Log OpenGraph image fetch results and cache remote thumbnails locally with content-type/size checks
- Use new thumbnail cache helper when generating and backfilling thumbnails

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bcd8c00eec832ca70910b1fe657cce