### PR TITLE
Ensure feed uses local thumbnails or placeholder

### DIFF
--- a/core/tests/test_feed_thumbnails.py
+++ b/core/tests/test_feed_thumbnails.py
@@ -60,7 +60,6 @@ def test_feed_thumbnails_are_images(client):
     )
     assert len(cards) == 3
     imgs = re.findall(r'<img[^>]+src="([^"]+)"', html)
-    img_src = img_post.image_thumb.url if img_post.image_thumb else img_post.image.url
-    assert img_src in imgs
+    assert img_post.image.url in imgs
     assert link_post.image.url in imgs
     assert any(src.startswith("data:image/svg+xml") for src in imgs)

--- a/templates/core/partials/post_row.html
+++ b/templates/core/partials/post_row.html
@@ -2,15 +2,8 @@
   {% with detail_url=post.get_absolute_url %}
     {% if post.post_type == 'link' %}
     {% include "partials/post_thumbnail.html" with post=post %}
-    {% elif post.image_thumb or post.image %}
-    <a href="{{ detail_url }}" class="thumb" style="aspect-ratio:16/9;" aria-label="Open post">
-      {% if post.image_thumb %}
-      <img src="{{ post.image_thumb.url }}" alt="{{ post.title }}" width="640" height="360" loading="lazy" decoding="async" referrerpolicy="no-referrer">
-      {% else %}
-      <img src="{{ post.image.url }}" alt="{{ post.title }}" width="640" height="360" loading="lazy" decoding="async" referrerpolicy="no-referrer">
-      {% endif %}
-      {% if post.link_domain %}<span class="thumb-label">{{ post.provider_name }}</span>{% endif %}
-    </a>
+    {% elif post.image %}
+    {% include "partials/post_thumbnail.html" with post=post href=detail_url target='' rel='' aria_label='Open post' %}
     {% endif %}
     <div class="post-meta">
       <a href="{% url 'community' post.community.slug %}">c/{{ post.community.slug }}</a> ·

--- a/templates/core/post_detail.html
+++ b/templates/core/post_detail.html
@@ -17,25 +17,8 @@
     </div>
   </header>
 
-{% if post.post_type == 'link' %}
+{% if post.post_type == 'link' or post.image %}
   {% include "partials/post_thumbnail.html" with post=post %}
-{% elif post.image_thumb or post.image %}
-  <a href="{{ post.content_url }}" target="_blank" rel="noreferrer noopener" class="thumb" style="aspect-ratio:16/9;" aria-label="Open content">
-    {% if post.image_thumb %}
-      <img
-        src="{{ post.image_thumb.url }}"
-        alt="{{ post.title }}"
-        loading="lazy" decoding="async" referrerpolicy="no-referrer"
-        width="640" height="360">
-    {% else %}
-      <img
-        src="{{ post.image.url }}"
-        alt="{{ post.title }}"
-        loading="lazy" decoding="async" referrerpolicy="no-referrer"
-        width="640" height="360">
-    {% endif %}
-    {% if post.provider_name %}<span class="thumb-label">{{ post.provider_name }}</span>{% endif %}
-  </a>
 {% endif %}
 
   {% if post.body %}

--- a/templates/partials/feed_card.html
+++ b/templates/partials/feed_card.html
@@ -4,23 +4,8 @@
   {% if not detail_url %}{% url 'post_detail_id' post.pk as detail_url %}{% endif %}
   {% if post.post_type == 'link' %}
     {% include "partials/post_thumbnail.html" with post=post %}
-  {% elif post.image_thumb or post.image %}
-    <a href="{{ detail_url }}" class="thumb" style="aspect-ratio:16/9;" aria-label="Open post">
-      {% if post.image_thumb %}
-        <img
-          src="{{ post.image_thumb.url }}"
-          alt="{{ post.title }}"
-          loading="lazy" decoding="async" referrerpolicy="no-referrer"
-          width="640" height="360">
-      {% else %}
-        <img
-          src="{{ post.image.url }}"
-          alt="{{ post.title }}"
-          loading="lazy" decoding="async" referrerpolicy="no-referrer"
-          width="640" height="360">
-      {% endif %}
-      {% if post.link_domain %}<span class="thumb-label">{{ post.provider_name }}</span>{% endif %}
-    </a>
+  {% elif post.image %}
+    {% include "partials/post_thumbnail.html" with post=post href=detail_url target='' rel='' aria_label='Open post' %}
   {% endif %}
   <div class="post-meta">
     <a href="{% url 'community' post.community.slug %}">r/{{ post.community.slug }}</a> · {{ post.author.username }} · {{ post.created_at|timesince }} ago

--- a/templates/partials/post_thumbnail.html
+++ b/templates/partials/post_thumbnail.html
@@ -1,24 +1,20 @@
 {% load thumbnails %}
-{% if post.image_thumb %}
-  {% with src=post.image_thumb.url alt=post.title %}
-  <a href="{{ post.content_url }}" target="_blank" rel="noopener noreferrer" class="thumb" style="aspect-ratio:16/9;">
-    <img src="{{ src }}" alt="{{ alt }}" loading="lazy" decoding="async" referrerpolicy="no-referrer" width="640" height="360">
-    {% if post.provider_name %}<span class="thumb-label">{{ post.provider_name }}</span>{% endif %}
-  </a>
-  {% endwith %}
-{% elif post.image %}
-  {% with src=post.image.url alt=post.title %}
-  <a href="{{ post.content_url }}" target="_blank" rel="noopener noreferrer" class="thumb" style="aspect-ratio:16/9;">
-    <img src="{{ src }}" alt="{{ alt }}" loading="lazy" decoding="async" referrerpolicy="no-referrer" width="640" height="360">
-    {% if post.provider_name %}<span class="thumb-label">{{ post.provider_name }}</span>{% endif %}
-  </a>
-  {% endwith %}
-{% else %}
-  {% svg_placeholder post.title as ph %}
-  {% with src=ph.src alt=ph.alt %}
-  <a href="{{ post.content_url }}" target="_blank" rel="noopener noreferrer" class="thumb" style="aspect-ratio:16/9;">
-    <img src="{{ src }}" alt="{{ alt }}" loading="lazy" decoding="async" referrerpolicy="no-referrer" width="640" height="360">
-    {% if post.provider_name %}<span class="thumb-label">{{ post.provider_name }}</span>{% endif %}
-  </a>
-  {% endwith %}
-{% endif %}
+{% with href=href|default:post.content_url target=target|default:"_blank" rel=rel|default:"noopener noreferrer" aria=aria_label|default:"" %}
+  {% if post.image and post.image.url|local_thumb %}
+    <a href="{{ href }}" class="thumb" style="aspect-ratio:16/9;"{% if target %} target="{{ target }}"{% endif %}{% if rel %} rel="{{ rel }}"{% endif %}{% if aria %} aria-label="{{ aria }}"{% endif %}>
+      <img src="{{ post.image.url }}" alt="{{ post.title }}" loading="lazy" decoding="async" referrerpolicy="no-referrer" width="640" height="360">
+      {% if post.provider_name %}<span class="thumb-label">{{ post.provider_name }}</span>{% endif %}
+    </a>
+  {% elif post.thumbnail_url|local_thumb %}
+    <a href="{{ href }}" class="thumb" style="aspect-ratio:16/9;"{% if target %} target="{{ target }}"{% endif %}{% if rel %} rel="{{ rel }}"{% endif %}{% if aria %} aria-label="{{ aria }}"{% endif %}>
+      <img src="{{ post.thumbnail_url }}" alt="{{ post.title }}" loading="lazy" decoding="async" referrerpolicy="no-referrer" width="640" height="360">
+      {% if post.provider_name %}<span class="thumb-label">{{ post.provider_name }}</span>{% endif %}
+    </a>
+  {% else %}
+    {% svg_placeholder post.title as ph %}
+    <a href="{{ href }}" class="thumb" style="aspect-ratio:16/9;"{% if target %} target="{{ target }}"{% endif %}{% if rel %} rel="{{ rel }}"{% endif %}{% if aria %} aria-label="{{ aria }}"{% endif %}>
+      <img src="{{ ph.src }}" alt="{{ ph.alt }}" loading="lazy" decoding="async" referrerpolicy="no-referrer" width="640" height="360">
+      {% if post.provider_name %}<span class="thumb-label">{{ post.provider_name }}</span>{% endif %}
+    </a>
+  {% endif %}
+{% endwith %}


### PR DESCRIPTION
## Summary
- remove image_thumb logic from post_thumbnail and gate rendering on local images
- simplify feed card, post row, and detail templates to use shared thumbnail partial
- adjust feed thumbnail test for new behavior

## Testing
- `make test` *(fails: ModuleNotFoundError: No module named 'freezegun'; plus 13 failures, 6 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bd4442c9e8832cbe6410abd5dee9e6