### PR TITLE
Cache remote thumbnails on posts

### DIFF
--- a/core/tests/tests_thumbnail_utils.py
+++ b/core/tests/tests_thumbnail_utils.py
@@ -2,7 +2,9 @@ import pytest
 import requests
 from django.core.cache import cache
 from pathlib import Path
+from django.contrib.auth import get_user_model
 
+from core.models import Community, Post
 from core.utils import thumbnails
 
 
@@ -253,3 +255,54 @@ def test_scrape_og_image_timeout_logs_elapsed(monkeypatch, caplog):
 
     assert "result=http_timeout" in caplog.text
     assert "elapsed=1.00" in caplog.text
+
+
+@pytest.mark.django_db
+def test_resolve_thumbnail_attaches_image(monkeypatch, settings, tmp_path):
+    cache.clear()
+    settings.MEDIA_ROOT = tmp_path / "media"
+    settings.MEDIA_URL = "/media/"
+    User = get_user_model()
+    user = User.objects.create_user("alice", password="pw")
+    com = Community.objects.create(slug="t", name="Test", title="Test", created_by=user)
+    post = Post.objects.create(
+        community=com,
+        author=user,
+        post_type="link",
+        title="Link",
+        content_url="https://example.com",
+    )
+
+    monkeypatch.setattr(
+        thumbnails, "fetch_og_image", lambda url: "https://cdn.example.com/thumb.jpg"
+    )
+
+    from io import BytesIO
+    from PIL import Image
+
+    buf = BytesIO()
+    Image.new("RGB", (1, 1), "white").save(buf, format="PNG")
+    img_bytes = buf.getvalue()
+
+    class Resp:
+        status_code = 200
+        headers = {"Content-Type": "image/png"}
+        content = img_bytes
+
+        def raise_for_status(self):
+            return None
+
+    monkeypatch.setattr(
+        thumbnails, "fetch_og_html", lambda url, source="thumb-fetch": Resp()
+    )
+
+    src, alt = thumbnails.resolve_thumbnail(
+        post.content_url, "label", fetch_remote=True, post=post
+    )
+    assert src.startswith(settings.MEDIA_URL)
+    post.refresh_from_db()
+    assert src == post.image.url
+    assert post.image
+    assert post.image_thumb
+    assert post.thumbnail_alt == "label"
+    assert alt == "label"

--- a/core/utils/thumbnails.py
+++ b/core/utils/thumbnails.py
@@ -8,7 +8,7 @@ import hashlib
 import time
 import requests
 from pathlib import Path
-from typing import Optional
+from typing import Optional, TYPE_CHECKING
 from urllib.parse import parse_qs, urlparse
 
 from django.core.cache import cache
@@ -18,6 +18,9 @@ from django.core.files.storage import default_storage
 
 from ..http_client import fetch_og_html
 from .url_cleanup import cleanup_url
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from ..models import Post
 
 OG_IMAGE_RE = re.compile(
     r"<meta\s+property=['\"]og:image['\"]\s+content=['\"]([^'\"]+)['\"]",
@@ -266,7 +269,9 @@ def cache_remote_image(origin_url: str) -> str | None:
     return default_storage.url(stored)
 
 
-def resolve_thumbnail(url: str, label: str, fetch_remote: bool = False) -> tuple[str, str]:
+def resolve_thumbnail(
+    url: str, label: str, fetch_remote: bool = False, *, post: "Post | None" = None
+) -> tuple[str, str]:
     """Return thumbnail URL and alt text.
 
     The URL is first canonicalised. We then check caches for a prior
@@ -327,6 +332,27 @@ def resolve_thumbnail(url: str, label: str, fetch_remote: bool = False) -> tuple
                     thumb = None
             else:
                 thumb = None
+
+    if thumb and thumb.startswith("http") and post is not None:
+        try:
+            resp = fetch_og_html(thumb, source="thumb-fetch")
+            status = resp.status_code
+            resp.raise_for_status()
+            content_type = resp.headers.get("Content-Type", "").split(";")[0].lower()
+            ext = _EXTENSION_MAP.get(content_type)
+            if not ext or len(resp.content) > 5 * 1024 * 1024:
+                raise ValueError("unsupported image")
+            path = f"posts/{post.id}/thumb.{ext}"
+            stored = default_storage.save(path, ContentFile(resp.content))
+            post.image.name = stored
+            post.thumbnail_alt = label
+            post.save(
+                update_fields=["image", "image_thumb", "thumbnail_alt"],
+                recompute_hot=False,
+            )
+            thumb = post.image.url
+        except Exception:
+            thumb = None
 
     if thumb and (thumb.startswith("https://") or thumb.startswith(settings.MEDIA_URL)):
         cache.set(success_key, thumb, _THUMB_TTL)


### PR DESCRIPTION
## Summary
- allow `resolve_thumbnail` to attach fetched thumbnails to posts
- persist remote images under `posts/<id>/thumb.ext`
- test thumbnail attachment

## Testing
- `export RUMBLE_DIRECT_OG=0`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd19fb4434832c8dd872f465787c2a