### PR TITLE
style: expand header bar width

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -18,6 +18,10 @@ html,body{margin:0; padding:0; background:var(--color-bg); color:var(--color-tex
   background:var(--color-header-bg);
   display:flex; align-items:center; gap:var(--space-4);
   padding: var(--space-3) 0;
+  border: none;
+  outline: none;
+  box-shadow: none;
+  width: 100%;
 }
 
 .nav-links a{ padding:4px 8px; border-radius:6px; text-decoration:none; }


### PR DESCRIPTION
## Summary
- ensure header bar spans full width and has no visual separators

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'config')*

------
https://chatgpt.com/codex/tasks/task_e_68be2dbe9188832cb77c302980a4ba7f