### PR TITLE
Inline astro chip and remove chip loader

### DIFF
--- a/core/tests/test_astro.py
+++ b/core/tests/test_astro.py
@@ -184,17 +184,14 @@ class AstroFeatureFlagViewTests(TestCase):
             self.assertEqual(self.client.get(url_methods).status_code, 404)
             self.assertEqual(self.client.get(url_posts).status_code, 404)
 
-    def test_chip_containers_hidden_when_flag_disabled(self):
+    def test_chip_containers_removed(self):
         chips_url = reverse("post_signals_chips", args=[self.post.pk])
         detail_url = reverse(
             "post_detail",
             args=[self.community.slug, self.post.pk, self.post.slug],
         )
-        self.assertContains(self.client.get(detail_url), chips_url)
-        self.assertContains(self.client.get(reverse("home")), chips_url)
-        with override_settings(ASTROTURF_WATCH=False):
-            self.assertNotContains(self.client.get(detail_url), chips_url)
-            self.assertNotContains(self.client.get(reverse("home")), chips_url)
+        self.assertNotContains(self.client.get(detail_url), chips_url)
+        self.assertNotContains(self.client.get(reverse("home")), chips_url)
 
 
 class AstroEnvVarToggleTests(SimpleTestCase):

--- a/templates/core/partials/post_row.html
+++ b/templates/core/partials/post_row.html
@@ -34,8 +34,5 @@
         {% endif %}
       {% endif %}
     </div>
-    {% if ASTROTURF_WATCH %}
-    <div hx-get="{% url 'post_signals_chips' post.pk %}" hx-trigger="load"></div>
-    {% endif %}
   {% endwith %}
 </article>

--- a/templates/core/post_detail.html
+++ b/templates/core/post_detail.html
@@ -1,5 +1,5 @@
 {% extends "core/base.html" %}
-{% load static %}
+{% load static astro_filters %}
 {% url 'post_detail' post.community.slug post.pk post.slug as post_url %}
 
 {% block head_extra %}
@@ -43,14 +43,7 @@
     <div class="post-actions">
       {% include "core/partials/vote_widget.html" with post=post user=user request=request only %}
 
-      {% if severity_band %}
-        <div class="astro-meter" title="Astro severity: {{ severity|floatformat:0 }}/100">
-          <div class="astro-chip {{ severity_band }}">
-            {{ severity|floatformat:0 }}
-          </div>
-          <span class="astro-label">Astro</span>
-        </div>
-      {% endif %}
+      {% include "core/partials/astro_chip_inline.html" with score=post.astro_score.score|default:severity %}
 
       {% if request.user == post.author or request.user.is_staff %}
         <form method="post" action="{% url 'post_delete_owner' post.pk %}" hx-post="{% url 'post_delete_owner' post.pk %}" style="display:inline">
@@ -62,9 +55,6 @@
     </div>
   {% else %}
     <em>[deleted by author]</em>
-  {% endif %}
-  {% if ASTROTURF_WATCH %}
-  <div hx-get="{% url 'post_signals_chips' post.pk %}" hx-trigger="load"></div>
   {% endif %}
 </article>
 


### PR DESCRIPTION
## Summary
- inline astro chip partial in post detail
- drop HTMX chip loader from post detail and list view
- adjust tests for removed chip loader

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68be17e5ec58832cbba72f7ceb05623a