### PR TITLE
Fix feed template conditionals and ensure image thumbnails render correctly

### DIFF
--- a/templates/core/partials/post_row.html
+++ b/templates/core/partials/post_row.html
@@ -10,9 +10,15 @@
     {% if post.excerpt %}
     <p class="post-excerpt">{{ post.excerpt }}</p>
     {% endif %}
-    {% if (post.post_type == 'image' or post.image) and post.image_thumb %}
-    <a href="{{ detail_url }}" class="post-image-link">
-      <img src="{{ post.image_thumb.url }}" alt="{{ post.title }}" class="post-image-thumb">
+    {% if post.post_type == "link" %}
+    {% include "partials/post_thumbnail.html" with post=post %}
+    {% elif post.image_thumb or post.image %}
+    <a href="{{ detail_url }}" class="thumb">
+      {% if post.image_thumb %}
+      <img src="{{ post.image_thumb.url }}" alt="{{ post.title }}">
+      {% elif post.image %}
+      <img src="{{ post.image.url }}" alt="{{ post.title }}">
+      {% endif %}
     </a>
     {% endif %}
     <div class="post-actions">

--- a/templates/core/post_detail.html
+++ b/templates/core/post_detail.html
@@ -21,11 +21,17 @@
   <p class="post-link">from: {{ post.content_url|escape }}</p>
   {% endif %}
 
-  {% if post.image %}
-  <div class="post-image">
-    <img src="{{ post.image.url }}" alt="{{ post.title }}">
-  </div>
-  {% endif %}
+    {% if post.post_type == "link" %}
+    {% include "partials/post_thumbnail.html" with post=post %}
+    {% elif post.image_thumb or post.image %}
+    <figure class="post-media">
+      {% if post.image_thumb %}
+      <img src="{{ post.image_thumb.url }}" alt="{{ post.title }}">
+      {% elif post.image %}
+      <img src="{{ post.image.url }}" alt="{{ post.title }}">
+      {% endif %}
+    </figure>
+    {% endif %}
 
   {% if post.body %}
   <div class="post-body prose">

--- a/templates/partials/feed_card.html
+++ b/templates/partials/feed_card.html
@@ -7,15 +7,26 @@
   </div>
   <h3 class="post-title"><a href="{{ detail_url }}">{{ post.title }}</a></h3>
   {% if post.is_deleted %}<span class="state-badge">deleted</span>{% endif %}
-  {% if post.is_draft %}<span class="state-badge">draft</span>{% endif %}
-    {% if post.excerpt %}
-    <p class="post-excerpt">{{ post.excerpt }}</p>
-    {% endif %}
-    <div class="post-actions">
-    {% if show_vote_widget is not False %}
-      {% include "core/partials/vote_widget.html" with post=post user=user request=request only %}
-    {% else %}
-      <span id="post-{{ post.pk }}-score-card" class="score">{{ post.score }}</span>
+    {% if post.is_draft %}<span class="state-badge">draft</span>{% endif %}
+      {% if post.excerpt %}
+      <p class="post-excerpt">{{ post.excerpt }}</p>
+      {% endif %}
+      {% if post.post_type == "link" %}
+        {% include "partials/post_thumbnail.html" with post=post %}
+      {% elif post.image_thumb or post.image %}
+      <a href="{{ detail_url }}" class="thumb">
+        {% if post.image_thumb %}
+        <img src="{{ post.image_thumb.url }}" alt="{{ post.title }}">
+        {% elif post.image %}
+        <img src="{{ post.image.url }}" alt="{{ post.title }}">
+        {% endif %}
+      </a>
+      {% endif %}
+      <div class="post-actions">
+      {% if show_vote_widget is not False %}
+        {% include "core/partials/vote_widget.html" with post=post user=user request=request only %}
+      {% else %}
+        <span id="post-{{ post.pk }}-score-card" class="score">{{ post.score }}</span>
     {% endif %}
     <a href="{{ detail_url }}#comments">{{ post.comment_count }} comments</a>
     {% if post.astro_score %}

--- a/templates/partials/post_thumbnail.html
+++ b/templates/partials/post_thumbnail.html
@@ -1,0 +1,11 @@
+{% with detail_url=post.get_absolute_url %}
+{% if post.image_thumb or post.image %}
+  <a href="{{ detail_url }}" class="thumb">
+    {% if post.image_thumb %}
+    <img src="{{ post.image_thumb.url }}" alt="{{ post.title }}">
+    {% elif post.image %}
+    <img src="{{ post.image.url }}" alt="{{ post.title }}">
+    {% endif %}
+  </a>
+{% endif %}
+{% endwith %}


### PR DESCRIPTION
## Summary
- fix feed row thumbnail conditional to avoid template syntax errors and guard image access
- render link and image thumbnails consistently via `post_thumbnail.html`
- wrap detail page media in responsive figure

## Testing
- `pytest` *(fails: Requested setting INSTALLED_APPS, but settings are not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68be0373f344832c84f07ee1e68068a8