### PR TITLE
Canonicalize video URLs on posts

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -200,8 +200,9 @@ class Post(models.Model):
         recompute = kwargs.pop("recompute_hot", True)
 
         if self.content_url:
-            self.content_url = canonicalize_video_url(self.content_url)
-            self.link_domain = urlparse(self.content_url).netloc
+            canon_url = canonicalize_video_url(self.content_url)
+            self.content_url = canon_url
+            self.link_domain = urlparse(canon_url).netloc.lower().lstrip("www.")
 
         # Apply domain throttling weight on every save
         from .mod import domain_weight  # avoid circular import at module load

--- a/core/tests/test_post_url_canonicalization.py
+++ b/core/tests/test_post_url_canonicalization.py
@@ -1,0 +1,27 @@
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from core.models import Community, Post
+
+
+class PostURLCanonicalizationTests(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.user = User.objects.create_user("alice", password="pw")
+        self.community = Community.objects.create(
+            slug="t", name="Test", title="Test", created_by=self.user
+        )
+
+    def test_rumble_url_query_cleaned(self):
+        post = Post.objects.create(
+            community=self.community,
+            author=self.user,
+            post_type="link",
+            title="Rumble",
+            content_url="https://rumble.com/v1abcd-something.html?foo=bar",
+        )
+        post.refresh_from_db()
+        self.assertEqual(
+            post.content_url, "https://rumble.com/v1abcd-something.html"
+        )
+        self.assertEqual(post.link_domain, "rumble.com")


### PR DESCRIPTION
## Summary
- Normalize post `content_url` and `link_domain` using `canonicalize_video_url`
- Add regression test for Rumble URLs with query parameters

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bcded275b0832cb66a82e8b405d82b