### PR TITLE
Add History community seed

### DIFF
--- a/core/management/commands/seed_basics.py
+++ b/core/management/commands/seed_basics.py
@@ -9,8 +9,7 @@ class Command(BaseCommand):
         seeds = [
             ("news", "News"),
             ("brisbane", "Brisbane"),
-            
-            
+            ("history", "History"),
             ("politics", "Politics"),
             ("social", "Social"),
         ]


### PR DESCRIPTION
## Summary
- include History community in seed list

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'core')*
- `python manage.py migrate`
- `python manage.py seed_basics`


------
https://chatgpt.com/codex/tasks/task_e_68be38cb9794832ca85a308c470ff512