### PR TITLE
Remove placeholder S3 secrets from Fly config

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -8,12 +8,8 @@ primary_region = "syd"
 [env]
   PORT = "8000"
   FLY_APP_NAME = "surejan"
-  AWS_STORAGE_BUCKET_NAME = "your-bucket-name"
-  AWS_ACCESS_KEY_ID = "your-access-key"
-  AWS_SECRET_ACCESS_KEY = "your-secret-key"
   AWS_S3_ENDPOINT_URL = "https://fly.storage.tigris.dev"
   AWS_S3_REGION_NAME = "auto"
-  MEDIA_URL = "https://your-bucket-url/"
 
 [deploy]
   release_command = "python manage.py migrate --noinput"


### PR DESCRIPTION
## Summary
- avoid deploying with fake S3 credentials by removing placeholder values from `fly.toml`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'config'; ImproperlyConfigured)*


------
https://chatgpt.com/codex/tasks/task_e_68bdf3c68ff4832cb46f09cdf1b804c3