### PR TITLE
Simplify CSP img-src hosts

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -107,18 +107,16 @@ if not DEBUG:
     SECURE_HSTS_PRELOAD = True
     SECURE_CONTENT_TYPE_NOSNIFF = True
 
-    _img_src = [
-        "'self'",
-        "https://surejan-media.fly.storage.tigris.dev",
-        "data:",
-    ]
+    MEDIA_STORAGE_HOST = os.getenv(
+        "MEDIA_STORAGE_HOST", "https://surejan-media.fly.storage.tigris.dev"
+    )
 
     CONTENT_SECURITY_POLICY = {
         "DIRECTIVES": {
             "default-src": ("'self'",),
             "script-src": ("'self'",),
             "style-src": ("'self'", "'unsafe-inline'"),
-            "img-src": tuple(_img_src),
+            "img-src": ("'self'", "data:", MEDIA_STORAGE_HOST),
             "connect-src": ("'self'",),
             "frame-ancestors": ("'self'",),
             "upgrade-insecure-requests": True,

--- a/core/tests/test_csp_headers.py
+++ b/core/tests/test_csp_headers.py
@@ -24,7 +24,11 @@ def test_csp_headers_include_expected_hosts(client):
         "/",
         reverse("post_detail", args=[community.slug, post.pk, post.slug]),
     ]
-    expected_hosts = ["'self'", "data:"]
+    expected_hosts = [
+        "'self'",
+        "data:",
+        "https://surejan-media.fly.storage.tigris.dev",
+    ]
     csp = {"DIRECTIVES": {"img-src": tuple(expected_hosts)}}
     with override_settings(DEBUG=False, CONTENT_SECURITY_POLICY=csp):
         for url in urls:

--- a/tests/test_csp_header.py
+++ b/tests/test_csp_header.py
@@ -4,13 +4,22 @@ from config import settings as conf_settings
 
 
 def test_csp_header_has_img_directive(client):
-    csp = {"DIRECTIVES": {"img-src": ("'self'", "data:")}}
+    csp = {
+        "DIRECTIVES": {
+            "img-src": (
+                "'self'",
+                "data:",
+                "https://surejan-media.fly.storage.tigris.dev",
+            )
+        }
+    }
     with override_settings(DEBUG=False, CONTENT_SECURITY_POLICY=csp):
         resp = client.get("/healthz")
     csp_header = resp["Content-Security-Policy"]
     assert "img-src" in csp_header
     assert "'self'" in csp_header
     assert "data:" in csp_header
+    assert "https://surejan-media.fly.storage.tigris.dev" in csp_header
 
 
 def test_no_legacy_csp_settings():


### PR DESCRIPTION
## Summary
- remove provider-specific CSP logic and limit `img-src` to `'self'`, `data:`, and the media storage host
- update CSP header tests to assert only the remaining hosts

## Testing
- `pytest tests/test_csp_header.py core/tests/test_csp_headers.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bde716702c832c804a328fbb1c388d