### PR TITLE
Render astroturf score as chip on feed cards

### DIFF
--- a/templates/core/partials/post_context_chips.html
+++ b/templates/core/partials/post_context_chips.html
@@ -1,13 +1,9 @@
 {% load astro_filters %}{% comment %}Display engagement signal chips for a post{% endcomment %}
 {% if ASTROTURF_WATCH and signals.score %}
 <div class="post-context-chips">
-  <details class="astro-why">
-    <summary><div class="astro-chip {{ signals.score|astro_band }}">{{ signals.score }}</div><span class="astro-label">Astro</span></summary>
-    <ul>
-      <li>Vote rate 15m: {{ signals.rate15 }}</li>
-      <li>Early new-account share: {{ signals.early_new_share|floatformat:2 }}</li>
-      <li>Discuss ratio: {{ signals.discuss_ratio|floatformat:2 }}</li>
-    </ul>
-  </details>
+  <div class="astro-meter">
+    <div class="astro-chip {{ signals.score|astro_band }}">{{ signals.score }}</div>
+    <span class="astro-label">Astro</span>
+  </div>
 </div>
 {% endif %}

--- a/templates/core/partials/post_row.html
+++ b/templates/core/partials/post_row.html
@@ -13,9 +13,9 @@
     {% if post.post_type == "link" %}
     {% include "partials/post_thumbnail.html" with post=post %}
     {% elif post.image_thumb or post.image %}
-    <a href="{{ detail_url }}" class="thumb">
+    <div class="thumb">
       <img src="{{ post.image_thumb.url|default:post.image.url }}" alt="{{ post.title }}" width="320" height="180" loading="lazy" decoding="async">
-    </a>
+    </div>
     {% endif %}
     <div class="post-actions">
       {% if show_vote_widget is not False %}

--- a/templates/partials/feed_card.html
+++ b/templates/partials/feed_card.html
@@ -14,9 +14,9 @@
       {% if post.post_type == "link" %}
         {% include "partials/post_thumbnail.html" with post=post %}
       {% elif post.image_thumb or post.image %}
-      <a href="{{ detail_url }}" class="thumb">
+      <div class="thumb">
         <img src="{{ post.image_thumb.url|default:post.image.url }}" alt="{{ post.title }}" width="320" height="180" loading="lazy" decoding="async">
-      </a>
+      </div>
       {% endif %}
       <div class="post-actions">
       {% if show_vote_widget is not False %}
@@ -26,14 +26,10 @@
     {% endif %}
     <a href="{{ detail_url }}#comments">{{ post.comment_count }} comments</a>
     {% if post.astro_score %}
-    <details class="astro-why">
-      <summary class="chip {{ post.astro_score.score|astro_band }}">Astro {{ post.astro_score.score }}</summary>
-      <ul>
-        <li>Vote rate 15m: {{ post.astro_score.rate15 }}</li>
-        <li>Early new-account share: {{ post.astro_score.early_new_share|floatformat:2 }}</li>
-        <li>Discuss ratio: {{ post.astro_score.discuss_ratio|floatformat:2 }}</li>
-      </ul>
-    </details>
+      <div class="astro-meter">
+        <div class="astro-chip {{ post.astro_score.score|astro_band }}">{{ post.astro_score.score }}</div>
+        <span class="sr-only">Astro score</span>
+      </div>
     {% endif %}
   </div>
 {% endwith %}


### PR DESCRIPTION
## Summary
- show astroturf score on feed cards as a colored chip
- simplify context chips partial to the chip-only structure
- drop duplicate detail links from image thumbnails

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68be12231b5c832c82b6e6ae1036be2e