### PR TITLE
Reset default page margins

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -10,7 +10,7 @@
   --sidebar-width:300px;
 }
 
-html,body{background:var(--color-bg); color:var(--color-text); font-family:var(--font-sans);}
+html,body{margin:0; padding:0; background:var(--color-bg); color:var(--color-text); font-family:var(--font-sans);}
 
 /* Header -------------------------------------------------------------- */
 .header-bar{


### PR DESCRIPTION
## Summary
- remove default margin and padding on html/body so background reaches viewport edge

## Testing
- `python manage.py collectstatic --noinput`
- `python manage.py test` *(fails: test_large_upload_rejected (core.tests_post_submit_types.PostSubmitTests.test_large_upload_rejected) ...)*

------
https://chatgpt.com/codex/tasks/task_e_68be2ca50bf4832c9ad8f2e9048c74bf