### PR TITLE
Allow loading images from media bucket

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -157,6 +157,7 @@ if not DEBUG:
     _img_src = ["'self'"]
     for provider in EMBED_PROVIDERS.values():
         _img_src.extend(provider["img_hosts"])
+    _img_src.append("https://surejan-media.fly.storage.tigris.dev")
     _img_src.append("data:")
 
     CONTENT_SECURITY_POLICY = {


### PR DESCRIPTION
## Summary
- allow CSP img-src to load images from SureJan media bucket

## Testing
- `flake8 config/settings.py` *(fails: line too long)*
- `pytest tests/test_settings.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68bcfd7cd1a8832ca0201a811e90932b