### PR TITLE
Simplify image blocks in templates

### DIFF
--- a/templates/core/partials/post_row.html
+++ b/templates/core/partials/post_row.html
@@ -14,11 +14,7 @@
     {% include "partials/post_thumbnail.html" with post=post %}
     {% elif post.image_thumb or post.image %}
     <a href="{{ detail_url }}" class="thumb">
-      {% if post.image_thumb %}
-      <img src="{{ post.image_thumb.url }}" alt="{{ post.title }}">
-      {% elif post.image %}
-      <img src="{{ post.image.url }}" alt="{{ post.title }}">
-      {% endif %}
+      <img src="{{ post.image_thumb.url|default:post.image.url }}" alt="{{ post.title }}" width="320" height="180" loading="lazy" decoding="async">
     </a>
     {% endif %}
     <div class="post-actions">

--- a/templates/partials/feed_card.html
+++ b/templates/partials/feed_card.html
@@ -15,11 +15,7 @@
         {% include "partials/post_thumbnail.html" with post=post %}
       {% elif post.image_thumb or post.image %}
       <a href="{{ detail_url }}" class="thumb">
-        {% if post.image_thumb %}
-        <img src="{{ post.image_thumb.url }}" alt="{{ post.title }}">
-        {% elif post.image %}
-        <img src="{{ post.image.url }}" alt="{{ post.title }}">
-        {% endif %}
+        <img src="{{ post.image_thumb.url|default:post.image.url }}" alt="{{ post.title }}" width="320" height="180" loading="lazy" decoding="async">
       </a>
       {% endif %}
       <div class="post-actions">


### PR DESCRIPTION
## Summary
- simplify image tags in feed and post row templates with fallback and lazy loading

## Testing
- `python manage.py test core.tests_mod_actions.ModActionTests.test_domain_throttle_affects_ranking 2>&1 | tail -n 20`
- `python manage.py test core.tests.test_links.PostLinkTests.test_feed_card_uses_absolute_url 2>&1 | tail -n 20` *(fails: AssertionError: 2 != 1)*

------
https://chatgpt.com/codex/tasks/task_e_68be073f20e4832c9ee741b13b988a64