### PR TITLE
Add explicit max length validators to forms

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -1,5 +1,9 @@
 from django import forms
-from django.core.validators import FileExtensionValidator
+from django.core.validators import (
+    FileExtensionValidator,
+    MaxLengthValidator,
+    URLValidator,
+)
 from django.utils.text import slugify
 
 import bleach
@@ -37,11 +41,19 @@ class PostForm(forms.Form):
 
     community = forms.ModelChoiceField(queryset=Community.objects.all(), required=True)
     post_type = forms.ChoiceField(choices=POST_TYPES, widget=forms.RadioSelect)
-    title = forms.CharField(max_length=300)
-    body = forms.CharField(
-        widget=forms.Textarea(attrs={"data-editor": "1"}), required=False
+    title = forms.CharField(
+        max_length=140, validators=[MaxLengthValidator(140)]
     )
-    content_url = forms.URLField(required=False)
+    body = forms.CharField(
+        widget=forms.Textarea(attrs={"data-editor": "1"}),
+        required=False,
+        validators=[MaxLengthValidator(10000)],
+    )
+    content_url = forms.CharField(
+        max_length=2048,
+        validators=[MaxLengthValidator(2048), URLValidator()],
+        required=False,
+    )
     image = forms.ImageField(
         required=False,
         validators=[
@@ -106,10 +118,16 @@ class PostForm(forms.Form):
 
 
 class CommentForm(forms.ModelForm):
+    body = forms.CharField(
+        widget=forms.Textarea(
+            attrs={"rows": 3, "data-editor": "1", "maxlength": 10000}
+        ),
+        validators=[MaxLengthValidator(10000)],
+    )
+
     class Meta:
         model = Comment
         fields = ["body"]
-        widgets = {"body": forms.Textarea(attrs={"rows": 3, "data-editor": "1"})}
 
     def clean_body(self):
         body = (self.cleaned_data.get("body") or "").strip()
@@ -125,6 +143,7 @@ class CommunityCreateForm(forms.ModelForm):
 
     def clean_slug(self):
         slug = slugify(self.cleaned_data.get("slug", ""))
+        MaxLengthValidator(191)(slug)
         if not slug:
             raise forms.ValidationError("Slug is required.")
         if Community.objects.filter(slug=slug).exists():

--- a/core/views.py
+++ b/core/views.py
@@ -33,6 +33,7 @@ from django.db.models import F
 from django import forms
 from django.core.exceptions import ValidationError
 from django.core.paginator import Paginator
+from django.core.validators import MaxLengthValidator
 
 from django.core.cache import cache
 from django.utils.cache import patch_cache_control
@@ -224,7 +225,9 @@ def post_signals_json(request, pk):
 
 
 class SignupForm(forms.Form):
-    username = forms.CharField(max_length=150)
+    username = forms.CharField(
+        max_length=191, validators=[MaxLengthValidator(191)]
+    )
     password = forms.CharField(widget=forms.PasswordInput)
     captcha = forms.IntegerField(required=False)
 


### PR DESCRIPTION
## Summary
- tighten PostForm field constraints with explicit max length validators
- limit comment bodies and community slugs to 10k/191 chars
- restrict signup usernames to 191 characters

## Testing
- `pytest -q --maxfail=1` *(fails: CommunitiesIndexTests::test_header_sort_highlight)*

------
https://chatgpt.com/codex/tasks/task_e_68be5df62d18832c91f984e417acdcab