### PR TITLE
Use DJANGO_SECRET_KEY consistently

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -16,10 +16,12 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # -----------------------------------------------------------------------------
 DEBUG = os.environ.get("DJANGO_DEBUG", "1") in ("1", "true", "True")
 
-SECRET_KEY = os.environ.get("DJANGO_SECRET_KEY")
+SECRET_KEY = os.environ.get("DJANGO_SECRET_KEY") or os.environ.get("SECRET_KEY")
 if not DEBUG:
     if not SECRET_KEY or SECRET_KEY == "dev-secret-key":
-        raise ImproperlyConfigured("DJANGO_SECRET_KEY must be set in production")
+        raise ImproperlyConfigured(
+            "DJANGO_SECRET_KEY or SECRET_KEY must be set in production"
+        )
 else:
     SECRET_KEY = SECRET_KEY or "dev-secret-key"
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -17,8 +17,8 @@ echo "Using Fly app name: ${APP}"
 fly apps create "${APP}" >/dev/null 2>&1 || true
 export FLY_APP="${APP}"
 
-# Optionally seed SECRET_KEY for new apps
-if ! fly secrets list 2>/dev/null | awk '{print $1}' | grep -q '^SECRET_KEY$'; then
+# Optionally seed DJANGO_SECRET_KEY for new apps
+if ! fly secrets list 2>/dev/null | awk '{print $1}' | grep -q '^DJANGO_SECRET_KEY$'; then
   if command -v python >/dev/null 2>&1; then
     SK="$(python - <<'PY'
 import secrets
@@ -28,8 +28,8 @@ PY
   else
     SK="$(openssl rand -base64 64 | tr -d '\n')"
   fi
-  fly secrets set SECRET_KEY="$SK" >/dev/null
-  echo "Set SECRET_KEY."
+  fly secrets set DJANGO_SECRET_KEY="$SK" >/dev/null
+  echo "Set DJANGO_SECRET_KEY."
 fi
 
 # Deploy using the committed Dockerfile

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,4 +1,17 @@
 import importlib
+
+
+def test_secret_key_fallback(monkeypatch):
+    monkeypatch.setenv("DJANGO_DEBUG", "0")
+    monkeypatch.delenv("DJANGO_SECRET_KEY", raising=False)
+    monkeypatch.setenv("SECRET_KEY", "fallback")
+    from config import settings as conf_settings
+    importlib.reload(conf_settings)
+    assert conf_settings.SECRET_KEY == "fallback"
+    monkeypatch.delenv("SECRET_KEY", raising=False)
+    monkeypatch.delenv("DJANGO_DEBUG", raising=False)
+    importlib.reload(conf_settings)
+
 def test_env_allowed_hosts_override(monkeypatch):
     monkeypatch.setenv("DJANGO_DEBUG", "0")
     monkeypatch.setenv("DJANGO_SECRET_KEY", "test")


### PR DESCRIPTION
## Summary
- Seed `DJANGO_SECRET_KEY` when deploying to Fly
- Allow `SECRET_KEY` env var to backfill missing `DJANGO_SECRET_KEY`
- Test coverage for SECRET_KEY fallback

## Testing
- `pytest tests/test_settings.py` *(fails: ModuleNotFoundError: No module named 'config')*

------
https://chatgpt.com/codex/tasks/task_e_68be30a7d6a8832c96e52c24f609ff20