### PR TITLE
Refine header layout and spacing

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -15,11 +15,9 @@ html,body{background:var(--color-bg); color:var(--color-text); font-family:var(-
 /* Header -------------------------------------------------------------- */
 .header-bar{
   position:sticky; top:0; z-index:1000;
-  background:var(--color-surface);
-  border-bottom:1px solid var(--color-border);
+  background:var(--color-header-bg);
   display:flex; align-items:center; gap:var(--space-4);
-  padding: var(--space-3) var(--space-6);
-  height:128px;
+  padding: var(--space-3) var(--space-6) 0;
 }
 
 .nav-links a{ padding:4px 8px; border-radius:6px; text-decoration:none; }
@@ -116,8 +114,10 @@ html,body{background:var(--color-bg); color:var(--color-text); font-family:var(-
 /* --- V3 layout lock (append; ~50 LOC) --- */
 
 /* Header: 128px band with 3 zones */
-.header-inner{max-width:1440px;margin:0 auto;display:grid;grid-template-columns:1fr 1fr 1fr;gap:24px;align-items:center;padding:0 24px}
-.hdr-left{justify-self:start}.hdr-center{justify-self:center}.hdr-right{justify-self:end}
+.header-inner{max-width:1440px;margin:0 auto;display:flex;align-items:flex-end;gap:24px;padding:0 24px}
+.hdr-left{}
+.hdr-center{margin-left:auto;margin-right:auto;}
+.hdr-right{margin-left:auto;}
 
 /* Page: left communities (200–240) + main shell */
 .page{display:grid;grid-template-columns:minmax(200px,240px) 1fr}


### PR DESCRIPTION
## Summary
- use theme header background color and drop bottom border
- switch header inner layout to flex and baseline-align sections
- trim header bottom spacing for tighter alignment

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'config')*

------
https://chatgpt.com/codex/tasks/task_e_68be24ef985c832cbdeb413ed60c7e2d