### PR TITLE
Show plain content URL in post detail

### DIFF
--- a/core/tests/test_post_detail.py
+++ b/core/tests/test_post_detail.py
@@ -1,0 +1,40 @@
+import re
+import pytest
+from django.urls import reverse
+from django.utils.html import escape
+from django.contrib.auth import get_user_model
+
+from core.models import Community, Post
+
+
+@pytest.mark.django_db
+def test_link_post_shows_plain_content_url(client):
+    User = get_user_model()
+    user = User.objects.create_user(username="alice", password="pw")
+    community = Community.objects.create(
+        slug="test",
+        name="test",
+        title="Test",
+        created_by=user,
+    )
+    url = "https://example.com/path?q=1&x=<tag>"
+    post = Post.objects.create(
+        community=community,
+        author=user,
+        post_type="link",
+        title="Link post",
+        content_url=url,
+    )
+
+    resp = client.get(reverse("post_detail", args=[community.slug, post.pk, post.slug]))
+    assert resp.status_code == 200
+    html = resp.content.decode()
+
+    # shows escaped, non-linked URL
+    assert f"from: {escape(url)}" in html
+    assert url not in html  # raw URL should be escaped
+
+    # preview elements removed
+    article = re.search(r'<article[^>]*class="post-detail"[^>]*>(.*?)</article>', html, re.DOTALL).group(1)
+    assert "<img" not in article
+    assert "<iframe" not in article

--- a/core/views.py
+++ b/core/views.py
@@ -652,7 +652,7 @@ def post_detail(request, community, pk, slug):
     """Display a single post and its comments."""
 
     post = get_object_or_404(
-        Post.objects.filter(is_deleted=False).prefetch_related("image_links"),
+        Post.objects.filter(is_deleted=False),
         pk=pk,
         community__slug=community,
     )
@@ -678,8 +678,6 @@ def post_detail(request, community, pk, slug):
     else:  # best
         comments = comments.order_by("-score", "path")
 
-    images = list(post.image_links.all())
-
     severity = None
     band = None
     try:
@@ -704,7 +702,6 @@ def post_detail(request, community, pk, slug):
     context = {
         "post": post,
         "comments": comments,
-        "images": images,
         "c_sort": c_sort,
         "q": q,
         "severity": severity,
@@ -717,7 +714,7 @@ def post_detail_id(request, pk):
     """Simpler post detail view addressed by ID only."""
 
     post = get_object_or_404(
-        Post.objects.filter(is_deleted=False).prefetch_related("image_links"),
+        Post.objects.filter(is_deleted=False),
         pk=pk,
     )
     c_sort = request.GET.get("c_sort", "best")
@@ -742,8 +739,6 @@ def post_detail_id(request, pk):
     else:  # best
         comments = comments.order_by("-score", "path")
 
-    images = list(post.image_links.all())
-
     severity = None
     band = None
     try:
@@ -768,7 +763,6 @@ def post_detail_id(request, pk):
     context = {
         "post": post,
         "comments": comments,
-        "images": images,
         "c_sort": c_sort,
         "q": q,
         "severity": severity,

--- a/templates/core/post_detail.html
+++ b/templates/core/post_detail.html
@@ -1,5 +1,5 @@
 {% extends "core/base.html" %}
-{% load permissions static %}
+{% load static %}
 {% url 'post_detail' post.community.slug post.pk post.slug as post_url %}
 
 {% block head_extra %}
@@ -16,6 +16,10 @@
       • <time datetime="{{ post.created_at|date:'c' }}">{{ post.created_at|timesince }} ago</time>
     </div>
   </header>
+
+  {% if post.content_url %}
+  <p class="post-link">from: {{ post.content_url|escape }}</p>
+  {% endif %}
 
   {% if post.body %}
   <div class="post-body prose">


### PR DESCRIPTION
## Summary
- display link posts' URLs as plain text on detail pages
- remove legacy preview context from post detail view
- add regression test for plain URL rendering

## Testing
- `pytest core/tests/test_post_detail.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bdebd1d53c832c93d9468e34eeae21