### PR TITLE
Use resolve_thumbnail to persist post images

### DIFF
--- a/core/tests_post_submit_types.py
+++ b/core/tests_post_submit_types.py
@@ -47,7 +47,7 @@ class PostSubmitTests(TestCase):
 
     def test_youtube_link_post(self):
         link = "https://www.youtube-nocookie.com/watch?v=dQw4w9WgXcQ"
-        with patch("core.utils.thumbnails.resolve_thumbnail", return_value=("data:image/svg+xml;base64,ph", "alt")):
+        with patch("core.views.resolve_thumbnail", return_value=("data:image/svg+xml;base64,ph", "alt")):
             resp = self.client.post(
                 reverse("post_submit"),
                 {
@@ -60,19 +60,21 @@ class PostSubmitTests(TestCase):
             )
         self.assertEqual(resp.status_code, 200)
         post = Post.objects.get(title="YT")
-        self.assertEqual(post.content_url, link)
+        self.assertEqual(post.content_url, "https://youtube.com/watch?v=dQw4w9WgXcQ")
         feed = self.client.get(reverse("home"))
         self.assertContains(feed, "YT")
 
     def test_link_post_remote_thumb_saved(self):
         link = "https://example.com/page"
-        def fake_persist(post, url, label):
+        def fake_resolve(url, label, fetch_remote=False, post=None):
             post.image = make_image("thumb.jpg")
             post.save(update_fields=["image"])
+            return ("https://cdn.example.com/thumb.jpg", "alt")
+
         with patch(
-            "core.utils.thumbnails.resolve_thumbnail",
-            return_value=("https://cdn.example.com/thumb.jpg", "alt"),
-        ), patch("core.utils.thumbnails.persist_thumbnail", side_effect=fake_persist):
+            "core.views.resolve_thumbnail",
+            side_effect=fake_resolve,
+        ):
             resp = self.client.post(
                 reverse("post_submit"),
                 {
@@ -110,7 +112,7 @@ class PostSubmitTests(TestCase):
             )
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(mock_fetch.call_count, 1)
-        self.assertEqual(called.get("url"), link)
+        self.assertEqual(called.get("url"), "https://rumble.com/v1abc.html")
 
     def test_image_post(self):
         img = make_image()

--- a/core/views.py
+++ b/core/views.py
@@ -51,7 +51,7 @@ from .services.votes import (
 from . import mod
 from .http import login_required_htmx
 from .utils.video_urls import canonicalize_video_url
-from .utils.thumbnails import resolve_thumbnail, persist_thumbnail
+from .utils.thumbnails import resolve_thumbnail
 
 
 def _is_banned(user):
@@ -556,12 +556,12 @@ def post_submit(request):
                 post.image = form.cleaned_data.get("image")
             post.save()
             if post_type == "link":
-                src, label = resolve_thumbnail(
+                resolve_thumbnail(
                     post.content_url,
-                    form.cleaned_data["title"],
+                    post.title,
                     fetch_remote=True,
+                    post=post,
                 )
-                persist_thumbnail(post, src, label)
             messages.success(request, "Post submitted")
             return redirect(
                 "post_detail",
@@ -806,12 +806,12 @@ def post_edit(request, pk):
             post.save()
             if post.post_type == "link" and post.content_url:
                 try:
-                    src, label = resolve_thumbnail(
+                    resolve_thumbnail(
                         post.content_url,
                         post.title,
                         fetch_remote=True,
+                        post=post,
                     )
-                    persist_thumbnail(post, src, label)
                 except Exception:
                     pass
             messages.success(request, "Post updated")


### PR DESCRIPTION
## Summary
- Persist link thumbnails by calling `resolve_thumbnail` with post objects in submit and edit views
- Remove `persist_thumbnail` import and update tests for new thumbnail logic

## Testing
- `pytest core/tests_post_submit_types.py::PostSubmitTests::test_youtube_link_post core/tests_post_submit_types.py::PostSubmitTests::test_link_post_remote_thumb_saved core/tests_post_submit_types.py::PostSubmitTests::test_rumble_link_post_fetches_og_image core/tests/tests_thumbnail_utils.py::test_resolve_thumbnail_attaches_image -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd466ea204832ca42e04a0aaac2eea