### PR TITLE
Include History community in static lists

### DIFF
--- a/core/tests/test_communities_index.py
+++ b/core/tests/test_communities_index.py
@@ -5,7 +5,7 @@ from django.urls import reverse
 class CommunitiesIndexTests(TestCase):
     def test_lists_communities(self):
         resp = self.client.get(reverse("communities_index"))
-        for name in ["News", "Brisbane", "Politics", "Social"]:
+        for name in ["News", "Brisbane", "History", "Politics", "Social"]:
             self.assertContains(resp, name)
 
     def test_header_sort_highlight(self):

--- a/core/views.py
+++ b/core/views.py
@@ -569,6 +569,7 @@ def communities_index(request):
     communities = [
         {"slug": "news", "name": "News"},
         {"slug": "brisbane", "name": "Brisbane"},
+        {"slug": "history", "name": "History"},
         {"slug": "politics", "name": "Politics"},
         {"slug": "social", "name": "Social"},
     ]

--- a/docs/UI-contract-V3.md
+++ b/docs/UI-contract-V3.md
@@ -20,7 +20,7 @@
 
 ## Left Sidebar
 - Title: Communities
-- Links: News, Brisbane, Politics, Social
+- Links: News, Brisbane, History, Politics, Social
 
 ## Right Sidebar
 - Account/Login

--- a/docs/V3-onepager.md
+++ b/docs/V3-onepager.md
@@ -4,7 +4,7 @@
 
 ## Scope
 - Pages: Main, Submit Post, Post Detail
-- Communities: News, Brisbane, Politics, Social
+- Communities: News, Brisbane, History, Politics, Social
 
 ## Grid
 - Frame: 1440px
@@ -19,7 +19,7 @@
 
 ## Left Sidebar
 - Label: Communities
-- Links: News, Brisbane, Politics, Social
+- Links: News, Brisbane, History, Politics, Social
 
 ## Right Sidebar
 - Account/Login

--- a/templates/core/partials/left_communities.html
+++ b/templates/core/partials/left_communities.html
@@ -2,6 +2,7 @@
 <nav class="comm-list" aria-label="Communities">
   <a href="{% url 'community' 'news' %}">c/news</a>
   <a href="{% url 'community' 'brisbane' %}">c/brisbane</a>
+  <a href="{% url 'community' 'history' %}">c/history</a>
   <a href="{% url 'community' 'politics' %}">c/politics</a>
   <a href="{% url 'community' 'social' %}">c/social</a>
 </nav>


### PR DESCRIPTION
## Summary
- Add History to communities index view and sidebar
- Document History community in V3 design specs
- Update test expectations for History community

## Testing
- `pytest core/tests/test_communities_index.py -q` *(fails: Requested setting DATABASES, but settings are not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68be39dc693c832caf9c1cad1c33598a