### PR TITLE
Use canonical post URL when resolving thumbnails

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -538,26 +538,26 @@ def post_submit(request):
             return render(request, "core/submit.html", {"form": form}, status=429)
         if form.is_valid():
             post_type = form.cleaned_data["post_type"]
-
-            content_url = ""
-            if post_type == "link":
-                content_url = canonicalize_video_url(
-                    form.cleaned_data.get("content_url", "")
-                )
             post = Post(
                 community=form.cleaned_data["community"],
                 author=request.user,
                 post_type=post_type,
                 title=form.cleaned_data["title"],
                 body=form.cleaned_data.get("body", ""),
-                content_url=content_url,
+                content_url=(
+                    canonicalize_video_url(
+                        form.cleaned_data.get("content_url", "")
+                    )
+                    if post_type == "link"
+                    else ""
+                ),
             )
             if post_type == "image":
                 post.image = form.cleaned_data.get("image")
             post.save()
             if post_type == "link":
                 resolve_thumbnail(
-                    content_url,
+                    post.content_url,
                     form.cleaned_data["title"],
                     fetch_remote=True,
                     post=post,


### PR DESCRIPTION
## Summary
- call `resolve_thumbnail` with `post.content_url` after saving to ensure canonical link
- remove temporary `content_url` variable in `post_submit`

## Testing
- `python manage.py test` *(fails: FAILED (failures=6, errors=44, skipped=2))*

------
https://chatgpt.com/codex/tasks/task_e_68bd2477903c832c81cb5b0e315008dd