### PR TITLE
Refresh link thumbnails on post edit

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -804,6 +804,16 @@ def post_edit(request, pk):
             if post.content_url:
                 post.content_url = canonicalize_video_url(post.content_url)
             post.save()
+            if post.post_type == "link" and post.content_url:
+                try:
+                    resolve_thumbnail(
+                        post.content_url,
+                        post.title,
+                        fetch_remote=True,
+                        post=post,
+                    )
+                except Exception:
+                    pass
             messages.success(request, "Post updated")
             return redirect(
                 "post_detail",


### PR DESCRIPTION
## Summary
- Refresh link thumbnails when editing posts
- Ignore thumbnail fetch failures during post edits

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bd28e906c8832cb70ab31c4891b4a0