### PR TITLE
Center sidebar auth links

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -107,6 +107,7 @@ html,body{background:var(--color-bg); color:var(--color-text); font-family:var(-
 .side-title{font-weight:600;margin-bottom:var(--space-3);}
 .comm-list a{display:block;padding:var(--space-2) 0;text-decoration:none;color:inherit;}
 .sidebar-cta{background:var(--color-surface);padding:var(--space-5);border-radius:var(--radius-lg);margin-top:var(--space-6);}
+.sidebar-auth{text-align:center;}
 .sidebar-link{display:block;margin-top:var(--space-3);text-decoration:none;color:inherit;}
 
 /* Form styles -------------------------------------------------- */

--- a/templates/partials/user_box.html
+++ b/templates/partials/user_box.html
@@ -1,5 +1,5 @@
 {% load points %}
-<div class="user-box">
+<div class="user-box sidebar-auth">
   {% if request.user.is_authenticated %}
     <a href="{% url 'user_overview' request.user.username %}">{{ request.user.username }}</a>
     | Points: {{ request.user|get_points }}


### PR DESCRIPTION
## Summary
- allow CSS targeting of login box with new `sidebar-auth` class
- center authentication links in sidebar

## Testing
- `pytest` *(fails: django.core.exceptions.ImproperlyConfigured: Requested setting INSTALLED_APPS, but settings are not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68be22dee010832c92e3b93bbaf866d1