### PR TITLE
Inline astro chip and remove chips endpoint

### DIFF
--- a/core/tests/test_astro.py
+++ b/core/tests/test_astro.py
@@ -138,7 +138,7 @@ class AstroSignalFlagTests(TestCase):
 class AstroEndpointTests(TestCase):
     @override_settings(ASTRO_EARLY_VOTES_N=5, ASTRO_MIN_EARLY_VOTES=3)
     @freeze_time("2024-04-01 00:00:00")
-    def test_json_and_chips_endpoints_feature_flag(self):
+    def test_json_endpoint_feature_flag(self):
         User = get_user_model()
         author = User.objects.create_user("author", password="pwd")
         voter = User.objects.create_user("voter", password="pwd")
@@ -151,16 +151,11 @@ class AstroEndpointTests(TestCase):
             )
         apply_vote(voter, "post", post.pk, 1)
         url_json = reverse("post_signals_json", args=[post.pk])
-        url_chips = reverse("post_signals_chips", args=[post.pk])
         resp = self.client.get(url_json)
         self.assertEqual(resp.status_code, 200)
         self.assertIn("rate5", resp.json())
-        resp = self.client.get(url_chips)
-        self.assertContains(resp, "post-context-chips")
         with override_settings(ASTROTURF_WATCH=False):
             resp = self.client.get(url_json)
-            self.assertEqual(resp.status_code, 404)
-            resp = self.client.get(url_chips)
             self.assertEqual(resp.status_code, 404)
 
 
@@ -185,13 +180,12 @@ class AstroFeatureFlagViewTests(TestCase):
             self.assertEqual(self.client.get(url_posts).status_code, 404)
 
     def test_chip_containers_removed(self):
-        chips_url = reverse("post_signals_chips", args=[self.post.pk])
         detail_url = reverse(
             "post_detail",
             args=[self.community.slug, self.post.pk, self.post.slug],
         )
-        self.assertNotContains(self.client.get(detail_url), chips_url)
-        self.assertNotContains(self.client.get(reverse("home")), chips_url)
+        self.assertNotContains(self.client.get(detail_url), "post-context-chips")
+        self.assertNotContains(self.client.get(reverse("home")), "post-context-chips")
 
 
 class AstroEnvVarToggleTests(SimpleTestCase):

--- a/core/urls.py
+++ b/core/urls.py
@@ -19,7 +19,6 @@ urlpatterns = [
 
     # Post signals
     path("posts/<int:pk>/signals.json", core_views.post_signals_json, name="post_signals_json"),
-    path("posts/<int:pk>/signals/chips", core_views.post_signals_chips, name="post_signals_chips"),
 
     # Recovery codes
     path("accounts/recovery-codes/", core_views.recovery_codes, name="recovery_codes"),

--- a/core/views.py
+++ b/core/views.py
@@ -223,27 +223,6 @@ def post_signals_json(request, pk):
     return response
 
 
-@require_GET
-def post_signals_chips(request, pk):
-    if not settings.ASTROTURF_WATCH:
-        raise Http404
-    try:
-        data = _cached_post_signals(pk)
-    except Post.DoesNotExist:
-        raise Http404
-    response = render(
-        request,
-        "core/partials/post_context_chips.html",
-        {"signals": data},
-    )
-    etag = hashlib.md5(response.content).hexdigest()
-    if request.headers.get("If-None-Match") == etag:
-        return HttpResponse(status=304)
-    response["ETag"] = etag
-    patch_cache_control(response, max_age=30)
-    return response
-
-
 class SignupForm(forms.Form):
     username = forms.CharField(max_length=150)
     password = forms.CharField(widget=forms.PasswordInput)

--- a/templates/core/partials/post_context_chips.html
+++ b/templates/core/partials/post_context_chips.html
@@ -1,9 +1,0 @@
-{% load astro_filters %}{% comment %}Display engagement signal chips for a post{% endcomment %}
-{% if ASTROTURF_WATCH and signals.score %}
-<div class="post-context-chips">
-  <div class="astro-meter">
-    <div class="astro-chip {{ signals.score|astro_band }}">{{ signals.score }}</div>
-    <span class="astro-label">Astro</span>
-  </div>
-</div>
-{% endif %}

--- a/templates/core/partials/post_row.html
+++ b/templates/core/partials/post_row.html
@@ -24,6 +24,11 @@
         <span id="post-{{ post.pk }}-score" class="score">{{ post.score }}</span>
       {% endif %}
       <a href="{{ post.get_absolute_url }}#comments">{{ post.comment_count }} comments</a>
+      {% with s=post.astro_score.score|default:'' %}
+        {% if s %}
+          {% include "core/partials/astro_chip_inline.html" with score=s %}
+        {% endif %}
+      {% endwith %}
       {% if not post.is_deleted %}
         {% if request.user == post.author or request.user.is_staff %}
           <form method="post" action="{% url 'post_delete_owner' post.pk %}" style="display:inline"

--- a/templates/partials/feed_card.html
+++ b/templates/partials/feed_card.html
@@ -25,7 +25,11 @@
         <span id="post-{{ post.pk }}-score-card" class="score">{{ post.score }}</span>
     {% endif %}
     <a href="{{ detail_url }}#comments">{{ post.comment_count }} comments</a>
-    {% include "core/partials/astro_chip_inline.html" with score=post.astro_score.score|default:signals.score %}
+    {% with s=post.astro_score.score|default:'' %}
+      {% if s %}
+        {% include "core/partials/astro_chip_inline.html" with score=s %}
+      {% endif %}
+    {% endwith %}
   </div>
 {% endwith %}
 </article>


### PR DESCRIPTION
## Summary
- Render astro chip inline in post row and feed card
- Remove obsolete `post_signals_chips` endpoint and template
- Adjust Astro tests for endpoint removal

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68be1baa0494832c8af0ab3cde8f881b