### PR TITLE
Consolidate astro-chip styles

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -369,5 +369,7 @@ body.layout-root {
 .comment-meta .dot{ opacity:.6; }
 .comment-actions{ display:flex; align-items:center; gap:8px; margin-top:6px; }
 .comment .score{ min-width:1.5ch; text-align:center; }
-.astro-chip{ min-width:28px; height:18px; padding:0 6px; border-radius:9px; font-size:11px; line-height:18px; color:#fff; font-weight:600; }
-.astro-chip.green{ background:#16a34a; } .astro-chip.amber{ background:#f59e0b; } .astro-chip.red{ background:#dc2626; }
+.comment-meta .astro-chip{
+  min-width:28px; height:18px; padding:0 6px;
+  border-radius:9px; font-size:11px; line-height:18px;
+}


### PR DESCRIPTION
## Summary
- dedupe `.astro-chip` CSS rules and add comment-specific size override
- rely on base stylesheet for chip styling in feed and detail pages

## Testing
- `python manage.py test 2>&1 | tail -n 20 | cut -c1-200` *(fails: failures=9, errors=5)*

------
https://chatgpt.com/codex/tasks/task_e_68be1d71593c832cb6fe398507080dd9