### PR TITLE
Add OG HTML fetcher with retries and robots checks

### DIFF
--- a/core/http_client.py
+++ b/core/http_client.py
@@ -4,11 +4,14 @@ from __future__ import annotations
 
 import logging
 from collections import Counter, defaultdict
+import random
+import time
 from typing import Optional
-from urllib.parse import urlparse
+from urllib.parse import urljoin, urlparse
 
 import requests
 from requests.adapters import HTTPAdapter
+from urllib import robotparser
 from urllib3.util.retry import Retry
 
 from .og_fetch_config import (
@@ -20,6 +23,8 @@ from .og_fetch_config import (
 )
 
 _SESSION: Optional[requests.Session] = None
+_OG_SESSION: Optional[requests.Session] = None
+_ROBOTS: dict[str, robotparser.RobotFileParser] = {}
 
 logger = logging.getLogger(__name__)
 # provider -> Counter(success=, error=)
@@ -78,3 +83,65 @@ def fetch_html(url: str, source: str = "unknown") -> requests.Response:
     resp = get_session().get(url, timeout=(CONNECT_TIMEOUT, READ_TIMEOUT))
     _log(url, source, getattr(resp, "status_code", None))
     return resp
+
+
+def get_og_session() -> requests.Session:
+    """Return a session for OG fetching without built-in retries."""
+    global _OG_SESSION
+    if _OG_SESSION is None:
+        session = requests.Session()
+        session.headers.update(OG_HEADERS)
+        _OG_SESSION = session
+    return _OG_SESSION
+
+
+def _robots_allowed(url: str) -> bool:
+    parsed = urlparse(url)
+    base = f"{parsed.scheme}://{parsed.netloc}"
+    parser = _ROBOTS.get(base)
+    if parser is None:
+        parser = robotparser.RobotFileParser()
+        parser.set_url(urljoin(base, "/robots.txt"))
+        try:
+            parser.read()
+        except Exception:
+            pass
+        _ROBOTS[base] = parser
+    ua = OG_HEADERS.get("User-Agent", "*")
+    return parser.can_fetch(ua, url)
+
+
+def fetch_og_html(url: str, source: str = "unknown") -> requests.Response:
+    """Fetch ``url`` for OpenGraph scraping with retries and robots checks."""
+    if not _robots_allowed(url):
+        _log(url, source, None)
+        raise PermissionError("Blocked by robots.txt")
+
+    session = get_og_session()
+    attempts = 1 if OG_FETCH_DISABLE_RETRIES else 3
+    resp: Optional[requests.Response] = None
+    last_exc: Optional[Exception] = None
+
+    for attempt in range(attempts):
+        try:
+            resp = session.get(url, timeout=(CONNECT_TIMEOUT, READ_TIMEOUT))
+        except requests.exceptions.Timeout as exc:
+            last_exc = exc
+            status = None
+        else:
+            status = resp.status_code
+            if status not in OG_RETRY_STATUSES or status in {403, 404}:
+                _log(url, source, status)
+                return resp
+
+        if attempt == attempts - 1:
+            _log(url, source, status if resp is not None else None)
+            if resp is not None:
+                return resp
+            raise last_exc if last_exc else Exception("fetch failed")
+
+        time.sleep(random.uniform(0.2, 0.3))
+        backoff = (0.5 if attempt == 0 else 1.5) + random.uniform(-0.25, 0.25)
+        time.sleep(max(backoff, 0))
+
+    return resp  # pragma: no cover

--- a/core/tests/test_http_client.py
+++ b/core/tests/test_http_client.py
@@ -1,4 +1,5 @@
 import requests
+import pytest
 
 from core import http_client
 
@@ -58,3 +59,50 @@ def test_logging_and_counters(monkeypatch, caplog):
     assert http_client.COUNTERS["example.com"]["error"] == 1
     assert "status=404" in caplog.text
     assert "Mozilla/5.0" in caplog.text
+
+
+def test_fetch_og_html_retries_on_timeout(monkeypatch):
+    http_client._OG_SESSION = None
+    monkeypatch.setattr(http_client, "OG_FETCH_DISABLE_RETRIES", False)
+    calls = []
+
+    def fake_get(url, timeout):
+        calls.append(1)
+        if len(calls) < 3:
+            raise requests.exceptions.Timeout()
+        return type("R", (), {"status_code": 200})()
+
+    monkeypatch.setattr(http_client, "_robots_allowed", lambda url: True)
+    session = http_client.get_og_session()
+    monkeypatch.setattr(session, "get", fake_get)
+    monkeypatch.setattr(http_client.time, "sleep", lambda s: None)
+    resp = http_client.fetch_og_html("https://example.com")
+    assert len(calls) == 3
+    assert resp.status_code == 200
+
+
+def test_fetch_og_html_no_retry_on_404(monkeypatch):
+    http_client._OG_SESSION = None
+    monkeypatch.setattr(http_client, "OG_FETCH_DISABLE_RETRIES", False)
+    calls = []
+
+    class Resp:
+        status_code = 404
+
+    def fake_get(url, timeout):
+        calls.append(1)
+        return Resp()
+
+    monkeypatch.setattr(http_client, "_robots_allowed", lambda url: True)
+    session = http_client.get_og_session()
+    monkeypatch.setattr(session, "get", fake_get)
+    monkeypatch.setattr(http_client.time, "sleep", lambda s: None)
+    resp = http_client.fetch_og_html("https://example.com")
+    assert len(calls) == 1
+    assert resp.status_code == 404
+
+
+def test_fetch_og_html_robots_block(monkeypatch):
+    monkeypatch.setattr(http_client, "_robots_allowed", lambda url: False)
+    with pytest.raises(PermissionError):
+        http_client.fetch_og_html("https://example.com")

--- a/core/tests/tests_thumbnail_utils.py
+++ b/core/tests/tests_thumbnail_utils.py
@@ -210,7 +210,7 @@ def _fake_resp(text):
 def test_fetch_og_image_from_fixture(monkeypatch):
     html = Path("tests/fixtures/youtube/ogonly.html").read_text()
     monkeypatch.setattr(
-        thumbnails, "fetch_html", lambda url, source=None: _fake_resp(html)
+        thumbnails, "fetch_og_html", lambda url, source=None: _fake_resp(html)
     )
     assert (
         thumbnails.fetch_og_image("https://youtu.be/abc123")
@@ -221,7 +221,7 @@ def test_fetch_og_image_from_fixture(monkeypatch):
 def test_x_fallback_thumb_from_fixture(monkeypatch):
     html = Path("tests/fixtures/x/fallback.html").read_text()
     monkeypatch.setattr(
-        thumbnails, "fetch_html", lambda url, source=None: _fake_resp(html)
+        thumbnails, "fetch_og_html", lambda url, source=None: _fake_resp(html)
     )
     assert (
         thumbnails.x_fallback_thumb("https://x.com/user/status/1")

--- a/core/utils/thumbnails.py
+++ b/core/utils/thumbnails.py
@@ -14,7 +14,7 @@ from django.conf import settings
 from django.core.files.base import ContentFile
 from django.core.files.storage import default_storage
 
-from ..http_client import fetch_html
+from ..http_client import fetch_og_html
 from .url_cleanup import cleanup_url
 
 OG_IMAGE_RE = re.compile(
@@ -33,7 +33,7 @@ def scrape_og_image(url: str) -> tuple[Optional[str], Optional[int]]:
     image = None
     result = "og_missing"
     try:
-        resp = fetch_html(url, source="og-image")
+        resp = fetch_og_html(url, source="og-image")
         status = resp.status_code
         resp.raise_for_status()
         match = OG_IMAGE_RE.search(resp.text)
@@ -118,7 +118,7 @@ def youtube_fallback_thumb(url: str, fetch_remote: bool = False) -> str | None:
     if fetch_remote:
         hi_res = f"{base}/maxresdefault.jpg"
         try:
-            resp = fetch_html(hi_res, source="youtube-thumb")
+            resp = fetch_og_html(hi_res, source="youtube-thumb")
             if resp.status_code != 404:
                 return hi_res
         except Exception:
@@ -147,7 +147,7 @@ def x_fallback_thumb(url: str) -> str | None:
     url = cleanup_url(url)
 
     try:
-        resp = fetch_html(url, source="x-thumb")
+        resp = fetch_og_html(url, source="x-thumb")
         resp.raise_for_status()
     except Exception:
         return None
@@ -215,7 +215,7 @@ def cache_remote_image(origin_url: str) -> str | None:
 
     status = None
     try:
-        resp = fetch_html(origin_url, source="rumble-thumb")
+        resp = fetch_og_html(origin_url, source="rumble-thumb")
         status = resp.status_code
         resp.raise_for_status()
     except Exception:

--- a/tests/test_rumble_thumbnail.py
+++ b/tests/test_rumble_thumbnail.py
@@ -24,11 +24,11 @@ def test_resolve_thumbnail_rumble(monkeypatch, tmp_path):
 
     calls = []
 
-    def fake_fetch_html(url, source="unknown"):
+    def fake_fetch_og_html(url, source="unknown"):
         calls.append(url)
         return Resp()
 
-    monkeypatch.setattr(thumbnails, "fetch_html", fake_fetch_html)
+    monkeypatch.setattr(thumbnails, "fetch_og_html", fake_fetch_og_html)
 
     url = "https://rumble.com/v1"
     digest = hashlib.sha1(remote_url.encode("utf-8")).hexdigest()
@@ -83,12 +83,12 @@ def test_resolve_thumbnail_rumble_direct_og_cached(monkeypatch, tmp_path):
 
     calls = []
 
-    def fake_fetch_html(url, source="unknown"):
+    def fake_fetch_og_html(url, source="unknown"):
         calls.append(url)
         return Resp()
 
     monkeypatch.setattr(thumbnails, "fetch_og_image", fake_fetch_og)
-    monkeypatch.setattr(thumbnails, "fetch_html", fake_fetch_html)
+    monkeypatch.setattr(thumbnails, "fetch_og_html", fake_fetch_og_html)
 
     url = "https://rumble.com/v1abc"
     digest = hashlib.sha1(remote_url.encode("utf-8")).hexdigest()
@@ -133,11 +133,11 @@ def test_resolve_thumbnail_rumble_direct_og_error(monkeypatch, settings, tmp_pat
         def raise_for_status(self):
             raise Exception("boom")
 
-    def fake_fetch_html(url, source="unknown"):
+    def fake_fetch_og_html(url, source="unknown"):
         return Resp()
 
     monkeypatch.setattr(thumbnails, "fetch_og_image", fake_fetch_og)
-    monkeypatch.setattr(thumbnails, "fetch_html", fake_fetch_html)
+    monkeypatch.setattr(thumbnails, "fetch_og_html", fake_fetch_og_html)
 
     src, alt = thumbnails.resolve_thumbnail("https://rumble.com/v1abc", "label", fetch_remote=True)
     assert src.startswith("data:image/svg+xml")


### PR DESCRIPTION
## Summary
- implement `fetch_og_html` with robots.txt checks and jittered retry logic
- switch thumbnail utilities to use `fetch_og_html`
- test retry/robots behaviour for `fetch_og_html`

## Testing
- `RUMBLE_DIRECT_OG=0 pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd0724c7a0832c80115537acdea328