### PR TITLE
Enable default Rumble OG scraping and add UA logging

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -99,7 +99,7 @@ YT_DIRECT_OG = os.environ.get("YT_DIRECT_OG", "0") in (
     "true",
     "True",
 )
-RUMBLE_DIRECT_OG = os.environ.get("RUMBLE_DIRECT_OG", "0") in (
+RUMBLE_DIRECT_OG = os.environ.get("RUMBLE_DIRECT_OG", "1") in (
     "1",
     "true",
     "True",

--- a/core/http_client.py
+++ b/core/http_client.py
@@ -51,7 +51,16 @@ def _log(url: str, source: str, status: int | None) -> None:
     level = logging.INFO if status and status < 400 else logging.WARNING
     key = "success" if status and status < 400 else "error"
     COUNTERS[provider][key] += 1
-    logger.log(level, "provider=%s url=%s source=%s status=%s", provider, url, source, status)
+    ua = get_session().headers.get("User-Agent", "")
+    logger.log(
+        level,
+        "provider=%s url=%s source=%s ua=%s status=%s",
+        provider,
+        url,
+        source,
+        ua,
+        status,
+    )
 
 
 def fetch_json(url: str, source: str = "unknown") -> dict:

--- a/core/tests/test_http_client.py
+++ b/core/tests/test_http_client.py
@@ -47,6 +47,7 @@ def test_logging_and_counters(monkeypatch, caplog):
         http_client.fetch_json("https://example.com/data", source="test")
     assert http_client.COUNTERS["example.com"]["success"] == 1
     assert "provider=example.com" in caplog.text
+    assert "Mozilla/5.0" in caplog.text
 
     class BadResp:
         status_code = 404
@@ -56,3 +57,4 @@ def test_logging_and_counters(monkeypatch, caplog):
         http_client.fetch_html("https://example.com/miss", source="test")
     assert http_client.COUNTERS["example.com"]["error"] == 1
     assert "status=404" in caplog.text
+    assert "Mozilla/5.0" in caplog.text

--- a/core/tests/tests_thumbnail_utils.py
+++ b/core/tests/tests_thumbnail_utils.py
@@ -71,6 +71,28 @@ def test_fail_ttl_throttled(monkeypatch):
 
 
 @pytest.mark.django_db
+def test_fail_ttl_forbidden(monkeypatch):
+    cache.clear()
+
+    def fake_fetch(url):
+        fake_fetch.last_status = 403
+        return None
+
+    monkeypatch.setattr(thumbnails, "fetch_og_image", fake_fetch)
+
+    seen = {}
+    orig_set = cache.set
+
+    def fake_set(key, value, timeout):
+        seen["timeout"] = timeout
+        return orig_set(key, value, timeout)
+
+    monkeypatch.setattr(cache, "set", fake_set)
+    thumbnails.resolve_thumbnail("https://example.com", "label", fetch_remote=True)
+    assert seen["timeout"] == thumbnails._FAIL_RETRY_TTL
+
+
+@pytest.mark.django_db
 def test_resolve_thumbnail_success_caches(monkeypatch):
     cache.clear()
     og_calls = []

--- a/core/tests_post_submit_types.py
+++ b/core/tests_post_submit_types.py
@@ -4,7 +4,9 @@ from django.contrib.auth import get_user_model
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.urls import reverse
 from django.test import TestCase
+from unittest.mock import patch
 
+from core.utils import thumbnails
 from .models import Community, Post
 
 
@@ -42,21 +44,47 @@ class PostSubmitTests(TestCase):
 
     def test_youtube_link_post(self):
         link = "https://www.youtube-nocookie.com/watch?v=dQw4w9WgXcQ"
-        resp = self.client.post(
-            reverse("post_submit"),
-            {
-                "community": self.community.id,
-                "post_type": "link",
-                "title": "YT",
-                "content_url": link,
-            },
-            follow=True,
-        )
+        with patch("core.utils.thumbnails.resolve_thumbnail", return_value=("data:image/svg+xml;base64,ph", "alt")):
+            resp = self.client.post(
+                reverse("post_submit"),
+                {
+                    "community": self.community.id,
+                    "post_type": "link",
+                    "title": "YT",
+                    "content_url": link,
+                },
+                follow=True,
+            )
         self.assertEqual(resp.status_code, 200)
         post = Post.objects.get(title="YT")
         self.assertEqual(post.content_url, link)
         feed = self.client.get(reverse("home"))
         self.assertContains(feed, "YT")
+
+    def test_rumble_link_post_fetches_og_image(self):
+        link = "https://rumble.com/v1abc"
+        called = {}
+
+        def fake_fetch(url):
+            called["url"] = url
+            thumbnails.fetch_og_image.last_status = 200
+            return None
+
+        with patch("core.utils.thumbnails.fetch_og_image", side_effect=fake_fetch) as mock_fetch, \
+            patch("core.utils.thumbnails._provider_fallback", return_value=None):
+            resp = self.client.post(
+                reverse("post_submit"),
+                {
+                    "community": self.community.id,
+                    "post_type": "link",
+                    "title": "R", 
+                    "content_url": link,
+                },
+                follow=True,
+            )
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(mock_fetch.call_count, 1)
+        self.assertEqual(called.get("url"), link)
 
     def test_image_post(self):
         img = make_image()

--- a/core/utils/thumbnails.py
+++ b/core/utils/thumbnails.py
@@ -305,5 +305,7 @@ def resolve_thumbnail(url: str, label: str, fetch_remote: bool = False) -> tuple
         cache.set(success_key, thumb, _THUMB_TTL)
         return thumb, label
 
-    cache.set(fail_key, True, _fail_ttl(status))
+    ttl = _fail_ttl(status)
+    logger.info("thumb-fail url=%s status=%s ttl=%s", canon_url, status, ttl)
+    cache.set(fail_key, True, ttl)
     return svg_placeholder(label)

--- a/core/views.py
+++ b/core/views.py
@@ -51,6 +51,7 @@ from .services.votes import (
 from . import mod
 from .http import login_required_htmx
 from .utils.video_urls import canonicalize_video_url
+from .utils.thumbnails import resolve_thumbnail
 
 
 def _is_banned(user):
@@ -554,6 +555,11 @@ def post_submit(request):
             if post_type == "image":
                 post.image = form.cleaned_data.get("image")
             post.save()
+            if post_type == "link":
+                src, alt = resolve_thumbnail(content_url, form.cleaned_data["title"], fetch_remote=True)
+                post.thumbnail_url = src
+                post.thumbnail_alt = alt
+                post.save(update_fields=["thumbnail_url", "thumbnail_alt"])
             messages.success(request, "Post submitted")
             return redirect(
                 "post_detail",

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -14,8 +14,9 @@ The `ASTROTURF_WATCH` environment variable (default `1`) controls all
 astroturf-detection features. Set `ASTROTURF_WATCH=0` to hide engagement
 chips and block transparency pages; related endpoints will return 404.
 
-`YT_DIRECT_OG`, `RUMBLE_DIRECT_OG`, and `X_DIRECT_OG` (all default `0`) opt a
-provider into direct OpenGraph thumbnail lookups. See
+`YT_DIRECT_OG`, `RUMBLE_DIRECT_OG`, and `X_DIRECT_OG` opt a provider into direct
+OpenGraph thumbnail lookups. `RUMBLE_DIRECT_OG` defaults to `1` while the
+others default to `0`. See
 [direct-og-rollout.md](direct-og-rollout.md) for rollout and rollback steps.
 
 ### CSP / Hosts

--- a/docs/direct-og-env.md
+++ b/docs/direct-og-env.md
@@ -1,0 +1,10 @@
+# Direct OpenGraph scraping flags
+
+Three environment variables control direct OpenGraph thumbnail fetching:
+
+- `YT_DIRECT_OG` – YouTube (default `0`)
+- `RUMBLE_DIRECT_OG` – Rumble (default `1`)
+- `X_DIRECT_OG` – X/Twitter (default `0`)
+
+When set to `1`, SureJan bypasses provider-specific fallback logic and
+scrapes the provider's OpenGraph metadata directly for thumbnail images.

--- a/docs/direct-og-rollout.md
+++ b/docs/direct-og-rollout.md
@@ -2,10 +2,11 @@
 
 Certain providers can fetch their OpenGraph poster images directly instead of
 using deterministic CDN fallbacks. Three environment variables control this
-behaviour and default to `0` (disabled):
+behaviour. `RUMBLE_DIRECT_OG` defaults to `1` (enabled) while the others
+default to `0` (disabled):
 
 - `YT_DIRECT_OG` – YouTube
-- `RUMBLE_DIRECT_OG` – Rumble
+- `RUMBLE_DIRECT_OG` – Rumble (default `1`)
 - `X_DIRECT_OG` – X/Twitter
 
 When enabled (`1`), SureJan skips URL canonicalisation and provider-specific

--- a/docs/rumble-thumbnail-cache.md
+++ b/docs/rumble-thumbnail-cache.md
@@ -5,8 +5,8 @@ SureJan downloads poster images for Rumble links and stores them under
 
 ## Configuration
 
-* Set `RUMBLE_DIRECT_OG=1` to fetch Rumble's OpenGraph thumbnails directly.
-  The fallback CDN thumbnail is cached in the same location.
+* `RUMBLE_DIRECT_OG` enables direct OpenGraph thumbnail fetching for Rumble and
+  defaults to `1`. The fallback CDN thumbnail is cached in the same location.
 * Ensure `MEDIA_ROOT` and `MEDIA_URL` are configured to serve media files.
   `THUMB_CACHE_DIR` controls the cache directory and defaults to
   `MEDIA_ROOT/thumbs`.

--- a/tests/test_smoke_v2.py
+++ b/tests/test_smoke_v2.py
@@ -13,7 +13,7 @@ from core.models import Community, Post
 
 
 @pytest.mark.django_db
-def test_signup_submit_sort_and_commands(client):
+def test_signup_submit_sort_and_commands(client, monkeypatch):
     # signup flow
     r = client.get('/accounts/signup/')
     a, b = client.session['signup_captcha_q']
@@ -36,6 +36,7 @@ def test_signup_submit_sort_and_commands(client):
         'body': 'body',
     }, follow=True)
     # submit link
+    monkeypatch.setattr('core.utils.thumbnails.resolve_thumbnail', lambda *a, **kw: ('data:image/svg+xml;base64,ph', 'alt'))
     client.post(reverse('post_submit'), {
         'community': com.id,
         'post_type': 'link',


### PR DESCRIPTION
## Summary
- enable RUMBLE_DIRECT_OG by default
- fetch thumbnails on link post submit and log UA on HTTP fetches
- document direct OG environment variables

## Testing
- `python manage.py test core.tests_post_submit_types.PostSubmitTests.test_rumble_link_post_fetches_og_image` *(fails: Missing staticfiles manifest entry for 'css/app.css')*


------
https://chatgpt.com/codex/tasks/task_e_68bce00f8128832ca69eee0deb217d89