### PR TITLE
chore: rely on release_command for migrations

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -32,12 +32,8 @@ PY
   echo "Set DJANGO_SECRET_KEY."
 fi
 
-# Deploy using the committed Dockerfile
+# Deploy using the committed Dockerfile; release_command in fly.toml runs migrations
 fly deploy --remote-only --dockerfile Dockerfile "$@"
-
-# Run database migrations
-fly ssh console -C "python manage.py migrate --noinput" || \
-  echo "WARNING: migrate failed via SSH; check logs."
 
 # Basic status and reachability
 fly status

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -35,7 +35,7 @@ git commit -m "alpha: public signup + header auth + submit CTA + seeds"
 # PowerShell
 $REV = (Get-Date).ToString("yyyyMMddHHmmss")
 flyctl deploy -a surejan --remote-only --build-arg BUILD_REV=$REV
-flyctl ssh console -a surejan -C "python manage.py migrate --noinput"
+# migrations run automatically via fly.toml release_command
 flyctl ssh console -a surejan -C "python manage.py seed_basics"
 flyctl logs -a surejan | Select-String -Pattern "ERROR|Traceback|favicon|collectstatic"
 ```


### PR DESCRIPTION
## Summary
- drop manual fly ssh migrate step from deploy script
- note automatic migrations in deploy docs

## Testing
- `pytest` *(fails: Requested setting INSTALLED_APPS...)*

------
https://chatgpt.com/codex/tasks/task_e_68be31a1a77c832cbcc050ee8059e036