### PR TITLE
Use stored images in thumbnail tests

### DIFF
--- a/core/tests/test_feed_thumbnails.py
+++ b/core/tests/test_feed_thumbnails.py
@@ -20,7 +20,7 @@ def test_feed_thumbnails_are_images(client):
     buf = BytesIO()
     Image.new("RGB", (10, 10), "white").save(buf, format="JPEG")
     img = SimpleUploadedFile("a.jpg", buf.getvalue(), content_type="image/jpeg")
-    Post.objects.create(
+    img_post = Post.objects.create(
         community=com,
         author=user,
         post_type="image",
@@ -29,14 +29,19 @@ def test_feed_thumbnails_are_images(client):
     )
 
     # Link post with explicit thumbnail
+    thumb_data = (
+        b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01"
+        b"\x08\x06\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\nIDATx\x9cc\x00"
+        b"\x00\x00\x02\x00\x01\xe2!\xbc3\x00\x00\x00\x00IEND\xaeB`\x82"
+    )
     link_post = Post.objects.create(
         community=com,
         author=user,
         post_type="link",
         title="Link",
         content_url="https://example.com",
+        image_thumb=SimpleUploadedFile("thumb.png", thumb_data, content_type="image/png"),
     )
-    Post.objects.filter(pk=link_post.pk).update(image="thumb.jpg", image_thumb="thumb.jpg")
 
     # Link post without thumbnail should use placeholder
     Post.objects.create(
@@ -49,10 +54,14 @@ def test_feed_thumbnails_are_images(client):
 
     resp = client.get("/")
     html = resp.content.decode()
+    img_post.refresh_from_db()
+    link_post.refresh_from_db()
     cards = re.findall(
         r"<article[^>]*data-testid=\"post-card\"[^>]*>(.*?)</article>", html, re.DOTALL
     )
     assert len(cards) == 3
-    for card in cards:
-        assert "<img" in card
-    assert "data:image/svg+xml" in html
+    imgs = re.findall(r'<img[^>]+src="([^"]+)"', html)
+    img_src = img_post.image_thumb.url if img_post.image_thumb else img_post.image.url
+    assert img_src in imgs
+    assert link_post.image_thumb.url in imgs
+    assert any(src.startswith("data:image/svg+xml") for src in imgs)

--- a/core/tests/test_links.py
+++ b/core/tests/test_links.py
@@ -98,18 +98,23 @@ class PostLinkTests(TestCase):
         self.assertIn(f'href="{user_url}"', html)
 
     def test_feed_card_thumbnail_links_to_content_url(self):
+        image_data = (
+            b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01"
+            b"\x08\x06\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\nIDATx\x9cc\x00"
+            b"\x00\x00\x02\x00\x01\xe2!\xbc3\x00\x00\x00\x00IEND\xaeB`\x82"
+        )
         post = Post.objects.create(
             community=self.community,
             author=self.user,
             post_type="link",
             title="Link",
             content_url="https://example.com/article",
+            image_thumb=SimpleUploadedFile("thumb.png", image_data, content_type="image/png"),
         )
-        Post.objects.filter(pk=post.pk).update(image="thumb.jpg", image_thumb="thumb.jpg")
-        post.refresh_from_db()
         request = self.factory.get("/")
         html = render_to_string("partials/feed_card.html", {"post": post}, request=request)
         detail_url = post.get_absolute_url()
+        self.assertIn(f'src="{post.image_thumb.url}"', html)
         self.assertIn(
             f'href="{post.content_url}" target="_blank" rel="noopener noreferrer"',
             html,
@@ -119,18 +124,23 @@ class PostLinkTests(TestCase):
         self.assertIn(f'href="{detail_url}#comments"', html)
 
     def test_post_row_thumbnail_links_to_content_url(self):
+        image_data = (
+            b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01"
+            b"\x08\x06\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\nIDATx\x9cc\x00"
+            b"\x00\x00\x02\x00\x01\xe2!\xbc3\x00\x00\x00\x00IEND\xaeB`\x82"
+        )
         post = Post.objects.create(
             community=self.community,
             author=self.user,
             post_type="link",
             title="Link",
             content_url="https://example.com/article",
+            image_thumb=SimpleUploadedFile("thumb.png", image_data, content_type="image/png"),
         )
-        Post.objects.filter(pk=post.pk).update(image="thumb.jpg", image_thumb="thumb.jpg")
-        post.refresh_from_db()
         request = self.factory.get("/")
         html = render_to_string("core/partials/post_row.html", {"post": post}, request=request)
         detail_url = post.get_absolute_url()
+        self.assertIn(f'src="{post.image_thumb.url}"', html)
         self.assertIn(
             f'href="{post.content_url}" target="_blank" rel="noopener noreferrer" class="thumb"',
             html,

--- a/tests/test_static_thumbnails.py
+++ b/tests/test_static_thumbnails.py
@@ -1,5 +1,6 @@
 import pytest
 from django.contrib.auth import get_user_model
+from django.core.files.uploadedfile import SimpleUploadedFile
 
 from core.models import Community, Post
 
@@ -9,16 +10,20 @@ def test_feed_and_detail_render_thumbnails(client):
     User = get_user_model()
     user = User.objects.create_user("alice", password="pw")
     com = Community.objects.create(slug="t", name="Test", title="Test", created_by=user)
+    image_data = (
+        b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01"
+        b"\x08\x06\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\nIDATx\x9cc\x00"
+        b"\x00\x00\x02\x00\x01\xe2!\xbc3\x00\x00\x00\x00IEND\xaeB`\x82"
+    )
     post = Post.objects.create(
         community=com,
         author=user,
         post_type="link",
         title="Link",
         content_url="https://example.com",
+        image_thumb=SimpleUploadedFile("thumb.png", image_data, content_type="image/png"),
     )
-    Post.objects.filter(pk=post.pk).update(image="thumb.jpg", image_thumb="thumb.jpg")
-    post.refresh_from_db()
 
     for url in ["/", post.get_absolute_url()]:
         html = client.get(url).content.decode()
-        assert "<img" in html
+        assert f'src="{post.image_thumb.url}"' in html


### PR DESCRIPTION
## Summary
- replace legacy thumbnail_url assignments in tests with real stored images
- assert rendered `<img>` tags use `post.image.url` or `post.image_thumb.url`

## Testing
- `pytest tests/test_static_thumbnails.py core/tests/test_feed_thumbnails.py core/tests/test_links.py`

------
https://chatgpt.com/codex/tasks/task_e_68bd36051c60832cbaa46e7885f489dd