### PR TITLE
Refine Astro severity chip markup

### DIFF
--- a/templates/core/partials/post_context_chips.html
+++ b/templates/core/partials/post_context_chips.html
@@ -2,7 +2,7 @@
 {% if ASTROTURF_WATCH and signals.score %}
 <div class="post-context-chips">
   <details class="astro-why">
-    <summary class="chip {{ signals.score|astro_band }}">Astro {{ signals.score }}</summary>
+    <summary><div class="astro-chip {{ signals.score|astro_band }}">{{ signals.score }}</div><span class="astro-label">Astro</span></summary>
     <ul>
       <li>Vote rate 15m: {{ signals.rate15 }}</li>
       <li>Early new-account share: {{ signals.early_new_share|floatformat:2 }}</li>


### PR DESCRIPTION
## Summary
- display astroturf severity using dedicated `astro-chip` markup

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'core'; django settings not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68be116c54c0832c8300c025c5be5ed6