### PR TITLE
chore: drop thumbnail and provider settings

### DIFF
--- a/config/env.schema.json
+++ b/config/env.schema.json
@@ -1,4 +1,1 @@
-{
-  "THUMBNAILS_ONLY": "bool",
-  "THUMBNAIL_CACHE_SECONDS": "int"
-}
+{}

--- a/config/provider_map.yml
+++ b/config/provider_map.yml
@@ -1,6 +1,0 @@
-youtube:
-  img_hosts: ["i.ytimg.com"]
-x:
-  img_hosts: ["*.twimg.com"]
-rumble:
-  img_hosts: ["*.rumblecdn.com", "*.rmbl.ws"]

--- a/config/settings.py
+++ b/config/settings.py
@@ -81,49 +81,7 @@ SESSION_COOKIE_AGE = 60 * 60 * 8  # 8 hours
 SESSION_EXPIRE_AT_BROWSER_CLOSE = True
 CSRF_COOKIE_SECURE = not DEBUG
 
-THUMBNAILS_ONLY = os.environ.get("THUMBNAILS_ONLY", "1") in (
-    "1",
-    "true",
-    "True",
-)
-THUMBNAIL_CACHE_SECONDS = int(os.environ.get("THUMBNAIL_CACHE_SECONDS", "3600"))
-
-# Opt-in provider-specific direct OpenGraph lookups
-YT_DIRECT_OG = os.environ.get("YT_DIRECT_OG", "0") in (
-    "1",
-    "true",
-    "True",
-)
-RUMBLE_DIRECT_OG = os.environ.get("RUMBLE_DIRECT_OG", "1") in (
-    "1",
-    "true",
-    "True",
-)
-X_DIRECT_OG = os.environ.get("X_DIRECT_OG", "0") in (
-    "1",
-    "true",
-    "True",
-)
-
-EMBED_PROVIDERS = {
-    "YOUTUBE": {
-        "img_hosts": ["https://*.ytimg.com"],
-    },
-    "X": {
-        "img_hosts": [
-            "https://*.twimg.com",
-            "https://pbs.twimg.com",
-        ],
-    },
-    "RUMBLE": {
-        "img_hosts": [
-            "https://rumblecdn.com",
-            "https://*.rumblecdn.com",
-            "https://i.rmbl.ws",
-            "https://*.rmbl.ws",
-        ],
-    },
-}
+# Removed legacy thumbnail and provider-specific settings
 
 # Simple per-user rate limits
 RATE_POSTS_PER_DAY_NEW = int(os.getenv("RATE_POSTS_PER_DAY_NEW", "10"))
@@ -149,11 +107,11 @@ if not DEBUG:
     SECURE_HSTS_PRELOAD = True
     SECURE_CONTENT_TYPE_NOSNIFF = True
 
-    _img_src = ["'self'"]
-    for provider in EMBED_PROVIDERS.values():
-        _img_src.extend(provider["img_hosts"])
-    _img_src.append("https://surejan-media.fly.storage.tigris.dev")
-    _img_src.append("data:")
+    _img_src = [
+        "'self'",
+        "https://surejan-media.fly.storage.tigris.dev",
+        "data:",
+    ]
 
     CONTENT_SECURITY_POLICY = {
         "DIRECTIVES": {
@@ -309,12 +267,10 @@ if USE_S3 and all(required) and not IS_BUILD:
     AWS_S3_SIGNATURE_VERSION = "s3v4"
     AWS_DEFAULT_ACL = "public-read"
     AWS_S3_OBJECT_PARAMETERS = {"CacheControl": "public, max-age=94608000"}
-    THUMB_CACHE_DIR = BASE_DIR / "media" / "thumbs"
 else:
     DEFAULT_FILE_STORAGE = "django.core.files.storage.FileSystemStorage"
     MEDIA_ROOT = BASE_DIR / "media"
     MEDIA_URL = "/media/"
-    THUMB_CACHE_DIR = MEDIA_ROOT / "thumbs"
 
 # Ensure STORAGES['default'] points to the active storage backend
 STORAGES["default"] = {"BACKEND": DEFAULT_FILE_STORAGE}

--- a/config/test_settings.py
+++ b/config/test_settings.py
@@ -19,5 +19,4 @@ STORAGES = {
 }
 
 MEDIA_ROOT = BASE_DIR / "test-media"
-THUMB_CACHE_DIR = MEDIA_ROOT / "thumbs"
 

--- a/core/tests/test_csp_headers.py
+++ b/core/tests/test_csp_headers.py
@@ -3,7 +3,6 @@ from django.contrib.auth import get_user_model
 from django.test import override_settings
 from django.urls import reverse
 
-from config import settings as conf_settings
 from core.models import Community, Post
 
 
@@ -25,23 +24,8 @@ def test_csp_headers_include_expected_hosts(client):
         "/",
         reverse("post_detail", args=[community.slug, post.pk, post.slug]),
     ]
-    img_src = ["'self'"]
-    for p in conf_settings.EMBED_PROVIDERS.values():
-        img_src.extend(p["img_hosts"])
-    img_src.append("data:")
-    expected_hosts = [
-        "'self'",
-        "https://*.ytimg.com",
-        "https://*.twimg.com",
-        "https://pbs.twimg.com",
-        "https://rumblecdn.com",
-        "https://*.rumblecdn.com",
-        "https://i.rmbl.ws",
-        "https://*.rmbl.ws",
-        "data:",
-    ]
-    assert img_src == expected_hosts
-    csp = {"DIRECTIVES": {"img-src": tuple(img_src)}}
+    expected_hosts = ["'self'", "data:"]
+    csp = {"DIRECTIVES": {"img-src": tuple(expected_hosts)}}
     with override_settings(DEBUG=False, CONTENT_SECURITY_POLICY=csp):
         for url in urls:
             resp = client.get(url)

--- a/fly.toml
+++ b/fly.toml
@@ -14,7 +14,6 @@ primary_region = "syd"
   AWS_S3_ENDPOINT_URL = "https://fly.storage.tigris.dev"
   AWS_S3_REGION_NAME = "auto"
   MEDIA_URL = "https://your-bucket-url/"
-  THUMBNAILS_ONLY = "1"
 
 [deploy]
   release_command = "python manage.py migrate --noinput"

--- a/tests/test_csp_header.py
+++ b/tests/test_csp_header.py
@@ -1,44 +1,6 @@
-import pytest
 from django.test import override_settings
 
 from config import settings as conf_settings
-
-
-def _build_csp(providers):
-    img_src = ["'self'"]
-    for p in providers.values():
-        img_src.extend(p["img_hosts"])
-    img_src.append("data:")
-    return {"DIRECTIVES": {"img-src": tuple(img_src)}}
-
-
-@pytest.mark.parametrize(
-    "provider,expected_hosts",
-    [
-        ("YOUTUBE", ["https://*.ytimg.com"]),
-        ("X", ["https://*.twimg.com", "https://pbs.twimg.com"]),
-        (
-            "RUMBLE",
-            [
-                "https://rumblecdn.com",
-                "https://*.rumblecdn.com",
-                "https://i.rmbl.ws",
-                "https://*.rmbl.ws",
-            ],
-        ),
-    ],
-)
-def test_csp_header_includes_provider_hosts(client, provider, expected_hosts):
-    providers = {provider: conf_settings.EMBED_PROVIDERS[provider]}
-    assert providers[provider]["img_hosts"] == expected_hosts
-    csp = _build_csp(providers)
-    with override_settings(DEBUG=False, EMBED_PROVIDERS=providers, CONTENT_SECURITY_POLICY=csp):
-        resp = client.get("/healthz")
-    csp_header = resp["Content-Security-Policy"]
-    for host in expected_hosts:
-        assert host in csp_header
-    assert "'self'" in csp_header
-    assert "data:" in csp_header
 
 
 def test_csp_header_has_img_directive(client):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,20 +1,4 @@
 import importlib
-
-
-def test_video_domains_in_csp_by_default(monkeypatch):
-    monkeypatch.setenv("DJANGO_DEBUG", "0")
-    monkeypatch.setenv("DJANGO_SECRET_KEY", "test")
-    from config import settings as conf_settings
-    importlib.reload(conf_settings)
-    img_src = conf_settings.CONTENT_SECURITY_POLICY["DIRECTIVES"]["img-src"]
-    assert any("twimg.com" in h for h in img_src)
-    assert any("ytimg.com" in h for h in img_src)
-    assert any("rumblecdn.com" in h for h in img_src)
-    monkeypatch.delenv("DJANGO_DEBUG", raising=False)
-    monkeypatch.delenv("DJANGO_SECRET_KEY", raising=False)
-    importlib.reload(conf_settings)
-
-
 def test_env_allowed_hosts_override(monkeypatch):
     monkeypatch.setenv("DJANGO_DEBUG", "0")
     monkeypatch.setenv("DJANGO_SECRET_KEY", "test")


### PR DESCRIPTION
## Summary
- remove legacy thumbnail and provider-specific configuration
- clean up related env vars and unused provider map
- simplify CSP tests to match new defaults

## Testing
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bd57f91374832c9cc9d8979feb8d24