### PR TITLE
Add inline astro chip template

### DIFF
--- a/templates/core/partials/astro_chip_inline.html
+++ b/templates/core/partials/astro_chip_inline.html
@@ -1,0 +1,2 @@
+{% load astro_filters %}
+<div class="astro-chip {{ score|astro_band }}">{{ score }}</div>


### PR DESCRIPTION
## Summary
- add `templates/core/partials/astro_chip_inline.html` that loads `astro_filters` and renders an astro chip for a given score

## Testing
- `make test` *(fails: missing staticfiles manifest and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68be16d9cee4832c8e837e65f2e744e2