### PR TITLE
Use model image fields for post thumbnails

### DIFF
--- a/templates/partials/post_thumbnail.html
+++ b/templates/partials/post_thumbnail.html
@@ -1,19 +1,24 @@
 {% load thumbnails %}
-{% with src=post.thumbnail_url|local_thumb %}
-  {% if src %}
-    {% with alt=post.thumbnail_alt|default:post.title %}
-    <a href="{{ post.content_url }}" target="_blank" rel="noopener noreferrer" class="thumb" style="aspect-ratio:16/9;">
-      <img src="{{ src }}" alt="{{ alt }}" loading="lazy" decoding="async" referrerpolicy="no-referrer" width="640" height="360">
-      {% if post.provider_name %}<span class="thumb-label">{{ post.provider_name }}</span>{% endif %}
-    </a>
-    {% endwith %}
-  {% else %}
-    {% svg_placeholder post.title as ph %}
-    {% with src=ph.src alt=ph.alt %}
-    <a href="{{ post.content_url }}" target="_blank" rel="noopener noreferrer" class="thumb" style="aspect-ratio:16/9;">
-      <img src="{{ src }}" alt="{{ alt }}" loading="lazy" decoding="async" referrerpolicy="no-referrer" width="640" height="360">
-      {% if post.provider_name %}<span class="thumb-label">{{ post.provider_name }}</span>{% endif %}
-    </a>
-    {% endwith %}
-  {% endif %}
-{% endwith %}
+{% if post.image_thumb %}
+  {% with src=post.image_thumb.url alt=post.thumbnail_alt|default:post.title %}
+  <a href="{{ post.content_url }}" target="_blank" rel="noopener noreferrer" class="thumb" style="aspect-ratio:16/9;">
+    <img src="{{ src }}" alt="{{ alt }}" loading="lazy" decoding="async" referrerpolicy="no-referrer" width="640" height="360">
+    {% if post.provider_name %}<span class="thumb-label">{{ post.provider_name }}</span>{% endif %}
+  </a>
+  {% endwith %}
+{% elif post.image %}
+  {% with src=post.image.url alt=post.thumbnail_alt|default:post.title %}
+  <a href="{{ post.content_url }}" target="_blank" rel="noopener noreferrer" class="thumb" style="aspect-ratio:16/9;">
+    <img src="{{ src }}" alt="{{ alt }}" loading="lazy" decoding="async" referrerpolicy="no-referrer" width="640" height="360">
+    {% if post.provider_name %}<span class="thumb-label">{{ post.provider_name }}</span>{% endif %}
+  </a>
+  {% endwith %}
+{% else %}
+  {% svg_placeholder post.title as ph %}
+  {% with src=ph.src alt=ph.alt %}
+  <a href="{{ post.content_url }}" target="_blank" rel="noopener noreferrer" class="thumb" style="aspect-ratio:16/9;">
+    <img src="{{ src }}" alt="{{ alt }}" loading="lazy" decoding="async" referrerpolicy="no-referrer" width="640" height="360">
+    {% if post.provider_name %}<span class="thumb-label">{{ post.provider_name }}</span>{% endif %}
+  </a>
+  {% endwith %}
+{% endif %}


### PR DESCRIPTION
## Summary
- Render post thumbnails using `post.image_thumb` or `post.image` instead of the `local_thumb` filter
- Fall back to the SVG placeholder when no image fields are available

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'config', ...)*
- `python manage.py test` *(fails: Missing staticfiles manifest entry for 'css/app.css')*


------
https://chatgpt.com/codex/tasks/task_e_68bd1cc20954832ca50b94084edcc5ca