### PR TITLE
Handle placeholder S3 settings with local fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ SureJan is an independent, Brisbane-built community forum inspired by the old Re
 * **Frontend**: HTMX for partial page updates, Django templates for rendering
 * **Database**: Postgres, SQLite fallback for development
 * **Deployment**: Fly.io with Docker-based builds
-* **Static Files**: WhiteNoise for static file serving, S3-compatible storage for media (Tigris)
+* **Static Files**: WhiteNoise for static file serving, S3-compatible storage for media (Tigris),
+  with a local `/media/` fallback when S3 credentials are missing or placeholders
 * **Security**: django-csp, CSRF protection, secure session and cookie handling
 * **Testing**: Django test framework with HTMX request coverage
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -243,22 +243,37 @@ STORAGES = {"staticfiles": {"BACKEND": STATICFILES_STORAGE}}
 WHITENOISE_MANIFEST_STRICT = True
 
 # Required envs
-AWS_STORAGE_BUCKET_NAME = os.getenv("AWS_STORAGE_BUCKET_NAME")
+AWS_STORAGE_BUCKET_NAME = os.getenv("AWS_STORAGE_BUCKET_NAME", "")
 AWS_ACCESS_KEY_ID = os.getenv("AWS_ACCESS_KEY_ID", "")
 AWS_SECRET_ACCESS_KEY = os.getenv("AWS_SECRET_ACCESS_KEY", "")
 AWS_S3_ENDPOINT_URL = os.getenv("AWS_S3_ENDPOINT_URL", "")  # e.g. https://fly.storage.tigris.dev
 AWS_S3_REGION_NAME = os.getenv("AWS_S3_REGION_NAME", "auto")
+
 # Determine if S3 is fully configured and enabled
-required = [
-    AWS_STORAGE_BUCKET_NAME,
-    AWS_ACCESS_KEY_ID,
-    AWS_SECRET_ACCESS_KEY,
-    AWS_S3_ENDPOINT_URL,
-    os.getenv("MEDIA_URL"),
+required = {
+    "AWS_STORAGE_BUCKET_NAME": AWS_STORAGE_BUCKET_NAME,
+    "AWS_ACCESS_KEY_ID": AWS_ACCESS_KEY_ID,
+    "AWS_SECRET_ACCESS_KEY": AWS_SECRET_ACCESS_KEY,
+    "AWS_S3_ENDPOINT_URL": AWS_S3_ENDPOINT_URL,
+    "MEDIA_URL": os.getenv("MEDIA_URL", ""),
+}
+
+# Basic placeholder detection so sample values like "your-bucket" don't enable S3
+placeholder_tokens = [
+    "your-bucket",
+    "your-access-key",
+    "your-secret",
+    "your-endpoint",
 ]
+has_placeholders = any(
+    token in (value or "")
+    for value in required.values()
+    for token in placeholder_tokens
+)
+
 USE_S3 = os.getenv("USE_S3", "1") in ("1", "true", "True")
-if USE_S3 and all(required) and not IS_BUILD:
-    MEDIA_URL = os.environ["MEDIA_URL"]
+if USE_S3 and all(required.values()) and not has_placeholders and not IS_BUILD:
+    MEDIA_URL = required["MEDIA_URL"]
     DEFAULT_FILE_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"
     AWS_QUERYSTRING_AUTH = False
     AWS_S3_ADDRESSING_STYLE = "virtual"
@@ -266,6 +281,8 @@ if USE_S3 and all(required) and not IS_BUILD:
     AWS_DEFAULT_ACL = "public-read"
     AWS_S3_OBJECT_PARAMETERS = {"CacheControl": "public, max-age=94608000"}
 else:
+    # Fallback to local storage so development and misconfigured deployments
+    # serve media from /media/.
     DEFAULT_FILE_STORAGE = "django.core.files.storage.FileSystemStorage"
     MEDIA_ROOT = BASE_DIR / "media"
     MEDIA_URL = "/media/"


### PR DESCRIPTION
## Summary
- Detect placeholder S3 values and only enable S3 when fully configured
- Default to local `/media/` storage when S3 config is missing or placeholders
- Document local media fallback in README

## Testing
- `python manage.py collectstatic --noinput`
- `PYTHONPATH=. DJANGO_SETTINGS_MODULE=config.settings pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bdf449de34832c9292b44c5ca9f78c