### PR TITLE
Normalize video URLs and purge tracking params

### DIFF
--- a/core/management/commands/backfill_thumbs.py
+++ b/core/management/commands/backfill_thumbs.py
@@ -11,7 +11,7 @@ from datetime import timedelta
 from core import og_fetch_config
 from core.models import Post, _make_thumb
 from core.utils.thumbnails import resolve_thumbnail
-from core.utils.video_urls import canonicalize_video_url
+from core.utils.url_cleanup import cleanup_url
 
 
 class Command(BaseCommand):
@@ -75,7 +75,7 @@ class Command(BaseCommand):
             if connection.vendor == "sqlite":
                 def worker_sync(post):
                     try:
-                        fail_key = f"thumbfail:{canonicalize_video_url(post.content_url or '')}"
+                        fail_key = f"thumbfail:{cleanup_url(post.content_url or '')}"
                         if cache.get(fail_key):
                             return 0
                         src, alt = resolve_thumbnail(
@@ -97,7 +97,7 @@ class Command(BaseCommand):
             else:
                 async def worker(post):
                     try:
-                        fail_key = f"thumbfail:{canonicalize_video_url(post.content_url or '')}"
+                        fail_key = f"thumbfail:{cleanup_url(post.content_url or '')}"
                         if cache.get(fail_key):
                             return 0
                         src, alt = await asyncio.to_thread(

--- a/core/tests/test_url_cleanup.py
+++ b/core/tests/test_url_cleanup.py
@@ -1,0 +1,16 @@
+from core.utils.url_cleanup import cleanup_url
+
+
+def test_cleanup_strips_tracking_params():
+    url = "https://example.com/watch?v=1&utm_source=newsletter&fbclid=123&x=1"
+    assert cleanup_url(url) == "https://example.com/watch?v=1&x=1"
+
+
+def test_cleanup_rumble_drops_all_queries():
+    url = "https://rumble.com/v1abcd-something.html?foo=bar&utm_source=newsletter"
+    assert cleanup_url(url) == "https://rumble.com/v1abcd-something.html"
+
+
+def test_cleanup_uses_canonicalize():
+    url = "https://youtu.be/abc123?utm_source=foo"
+    assert cleanup_url(url) == "https://youtube.com/watch?v=abc123"

--- a/core/tests/tests_thumbnail_utils.py
+++ b/core/tests/tests_thumbnail_utils.py
@@ -167,7 +167,7 @@ def test_resolve_thumbnail_falls_back_after_og(monkeypatch):
 
 
 @pytest.mark.django_db
-def test_resolve_thumbnail_direct_skips_canon_and_fallback(settings, monkeypatch):
+def test_resolve_thumbnail_direct_canonizes_no_fallback(settings, monkeypatch):
     cache.clear()
     settings.YT_DIRECT_OG = True
     called = {
@@ -175,7 +175,7 @@ def test_resolve_thumbnail_direct_skips_canon_and_fallback(settings, monkeypatch
         "fallback": False,
     }
 
-    def fake_canon(url):
+    def fake_cleanup(url):
         called["canon"] = True
         return url
 
@@ -183,14 +183,14 @@ def test_resolve_thumbnail_direct_skips_canon_and_fallback(settings, monkeypatch
         called["fallback"] = True
         return "https://example.com/thumb.jpg"
 
-    monkeypatch.setattr(thumbnails, "canonicalize_video_url", fake_canon)
+    monkeypatch.setattr(thumbnails, "cleanup_url", fake_cleanup)
     monkeypatch.setattr(thumbnails, "_provider_fallback", fake_fallback)
     monkeypatch.setattr(thumbnails, "fetch_og_image", lambda url: None)
 
     src, alt = thumbnails.resolve_thumbnail("https://youtu.be/abc123", "label", fetch_remote=True)
     assert src.startswith("data:image/svg+xml")
     assert alt == thumbnails.FALLBACK_ALT
-    assert called["canon"] is False
+    assert called["canon"] is True
     assert called["fallback"] is False
 
 

--- a/core/utils/thumbnails.py
+++ b/core/utils/thumbnails.py
@@ -15,7 +15,7 @@ from django.core.files.base import ContentFile
 from django.core.files.storage import default_storage
 
 from ..http_client import fetch_html
-from .video_urls import canonicalize_video_url
+from .url_cleanup import cleanup_url
 
 OG_IMAGE_RE = re.compile(
     r"<meta\s+property=['\"]og:image['\"]\s+content=['\"]([^'\"]+)['\"]",
@@ -27,6 +27,7 @@ logger = logging.getLogger(__name__)
 
 def scrape_og_image(url: str) -> tuple[Optional[str], Optional[int]]:
     """Return the first OpenGraph image URL for ``url`` if present."""
+    url = cleanup_url(url)
     provider = urlparse(url).netloc
     status = None
     image = None
@@ -59,6 +60,8 @@ FALLBACK_ALT = "Preview image unavailable"  # alt text for missing thumbnails
 
 def fetch_og_image(url: str) -> Optional[str]:
     """Fetch the OpenGraph image for ``url`` with caching."""
+
+    url = cleanup_url(url)
 
     # During tests we bypass caching to avoid cross-test interference.
     if os.getenv("PYTEST_CURRENT_TEST"):
@@ -140,6 +143,8 @@ def rumble_fallback_thumb(url: str) -> str | None:
 
 def x_fallback_thumb(url: str) -> str | None:
     """Scrape the X status page for a pbs.twimg.com image."""
+
+    url = cleanup_url(url)
 
     try:
         resp = fetch_html(url, source="x-thumb")
@@ -273,7 +278,7 @@ def resolve_thumbnail(url: str, label: str, fetch_remote: bool = False) -> tuple
         )
     )
 
-    canon_url = url if direct_og else canonicalize_video_url(url)
+    canon_url = cleanup_url(url)
 
     success_key = f"{_THUMB_KEY_PREFIX}{canon_url}"
     cached = cache.get(success_key)

--- a/core/utils/url_cleanup.py
+++ b/core/utils/url_cleanup.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+"""Helpers for normalising video URLs and removing tracking parameters."""
+
+from urllib.parse import parse_qsl, urlparse, urlencode, urlunparse
+
+from .video_urls import canonicalize_video_url, is_rumble_url
+
+# Common tracking parameters to drop from URLs.
+_TRACKING_PARAMS = {
+    "fbclid",
+    "gclid",
+    "igshid",
+}
+
+
+def cleanup_url(url: str) -> str:
+    """Return ``url`` canonicalised with tracking parameters removed.
+
+    The URL is first canonicalised using :func:`canonicalize_video_url`. Query
+    parameters used for tracking, such as ``utm_*`` or ``fbclid``, are removed.
+    For Rumble URLs all query parameters are dropped entirely.
+    """
+
+    url = canonicalize_video_url(url)
+    parsed = urlparse(url)
+
+    # Rumble URLs ignore all query parameters.
+    if is_rumble_url(url):
+        parsed = parsed._replace(query="")
+        return urlunparse(parsed)
+
+    qs = parse_qsl(parsed.query, keep_blank_values=True)
+    filtered = [
+        (k, v)
+        for k, v in qs
+        if not (k.startswith("utm_") or k in _TRACKING_PARAMS)
+    ]
+    parsed = parsed._replace(query=urlencode(filtered, doseq=True))
+    return urlunparse(parsed)


### PR DESCRIPTION
## Summary
- add `cleanup_url` helper to canonicalize video URLs and strip tracking parameters
- apply URL cleanup when scraping OpenGraph images and resolving thumbnails
- ensure backfill command and tests use cleaned URLs

## Testing
- `RUMBLE_DIRECT_OG=0 pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd043472f4832cb1f58abc49adeedf