### PR TITLE
Render images in posts

### DIFF
--- a/templates/core/partials/post_row.html
+++ b/templates/core/partials/post_row.html
@@ -10,6 +10,11 @@
     {% if post.excerpt %}
     <p class="post-excerpt">{{ post.excerpt }}</p>
     {% endif %}
+    {% if (post.post_type == 'image' or post.image) and post.image_thumb %}
+    <a href="{{ detail_url }}" class="post-image-link">
+      <img src="{{ post.image_thumb.url }}" alt="{{ post.title }}" class="post-image-thumb">
+    </a>
+    {% endif %}
     <div class="post-actions">
       {% if show_vote_widget is not False %}
         {% include "core/partials/vote_widget.html" with post=post user=user request=request only %}

--- a/templates/core/post_detail.html
+++ b/templates/core/post_detail.html
@@ -21,6 +21,12 @@
   <p class="post-link">from: {{ post.content_url|escape }}</p>
   {% endif %}
 
+  {% if post.image %}
+  <div class="post-image">
+    <img src="{{ post.image.url }}" alt="{{ post.title }}">
+  </div>
+  {% endif %}
+
   {% if post.body %}
   <div class="post-body prose">
     {{ post.body|safe }}


### PR DESCRIPTION
## Summary
- show thumbnail images on post listings when an image is attached
- display the full image above the body on post detail pages
- confirm MEDIA_URL and debug URLs serve uploaded files

## Testing
- `python manage.py test` *(fails: failures=6, errors=44)*

------
https://chatgpt.com/codex/tasks/task_e_68be006687f4832c87ede0ae5e19a294