### PR TITLE
Validate image extensions in PostForm

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -1,4 +1,5 @@
 from django import forms
+from django.core.validators import FileExtensionValidator
 from django.utils.text import slugify
 
 import bleach
@@ -41,7 +42,12 @@ class PostForm(forms.Form):
         widget=forms.Textarea(attrs={"data-editor": "1"}), required=False
     )
     content_url = forms.URLField(required=False)
-    image = forms.FileField(required=False)
+    image = forms.ImageField(
+        required=False,
+        validators=[
+            FileExtensionValidator(allowed_extensions=["jpg", "jpeg", "png", "gif", "webp"])
+        ],
+    )
 
     def clean_body(self):
         body = (self.cleaned_data.get("body") or "").strip()


### PR DESCRIPTION
## Summary
- switch `image` field to `ImageField` with strict file extension validation
- add `FileExtensionValidator` import for image uploads

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'config'; ImproperlyConfigured: Requested setting INSTALLED_APPS)*

------
https://chatgpt.com/codex/tasks/task_e_68be090dcda0832c8a35f23013639c70