### PR TITLE
Ensure post thumbnails are stored on Post.image

### DIFF
--- a/core/tests/test_video_thumbnails.py
+++ b/core/tests/test_video_thumbnails.py
@@ -3,6 +3,9 @@ import pytest
 from django.contrib.auth import get_user_model
 from django.template.loader import render_to_string
 from django.conf import settings
+from django.core.files.uploadedfile import SimpleUploadedFile
+from io import BytesIO
+from PIL import Image
 
 from core.models import Community, Post
 
@@ -27,7 +30,11 @@ def test_post_thumbnail_uses_img_not_iframe(url):
         post_type="link",
         title="Video",
         content_url=url,
-        thumbnail_url=f"{settings.MEDIA_URL}thumb.jpg",
+        image=SimpleUploadedFile(
+            "thumb.png",
+            (lambda buf: (Image.new("RGB", (1, 1), "white").save(buf, format="PNG"), buf.getvalue()))(BytesIO())[1],
+            content_type="image/png",
+        ),
     )
 
     html = render_to_string("partials/post_thumbnail.html", {"post": post})

--- a/core/tests/tests_thumbnail_utils.py
+++ b/core/tests/tests_thumbnail_utils.py
@@ -303,8 +303,8 @@ def test_resolve_thumbnail_attaches_image(monkeypatch, settings, tmp_path):
     post.refresh_from_db()
     assert src == post.image.url
     assert post.image
-    assert post.image_thumb
-    assert post.thumbnail_alt == "label"
+    assert not post.image_thumb
+    assert post.thumbnail_alt == ""
     assert alt == "label"
 
 
@@ -349,4 +349,39 @@ def test_resolve_thumbnail_uses_existing_image(monkeypatch, settings, tmp_path):
 
     assert called["og"] is False
     assert src == post.image.url
-    assert alt == "stored"
+    assert alt == "label"
+    assert post.thumbnail_alt == "stored"
+
+
+@pytest.mark.django_db
+def test_resolve_thumbnail_overrides_url(monkeypatch, settings, tmp_path):
+    cache.clear()
+    settings.MEDIA_ROOT = tmp_path / "media"
+    settings.MEDIA_URL = "/media/"
+    User = get_user_model()
+    user = User.objects.create_user("alice", password="pw")
+    com = Community.objects.create(slug="t", name="Test", title="Test", created_by=user)
+    post = Post.objects.create(
+        community=com,
+        author=user,
+        post_type="link",
+        title="Link",
+        content_url="https://example.com/real",
+    )
+
+    captured = {}
+
+    def fake_fetch(url):
+        captured["url"] = url
+        return None
+
+    monkeypatch.setattr(thumbnails, "fetch_og_image", fake_fetch)
+
+    thumbnails.resolve_thumbnail(
+        "https://ignored.com/elsewhere",
+        "label",
+        fetch_remote=True,
+        post=post,
+    )
+
+    assert captured["url"] == "https://example.com/real"

--- a/core/utils/thumbnails.py
+++ b/core/utils/thumbnails.py
@@ -280,8 +280,10 @@ def resolve_thumbnail(
     provider-specific heuristics. A missing thumbnail results in an inline
     SVG placeholder.
     """
-    if post is not None and post.image:
-        return post.image.url, post.thumbnail_alt or label
+    if post is not None:
+        if post.image:
+            return post.image.url, label
+        url = post.content_url or url
 
     domain = urlparse(url).netloc.lower()
     direct_og = (
@@ -346,12 +348,8 @@ def resolve_thumbnail(
                 raise ValueError("unsupported image")
             path = f"posts/{post.id}/thumb.{ext}"
             stored = default_storage.save(path, ContentFile(resp.content))
-            post.image.name = stored
-            post.thumbnail_alt = label
-            post.save(
-                update_fields=["image", "image_thumb", "thumbnail_alt"],
-                recompute_hot=False,
-            )
+            post.image = stored
+            post.save(update_fields=["image"], recompute_hot=False)
             thumb = post.image.url
         except Exception:
             thumb = None

--- a/tests/test_rumble_thumbnail.py
+++ b/tests/test_rumble_thumbnail.py
@@ -37,6 +37,7 @@ def test_resolve_thumbnail_rumble(monkeypatch, tmp_path):
         MEDIA_ROOT=tmp_path / "media",
         THUMB_CACHE_DIR=tmp_path / "media" / "thumbs",
         MEDIA_URL="/media/",
+        RUMBLE_DIRECT_OG=False,
     ):
         expected = settings.THUMB_CACHE_DIR / "rumble" / f"{digest}.jpg"
 


### PR DESCRIPTION
## Summary
- use Post.content_url in resolve_thumbnail when a post is supplied
- store fetched thumbnails on Post.image and drop image_thumb/thumbnail_alt writes
- align tests with new thumbnail behaviour

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd268887a8832c9979f2e0a159f720