### PR TITLE
Handle oversized field errors when saving posts and comments

### DIFF
--- a/core/tests/test_length_errors.py
+++ b/core/tests/test_length_errors.py
@@ -1,0 +1,70 @@
+from unittest.mock import patch
+
+from django.contrib.auth import get_user_model
+from django.core.cache import cache
+from django.db import DataError
+from django.test import TestCase
+from django.urls import reverse
+
+from core.models import Community, Post
+
+
+class LengthErrorHandlingTests(TestCase):
+    def setUp(self):
+        cache.clear()
+        user_model = get_user_model()
+        self.user = user_model.objects.create_user("alice", password="pwd")
+        self.community = Community.objects.create(
+            slug="t", name="Test", title="Test", created_by=self.user
+        )
+        self.post = Post.objects.create(
+            community=self.community,
+            author=self.user,
+            post_type="text",
+            title="Hello",
+        )
+        self.client.login(username="alice", password="pwd")
+
+    def test_post_submit_data_error(self):
+        url = reverse("post_submit")
+        data = {
+            "community": self.community.pk,
+            "post_type": "text",
+            "title": "Hi",
+            "body": "Body",
+        }
+        with patch("core.views.Post.save", side_effect=DataError("too long")):
+            resp = self.client.post(url, data)
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn(
+            "One or more fields exceed the allowed length.",
+            resp.context["form"].non_field_errors(),
+        )
+
+    def test_comment_reply_data_error(self):
+        url = reverse("comment_reply", args=[self.post.pk])
+        with patch(
+            "core.views.Comment.objects.create", side_effect=DataError("too long")
+        ):
+            resp = self.client.post(
+                url, {"body": "Hi"}, HTTP_HX_REQUEST="true"
+            )
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn(
+            "One or more fields exceed the allowed length.",
+            resp.context["form"].non_field_errors(),
+        )
+
+    def test_comment_create_data_error(self):
+        url = reverse("comment_create")
+        data = {"post": self.post.pk, "body": "Hi"}
+        with patch(
+            "core.views.Comment.objects.create", side_effect=DataError("too long")
+        ):
+            resp = self.client.post(url, data, HTTP_HX_REQUEST="true")
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn(
+            "One or more fields exceed the allowed length.",
+            resp.context["form"].non_field_errors(),
+        )
+

--- a/core/views.py
+++ b/core/views.py
@@ -5,6 +5,8 @@ import secrets
 import string
 import hashlib
 import json
+import logging
+from types import SimpleNamespace
 from datetime import timedelta
 
 import bleach
@@ -29,6 +31,7 @@ from django.conf import settings
 from django.http import Http404, HttpResponse, HttpResponseBadRequest, HttpResponseForbidden
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils import timezone
+from django.db import DataError, IntegrityError
 from django.db.models import F
 from django import forms
 from django.core.exceptions import ValidationError
@@ -55,6 +58,9 @@ from . import mod
 from .http import login_required_htmx
 
 
+logger = logging.getLogger(__name__)
+
+
 def _is_banned(user):
     return getattr(getattr(user, "profile", None), "is_banned", False)
 
@@ -74,6 +80,24 @@ def limit_or_429(request, group, rate):
         method=["POST"],
         increment=True,
     )
+
+
+def _find_offending_field(form):
+    for name, field in form.fields.items():
+        value = form.data.get(name)
+        if value is None:
+            continue
+        try:
+            length = len(value)
+        except TypeError:
+            continue
+        maxlen = getattr(field, "max_length", None)
+        if maxlen and length > maxlen:
+            return name, length
+        for validator in field.validators:
+            if isinstance(validator, MaxLengthValidator) and length > validator.limit_value:
+                return name, length
+    return "unknown", 0
 
 
 markdown_renderer = mistune.create_markdown()
@@ -539,7 +563,15 @@ def post_submit(request):
                 except UnidentifiedImageError:
                     raise ValidationError("Uploaded file is not a valid image.")
                 post.image = uploaded
-            post.save()
+            try:
+                post.save()
+            except (DataError, IntegrityError):
+                field, size = _find_offending_field(form)
+                logger.error("path=%s field=%s size=%s", request.path, field, size)
+                form.add_error(
+                    None, "One or more fields exceed the allowed length."
+                )
+                return render(request, "core/submit.html", {"form": form}, status=400)
             messages.success(request, "Post submitted")
             return redirect(
                 "post_detail",
@@ -831,14 +863,34 @@ def comment_reply(request, post_id):
         root_seq = post.comments.filter(parent__isnull=True).count() + 1
         path = f"{root_seq:04d}"
 
-    comment = Comment.objects.create(
-        post=post,
-        author=request.user,
-        parent=parent,
-        body=form.cleaned_data["body"],
-        path=path,
-    )
-    Post.objects.filter(pk=post.pk).update(comment_count=F("comment_count") + 1)
+    try:
+        comment = Comment.objects.create(
+            post=post,
+            author=request.user,
+            parent=parent,
+            body=form.cleaned_data["body"],
+            path=path,
+        )
+        Post.objects.filter(pk=post.pk).update(
+            comment_count=F("comment_count") + 1
+        )
+    except (DataError, IntegrityError):
+        field, size = _find_offending_field(form)
+        logger.error("path=%s field=%s size=%s", request.path, field, size)
+        form.add_error(
+            None, "One or more fields exceed the allowed length."
+        )
+        class Dummy(SimpleNamespace):
+            def __bool__(self):
+                return False
+
+        dummy = Dummy(pk=None)
+        return render(
+            request,
+            "core/partials/comment_form.html",
+            {"form": form, "post": post, "parent": parent or dummy, "comment": dummy},
+            status=400,
+        )
 
     if request.headers.get("HX-Request") == "true":
         depth = comment.path.count("/")
@@ -960,16 +1012,35 @@ def comment_create(request):
     else:
         root_seq = post.comments.filter(parent__isnull=True).count() + 1
         path = f"{root_seq:04d}"
+    try:
+        comment = Comment.objects.create(
+            post=post,
+            author=request.user,
+            parent=parent,
+            body=form.cleaned_data["body"],
+            path=path,
+        )
+        Post.objects.filter(pk=post.pk).update(
+            comment_count=F("comment_count") + 1
+        )
+        post.refresh_from_db(fields=["comment_count"])
+    except (DataError, IntegrityError):
+        field, size = _find_offending_field(form)
+        logger.error("path=%s field=%s size=%s", request.path, field, size)
+        form.add_error(
+            None, "One or more fields exceed the allowed length."
+        )
+        class Dummy(SimpleNamespace):
+            def __bool__(self):
+                return False
 
-    comment = Comment.objects.create(
-        post=post,
-        author=request.user,
-        parent=parent,
-        body=form.cleaned_data["body"],
-        path=path,
-    )
-    Post.objects.filter(pk=post.pk).update(comment_count=F("comment_count") + 1)
-    post.refresh_from_db(fields=["comment_count"])
+        dummy = Dummy(pk=None)
+        return render(
+            request,
+            "core/partials/comment_form.html",
+            {"form": form, "post": post, "parent": parent or dummy, "comment": dummy},
+            status=400,
+        )
 
     if request.headers.get("HX-Request") == "true":
         item_html = render_to_string(


### PR DESCRIPTION
## Summary
- log request path and offending field when saving a post or comment triggers a database length error
- surface a user-facing non-field error and re-render the form with HTTP 400
- cover these scenarios with tests

## Testing
- `pytest core/tests/test_length_errors.py`
- `pytest` *(fails: 13 failed, 155 passed, 2 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68be5fa83868832c89fb220833a0640f