### PR TITLE
Cache link thumbnails locally and refetch off-site images

### DIFF
--- a/core/management/commands/refetch_thumbs.py
+++ b/core/management/commands/refetch_thumbs.py
@@ -1,0 +1,36 @@
+from django.conf import settings
+from django.core.management.base import BaseCommand
+
+from core.models import Post
+from core.utils.thumbnails import resolve_thumbnail
+
+
+class Command(BaseCommand):
+    help = "Re-fetch thumbnails for posts with off-site thumbnail URLs"
+
+    def add_arguments(self, parser):
+        parser.add_argument("--limit", type=int, default=100, help="Maximum posts to process")
+
+    def handle(self, *args, **opts):
+        qs = (
+            Post.objects.filter(post_type="link")
+            .exclude(thumbnail_url__isnull=True)
+            .exclude(thumbnail_url="")
+            .exclude(thumbnail_url__startswith=settings.MEDIA_URL)
+            .exclude(thumbnail_url__startswith="data:")
+            .order_by("-created_at")[: opts["limit"]]
+        )
+        count = 0
+        for post in qs:
+            try:
+                src, alt = resolve_thumbnail(
+                    post.content_url or "", post.title, fetch_remote=True
+                )
+                if src and src.startswith(settings.MEDIA_URL):
+                    post.thumbnail_url = src
+                    post.thumbnail_alt = alt
+                    post.save(update_fields=["thumbnail_url", "thumbnail_alt"])
+                    count += 1
+            except Exception as e:  # pragma: no cover - log and continue
+                self.stderr.write(f"Post {post.id}: {e}")
+        self.stdout.write(f"Refetched {count} thumbnails")

--- a/core/tests/tests_refetch_thumbs_command.py
+++ b/core/tests/tests_refetch_thumbs_command.py
@@ -1,0 +1,32 @@
+import pytest
+from django.contrib.auth import get_user_model
+from django.core.management import call_command
+from django.conf import settings
+
+from core.models import Community, Post
+from core.utils import thumbnails
+
+
+@pytest.mark.django_db
+def test_refetch_thumbs_replaces_remote(monkeypatch):
+    User = get_user_model()
+    user = User.objects.create_user("alice", password="pw")
+    com = Community.objects.create(slug="t", name="Test", title="Test", created_by=user)
+    post = Post.objects.create(
+        community=com,
+        author=user,
+        post_type="link",
+        title="Link",
+        content_url="https://example.com",
+        thumbnail_url="https://cdn.example.com/old.jpg",
+        thumbnail_alt="old",
+    )
+
+    def fake_resolve(url, label, fetch_remote=False):
+        return f"{settings.MEDIA_URL}thumbs/new.jpg", "new"
+
+    monkeypatch.setattr(thumbnails, "resolve_thumbnail", fake_resolve)
+    call_command("refetch_thumbs", limit=1)
+    post.refresh_from_db()
+    assert post.thumbnail_url == f"{settings.MEDIA_URL}thumbs/new.jpg"
+    assert post.thumbnail_alt == "new"

--- a/core/tests_post_submit_types.py
+++ b/core/tests_post_submit_types.py
@@ -61,6 +61,27 @@ class PostSubmitTests(TestCase):
         feed = self.client.get(reverse("home"))
         self.assertContains(feed, "YT")
 
+    def test_link_post_remote_thumb_not_saved(self):
+        link = "https://example.com/page"
+        with patch(
+            "core.utils.thumbnails.resolve_thumbnail",
+            return_value=("https://cdn.example.com/thumb.jpg", "alt"),
+        ):
+            resp = self.client.post(
+                reverse("post_submit"),
+                {
+                    "community": self.community.id,
+                    "post_type": "link",
+                    "title": "NoThumb",
+                    "content_url": link,
+                },
+                follow=True,
+            )
+        self.assertEqual(resp.status_code, 200)
+        post = Post.objects.get(title="NoThumb")
+        self.assertEqual(post.thumbnail_url, "")
+        self.assertEqual(post.thumbnail_alt, "")
+
     def test_rumble_link_post_fetches_og_image(self):
         link = "https://rumble.com/v1abc"
         called = {}

--- a/core/views.py
+++ b/core/views.py
@@ -556,10 +556,13 @@ def post_submit(request):
                 post.image = form.cleaned_data.get("image")
             post.save()
             if post_type == "link":
-                src, alt = resolve_thumbnail(content_url, form.cleaned_data["title"], fetch_remote=True)
-                post.thumbnail_url = src
-                post.thumbnail_alt = alt
-                post.save(update_fields=["thumbnail_url", "thumbnail_alt"])
+                src, alt = resolve_thumbnail(
+                    content_url, form.cleaned_data["title"], fetch_remote=True
+                )
+                if src and src.startswith(settings.MEDIA_URL):
+                    post.thumbnail_url = src
+                    post.thumbnail_alt = alt
+                    post.save(update_fields=["thumbnail_url", "thumbnail_alt"])
             messages.success(request, "Post submitted")
             return redirect(
                 "post_detail",


### PR DESCRIPTION
## Summary
- Only keep thumbnails when resolved image is stored under `MEDIA_URL`
- Add `refetch_thumbs` management command to convert remote thumbnails to local copies
- Test link submission skips remote thumbnails and refetch command replaces them

## Testing
- `RUMBLE_DIRECT_OG=0 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bce2c20dd8832ca9961fb0045b81bb