### PR TITLE
Add open-source basics

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,12 @@
+# Contributing
+
+Thanks for your interest in improving SureJan!
+
+- Fork the repo and create a branch for your change.
+- Keep pull requests small, focused, and well described.
+- Run the test suite with `pytest` before submitting.
+- For large features, open an issue first to discuss the approach.
+- Follow existing style and patterns in the codebase.
+- Never commit secrets. Use a `.env` for local development and `fly secrets` in production.
+
+We appreciate your contributions!

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Surejan Collective
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,68 +1,37 @@
-
----
-
 # SureJan
 
-SureJan is an independent, Brisbane-built community forum inspired by the old Reddit layout. It is designed to provide a fast and simple way for locals to post, comment, and vote without interference from algorithms, astroturfing, or excessive big-tech influence.
+SureJan is a lightweight, local-first forum inspired by old Reddit, built with Django + HTMX + Postgres, deployed on Fly.io.
 
-**Live site:** back under development as of 31/08/2025
+## Anti-astroturfing
 
-## V3 UI Specs
-- [V3 One-Pager](docs/V3-onepager.md) — quick summary
-- [UI Contract](docs/UI-contract-V3.md) — full layout and selectors
+SureJan includes a built‑in defence against coordinated manipulation:
 
-## Features (MVP)
+- Early votes are analysed in 30‑second buckets and grouped over 300 seconds.
+- Votes from new accounts are weighted differently to limit sockpuppet impact.
+- A threshold-based flagging system slows posts when the risk score rises, placing them in slowmode for review.
+- Only aggregate patterns are reviewed; personal data is never stored.
 
-* **Community Feeds**: Old-Reddit style feeds with sorting options (Hot, New, Top). Pagination set to 25 posts per page.
-* **Time Filters**: When sorting by Top, buttons let you view posts from the last 24 hours, last 7 days, or all time.
-* **Seed Communities**: Two initial communities, `news` and `brisbane`, seeded via a management command.
-* **User Accounts**: Username and password based authentication (email optional). Accounts display total “points” (sum of post and comment votes).
-* **Posts**: Supports text or link submissions. Posts can be assigned to communities and rendered with basic Markdown formatting.
-* **Comments**: Threaded comment trees with reply support, relative timestamps, and Markdown.
-* **Voting**: Upvote and downvote support for posts and comments. Voting updates dynamically with HTMX requests. Rate limits apply to reduce spam.
-* **Profiles**: Public user profiles with tabs for Overview, Posts, and Comments. Pagination provided for long histories.
-* **Authentication & Security**: Secure session cookies, CSRF protection, CAPTCHA during signup, recovery codes for account resets, and basic rate limiting.
+## Run locally
 
-## Tech Stack
-
-* **Backend**: Django 5, Python 3.12+
-* **Frontend**: HTMX for partial page updates, Django templates for rendering
-* **Database**: Postgres, SQLite fallback for development
-* **Deployment**: Fly.io with Docker-based builds
-* **Static Files**: WhiteNoise for static file serving, S3-compatible storage for media (Tigris),
-  with a local `/media/` fallback when S3 credentials are missing or placeholders
-* **Security**: django-csp, CSRF protection, secure session and cookie handling
-* **Testing**: Django test framework with HTMX request coverage
-
-## Development Setup
-
-```bash
-git clone https://github.com/Dexter2099/SureJan.git
-cd SureJan
+```powershell
 python -m venv .venv
-source .venv/bin/activate   # or .venv\Scripts\activate on Windows
+.\.venv\Scripts\Activate.ps1
 pip install -r requirements.txt
+copy .env.example .env   # Or create manually on Windows
 python manage.py migrate
-python manage.py seed_basics
 python manage.py runserver
 ```
 
-Visit `http://127.0.0.1:8000` to access the dev server.
+### Environment variables
 
-### Feature flags
+- `DJANGO_SECRET_KEY` – random string, required
+- `DATABASE_URL`
+- `MEDIA_URL`
+- `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`
+- `SENTRY_DSN` – optional
 
-Set the `ASTROTURF_WATCH` environment variable to control astroturf-detection
-features. It defaults to `1`; set `ASTROTURF_WATCH=0` to hide engagement chips
-and transparency pages.
+Production secrets are set via `fly secrets` and should never be committed to the repo.
 
-## Status
+## License
 
-SureJan is an early-stage MVP. Contributions, bug reports, and feedback are welcome.
-This project was developed and MVP shipped in three weeks with the use of AI coding agents.
-
----
-
-
-
-<img width="673" height="718" alt="Surejan Public beta" src="https://github.com/user-attachments/assets/6086515d-cfd1-44b7-8591-b21057b975ff" />
-
+This project is licensed under the [MIT License](LICENSE).


### PR DESCRIPTION
## Summary
- add MIT license for SureJan Collective
- rewrite README with anti-astroturfing details and local setup
- document contribution guidelines

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'core'; settings are not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68be55507ba8832c9e05f59484b4cb95