### PR TITLE
Add header color tokens

### DIFF
--- a/static/css/tokens.css
+++ b/static/css/tokens.css
@@ -1,5 +1,6 @@
 :root{
   --color-bg:#0b0b0d; --color-surface:#141418; --color-text:#e9e9ee; --color-accent:#66ccff;
+  --color-header-bg:#1D1D1D; --color-header-link:#FFFFFF;
   --space-1:4px; --space-2:8px; --space-3:12px; --space-4:16px; --space-5:24px; --space-6:32px;
   --radius-sm:4px; --radius-md:8px; --radius-lg:12px;
   --font-sans: system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;


### PR DESCRIPTION
## Summary
- add `--color-header-bg` and `--color-header-link` tokens for header styling
- confirm no theme files override the new tokens

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: Requested setting INSTALLED_APPS, but settings are not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68be2438c34c832cacc516a179cf2baf