### PR TITLE
Add Open Graph fetch configuration and integrate into HTTP client

### DIFF
--- a/core/http_client.py
+++ b/core/http_client.py
@@ -11,16 +11,15 @@ import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
+from .og_fetch_config import (
+    CONNECT_TIMEOUT,
+    OG_FETCH_DISABLE_RETRIES,
+    OG_HEADERS,
+    OG_RETRY_STATUSES,
+    READ_TIMEOUT,
+)
+
 _SESSION: Optional[requests.Session] = None
-_TIMEOUT = 5  # seconds
-_HEADERS = {
-    "User-Agent": (
-        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
-        "AppleWebKit/537.36 (KHTML, like Gecko) "
-        "Chrome/125.0.0.0 Safari/537.36"
-    ),
-    "Accept-Language": "en-US,en;q=0.9",
-}
 
 logger = logging.getLogger(__name__)
 # provider -> Counter(success=, error=)
@@ -32,16 +31,19 @@ def get_session() -> requests.Session:
     global _SESSION
     if _SESSION is None:
         session = requests.Session()
-        session.headers.update(_HEADERS)
-        retries = Retry(
-            total=2,
-            backoff_factor=0.5,
-            status_forcelist=[500, 502, 503, 504],
-            allowed_methods=["GET", "HEAD", "OPTIONS"],
-        )
-        adapter = HTTPAdapter(max_retries=retries)
-        session.mount("http://", adapter)
-        session.mount("https://", adapter)
+        session.headers.update(OG_HEADERS)
+
+        if not OG_FETCH_DISABLE_RETRIES:
+            retries = Retry(
+                total=2,
+                backoff_factor=0.5,
+                status_forcelist=list(OG_RETRY_STATUSES),
+                allowed_methods=["GET", "HEAD", "OPTIONS"],
+            )
+            adapter = HTTPAdapter(max_retries=retries)
+            session.mount("http://", adapter)
+            session.mount("https://", adapter)
+
         _SESSION = session
     return _SESSION
 
@@ -65,7 +67,7 @@ def _log(url: str, source: str, status: int | None) -> None:
 
 def fetch_json(url: str, source: str = "unknown") -> dict:
     """Fetch ``url`` and return the parsed JSON response."""
-    resp = get_session().get(url, timeout=_TIMEOUT)
+    resp = get_session().get(url, timeout=(CONNECT_TIMEOUT, READ_TIMEOUT))
     _log(url, source, getattr(resp, "status_code", None))
     resp.raise_for_status()
     return resp.json()
@@ -73,6 +75,6 @@ def fetch_json(url: str, source: str = "unknown") -> dict:
 
 def fetch_html(url: str, source: str = "unknown") -> requests.Response:
     """Fetch ``url`` and return the raw response object."""
-    resp = get_session().get(url, timeout=_TIMEOUT)
+    resp = get_session().get(url, timeout=(CONNECT_TIMEOUT, READ_TIMEOUT))
     _log(url, source, getattr(resp, "status_code", None))
     return resp

--- a/core/management/commands/backfill_thumbs.py
+++ b/core/management/commands/backfill_thumbs.py
@@ -8,7 +8,7 @@ from django.db.models import Q
 from django.utils import timezone
 from datetime import timedelta
 
-from core import http_client
+from core import og_fetch_config
 from core.models import Post, _make_thumb
 from core.utils.thumbnails import resolve_thumbnail
 from core.utils.video_urls import canonicalize_video_url
@@ -69,7 +69,8 @@ class Command(BaseCommand):
         if count < opts["limit"]:
             limit = opts["limit"] - count
             posts = list(qs_link[:limit])
-            http_client._TIMEOUT = opts["timeout"]
+            og_fetch_config.CONNECT_TIMEOUT = opts["timeout"]
+            og_fetch_config.READ_TIMEOUT = opts["timeout"]
 
             if connection.vendor == "sqlite":
                 def worker_sync(post):

--- a/core/og_fetch_config.py
+++ b/core/og_fetch_config.py
@@ -1,0 +1,30 @@
+"""Configuration for fetching Open Graph data."""
+
+from __future__ import annotations
+
+import os
+
+OG_HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/125.0.0.0 Safari/537.36"
+    ),
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+    "Accept-Language": "en-US,en;q=0.9",
+}
+
+CONNECT_TIMEOUT = 5
+READ_TIMEOUT = 8
+
+OG_RETRY_STATUSES = {429, 502, 503, 504}
+
+OG_FETCH_DISABLE_RETRIES = bool(os.getenv("OG_FETCH_DISABLE_RETRIES"))
+
+__all__ = [
+    "OG_HEADERS",
+    "CONNECT_TIMEOUT",
+    "READ_TIMEOUT",
+    "OG_RETRY_STATUSES",
+    "OG_FETCH_DISABLE_RETRIES",
+]


### PR DESCRIPTION
## Summary
- centralize OG fetch settings in new `og_fetch_config` module
- apply shared headers, timeouts, retry statuses, and env flag in HTTP client
- allow thumbnail backfill command to tune OG fetch timeouts

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'config')*


------
https://chatgpt.com/codex/tasks/task_e_68bd036e5354832c8b1a743c5c26447a