### PR TITLE
feat: skip remote fetch when post already has image thumbnail

### DIFF
--- a/core/tests/tests_thumbnail_utils.py
+++ b/core/tests/tests_thumbnail_utils.py
@@ -306,3 +306,47 @@ def test_resolve_thumbnail_attaches_image(monkeypatch, settings, tmp_path):
     assert post.image_thumb
     assert post.thumbnail_alt == "label"
     assert alt == "label"
+
+
+@pytest.mark.django_db
+def test_resolve_thumbnail_uses_existing_image(monkeypatch, settings, tmp_path):
+    cache.clear()
+    settings.MEDIA_ROOT = tmp_path / "media"
+    settings.MEDIA_URL = "/media/"
+    User = get_user_model()
+    user = User.objects.create_user("alice", password="pw")
+    com = Community.objects.create(slug="t", name="Test", title="Test", created_by=user)
+
+    from io import BytesIO
+    from PIL import Image
+    from django.core.files.uploadedfile import SimpleUploadedFile
+
+    buf = BytesIO()
+    Image.new("RGB", (1, 1), "white").save(buf, format="PNG")
+    img = SimpleUploadedFile("a.png", buf.getvalue(), content_type="image/png")
+
+    post = Post.objects.create(
+        community=com,
+        author=user,
+        post_type="link",
+        title="Link",
+        content_url="https://example.com",
+        image=img,
+        thumbnail_alt="stored",
+    )
+
+    called = {"og": False}
+
+    def fake_fetch(url):
+        called["og"] = True
+        return "https://cdn.example.com/thumb.jpg"
+
+    monkeypatch.setattr(thumbnails, "fetch_og_image", fake_fetch)
+
+    src, alt = thumbnails.resolve_thumbnail(
+        post.content_url, "label", fetch_remote=True, post=post
+    )
+
+    assert called["og"] is False
+    assert src == post.image.url
+    assert alt == "stored"

--- a/core/utils/thumbnails.py
+++ b/core/utils/thumbnails.py
@@ -280,6 +280,8 @@ def resolve_thumbnail(
     provider-specific heuristics. A missing thumbnail results in an inline
     SVG placeholder.
     """
+    if post is not None and post.image:
+        return post.image.url, post.thumbnail_alt or label
 
     domain = urlparse(url).netloc.lower()
     direct_og = (


### PR DESCRIPTION
## Summary
- bail out early in `resolve_thumbnail` when `post.image` already exists
- add regression test to ensure remote fetch is skipped and existing alt text is used

## Testing
- `pytest core/tests/tests_thumbnail_utils.py::test_resolve_thumbnail_uses_existing_image core/tests/tests_thumbnail_utils.py::test_resolve_thumbnail_attaches_image -q`

------
https://chatgpt.com/codex/tasks/task_e_68bd22a03af0832ca7de1b23ddd17f28