### PR TITLE
Use resolve_thumbnail to attach post image

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -556,13 +556,12 @@ def post_submit(request):
                 post.image = form.cleaned_data.get("image")
             post.save()
             if post_type == "link":
-                src, alt = resolve_thumbnail(
-                    content_url, form.cleaned_data["title"], fetch_remote=True
+                resolve_thumbnail(
+                    content_url,
+                    form.cleaned_data["title"],
+                    fetch_remote=True,
+                    post=post,
                 )
-                if src and src.startswith(settings.MEDIA_URL):
-                    post.thumbnail_url = src
-                    post.thumbnail_alt = alt
-                    post.save(update_fields=["thumbnail_url", "thumbnail_alt"])
             messages.success(request, "Post submitted")
             return redirect(
                 "post_detail",


### PR DESCRIPTION
## Summary
- attach link post thumbnails via `resolve_thumbnail(..., post=post)`
- drop manual `thumbnail_url` assignment

## Testing
- `pytest` *(fails: 4 failed, 108 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68bd1e04ea3c832ca3a10d0f700fc1ff