### PR TITLE
feat: improve OG fetch logging

### DIFF
--- a/core/http_client.py
+++ b/core/http_client.py
@@ -111,10 +111,17 @@ def _robots_allowed(url: str) -> bool:
     return parser.can_fetch(ua, url)
 
 
-def fetch_og_html(url: str, source: str = "unknown") -> requests.Response:
+def fetch_og_html(
+    url: str, source: str = "unknown", fallback: bool = False
+) -> requests.Response:
     """Fetch ``url`` for OpenGraph scraping with retries and robots checks."""
+
+    provider = urlparse(url).netloc
     if not _robots_allowed(url):
         _log(url, source, None)
+        logger.warning(
+            "provider=%s url=%s reason=robots fallback=%s", provider, url, fallback
+        )
         raise PermissionError("Blocked by robots.txt")
 
     session = get_og_session()
@@ -122,26 +129,50 @@ def fetch_og_html(url: str, source: str = "unknown") -> requests.Response:
     resp: Optional[requests.Response] = None
     last_exc: Optional[Exception] = None
 
-    for attempt in range(attempts):
+    for attempt in range(1, attempts + 1):
         try:
             resp = session.get(url, timeout=(CONNECT_TIMEOUT, READ_TIMEOUT))
+            status: Optional[int] = resp.status_code
         except requests.exceptions.Timeout as exc:
             last_exc = exc
             status = None
-        else:
-            status = resp.status_code
-            if status not in OG_RETRY_STATUSES or status in {403, 404}:
-                _log(url, source, status)
-                return resp
 
-        if attempt == attempts - 1:
+        logger.info(
+            "provider=%s url=%s status=%s attempt=%s",
+            provider,
+            url,
+            status if status is not None else "timeout",
+            attempt,
+        )
+
+        if status is not None and (status not in OG_RETRY_STATUSES or status in {403, 404}):
+            _log(url, source, status)
+            if status >= 400:
+                logger.warning(
+                    "provider=%s url=%s reason=http_%s fallback=%s",
+                    provider,
+                    url,
+                    status,
+                    fallback,
+                )
+            return resp
+
+        if attempt == attempts:
             _log(url, source, status if resp is not None else None)
+            reason = "timeout" if status is None else f"http_{status}"
+            logger.warning(
+                "provider=%s url=%s reason=%s fallback=%s",
+                provider,
+                url,
+                reason,
+                fallback,
+            )
             if resp is not None:
                 return resp
             raise last_exc if last_exc else Exception("fetch failed")
 
         time.sleep(random.uniform(0.2, 0.3))
-        backoff = (0.5 if attempt == 0 else 1.5) + random.uniform(-0.25, 0.25)
+        backoff = (0.5 if attempt == 1 else 1.5) + random.uniform(-0.25, 0.25)
         time.sleep(max(backoff, 0))
 
     return resp  # pragma: no cover

--- a/core/tests/test_http_client.py
+++ b/core/tests/test_http_client.py
@@ -106,3 +106,47 @@ def test_fetch_og_html_robots_block(monkeypatch):
     monkeypatch.setattr(http_client, "_robots_allowed", lambda url: False)
     with pytest.raises(PermissionError):
         http_client.fetch_og_html("https://example.com")
+
+
+def test_fetch_og_html_logs_attempts(monkeypatch, caplog):
+    http_client._OG_SESSION = None
+    monkeypatch.setattr(http_client, "OG_FETCH_DISABLE_RETRIES", False)
+    calls = []
+
+    def fake_get(url, timeout):
+        calls.append(1)
+        if len(calls) < 3:
+            raise requests.exceptions.Timeout()
+        return type("R", (), {"status_code": 200})()
+
+    monkeypatch.setattr(http_client, "_robots_allowed", lambda url: True)
+    session = http_client.get_og_session()
+    monkeypatch.setattr(session, "get", fake_get)
+    monkeypatch.setattr(http_client.time, "sleep", lambda s: None)
+    with caplog.at_level("INFO"):
+        http_client.fetch_og_html("https://example.com", fallback=True)
+    attempt_logs = [m for m in caplog.messages if "attempt=" in m]
+    assert len(attempt_logs) == 3
+    assert "status=timeout" in attempt_logs[0]
+    assert "status=timeout" in attempt_logs[1]
+    assert "status=200" in attempt_logs[2]
+
+
+def test_fetch_og_html_failure_summary(monkeypatch, caplog):
+    http_client._OG_SESSION = None
+    monkeypatch.setattr(http_client, "OG_FETCH_DISABLE_RETRIES", False)
+
+    def fake_get(url, timeout):
+        raise requests.exceptions.Timeout()
+
+    monkeypatch.setattr(http_client, "_robots_allowed", lambda url: True)
+    session = http_client.get_og_session()
+    monkeypatch.setattr(session, "get", fake_get)
+    monkeypatch.setattr(http_client.time, "sleep", lambda s: None)
+    with caplog.at_level("INFO"):
+        with pytest.raises(requests.exceptions.Timeout):
+            http_client.fetch_og_html("https://example.com", fallback=True)
+    summary_logs = [m for m in caplog.messages if "reason=" in m]
+    assert summary_logs
+    assert "reason=timeout" in summary_logs[-1]
+    assert "fallback=True" in summary_logs[-1]

--- a/core/tests/tests_thumbnail_utils.py
+++ b/core/tests/tests_thumbnail_utils.py
@@ -1,4 +1,5 @@
 import pytest
+import requests
 from django.core.cache import cache
 from pathlib import Path
 
@@ -210,7 +211,9 @@ def _fake_resp(text):
 def test_fetch_og_image_from_fixture(monkeypatch):
     html = Path("tests/fixtures/youtube/ogonly.html").read_text()
     monkeypatch.setattr(
-        thumbnails, "fetch_og_html", lambda url, source=None: _fake_resp(html)
+        thumbnails,
+        "fetch_og_html",
+        lambda url, source=None, fallback=False: _fake_resp(html),
     )
     assert (
         thumbnails.fetch_og_image("https://youtu.be/abc123")
@@ -221,9 +224,32 @@ def test_fetch_og_image_from_fixture(monkeypatch):
 def test_x_fallback_thumb_from_fixture(monkeypatch):
     html = Path("tests/fixtures/x/fallback.html").read_text()
     monkeypatch.setattr(
-        thumbnails, "fetch_og_html", lambda url, source=None: _fake_resp(html)
+        thumbnails,
+        "fetch_og_html",
+        lambda url, source=None, fallback=False: _fake_resp(html),
     )
     assert (
         thumbnails.x_fallback_thumb("https://x.com/user/status/1")
         == "https://pbs.twimg.com/media/xyz.jpg"
     )
+
+
+def test_scrape_og_image_timeout_logs_elapsed(monkeypatch, caplog):
+    def fake_fetch(url, source="og-image", fallback=True):
+        raise requests.exceptions.Timeout()
+
+    monkeypatch.setattr(thumbnails, "fetch_og_html", fake_fetch)
+
+    counter = {"t": 0}
+
+    def fake_monotonic():
+        counter["t"] += 1
+        return counter["t"]
+
+    monkeypatch.setattr(thumbnails.time, "monotonic", fake_monotonic)
+
+    with caplog.at_level("INFO"):
+        thumbnails.scrape_og_image("https://example.com")
+
+    assert "result=http_timeout" in caplog.text
+    assert "elapsed=1.00" in caplog.text

--- a/core/utils/thumbnails.py
+++ b/core/utils/thumbnails.py
@@ -5,6 +5,8 @@ import logging
 import os
 import re
 import hashlib
+import time
+import requests
 from pathlib import Path
 from typing import Optional
 from urllib.parse import parse_qs, urlparse
@@ -29,25 +31,39 @@ def scrape_og_image(url: str) -> tuple[Optional[str], Optional[int]]:
     """Return the first OpenGraph image URL for ``url`` if present."""
     url = cleanup_url(url)
     provider = urlparse(url).netloc
-    status = None
+    status: Optional[int] = None
     image = None
     result = "og_missing"
+    start = time.monotonic()
+    elapsed: Optional[float] = None
     try:
-        resp = fetch_og_html(url, source="og-image")
+        resp = fetch_og_html(url, source="og-image", fallback=True)
         status = resp.status_code
         resp.raise_for_status()
         match = OG_IMAGE_RE.search(resp.text)
         if match:
             image = match.group(1)
             result = "og_found"
+    except requests.exceptions.Timeout:
+        elapsed = time.monotonic() - start
+        result = "http_timeout"
     except Exception:
         if status == 403:
             result = "http_403"
         else:
             result = f"http_{status}" if status else "error"
-    logger.info(
-        "provider=%s result=%s origin_image_url=%s", provider, result, image or ""
-    )
+    if elapsed is not None:
+        logger.info(
+            "provider=%s result=%s origin_image_url=%s elapsed=%.2f",
+            provider,
+            result,
+            image or "",
+            elapsed,
+        )
+    else:
+        logger.info(
+            "provider=%s result=%s origin_image_url=%s", provider, result, image or "",
+        )
     return image, status
 
 

--- a/tests/test_rumble_thumbnail.py
+++ b/tests/test_rumble_thumbnail.py
@@ -24,7 +24,7 @@ def test_resolve_thumbnail_rumble(monkeypatch, tmp_path):
 
     calls = []
 
-    def fake_fetch_og_html(url, source="unknown"):
+    def fake_fetch_og_html(url, source="unknown", fallback=False):
         calls.append(url)
         return Resp()
 
@@ -83,7 +83,7 @@ def test_resolve_thumbnail_rumble_direct_og_cached(monkeypatch, tmp_path):
 
     calls = []
 
-    def fake_fetch_og_html(url, source="unknown"):
+    def fake_fetch_og_html(url, source="unknown", fallback=False):
         calls.append(url)
         return Resp()
 
@@ -133,7 +133,7 @@ def test_resolve_thumbnail_rumble_direct_og_error(monkeypatch, settings, tmp_pat
         def raise_for_status(self):
             raise Exception("boom")
 
-    def fake_fetch_og_html(url, source="unknown"):
+    def fake_fetch_og_html(url, source="unknown", fallback=False):
         return Resp()
 
     monkeypatch.setattr(thumbnails, "fetch_og_image", fake_fetch_og)


### PR DESCRIPTION
## Summary
- log OG HTML fetch attempts with provider, URL, status or timeout, and attempt number
- summarize final fetch failure and whether a provider fallback will run
- surface timing for OG image scraping timeouts

## Testing
- `pytest` *(fails: django.core.exceptions.ImproperlyConfigured: Requested setting INSTALLED_APPS, but ...)*

------
https://chatgpt.com/codex/tasks/task_e_68bd09976dfc832c9696eeb23099664e