### PR TITLE
Add explicit maxlengths and char count displays

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -45,7 +45,7 @@ class PostForm(forms.Form):
         max_length=140, validators=[MaxLengthValidator(140)]
     )
     body = forms.CharField(
-        widget=forms.Textarea(attrs={"data-editor": "1"}),
+        widget=forms.Textarea(attrs={"data-editor": "1", "maxlength": 10000}),
         required=False,
         validators=[MaxLengthValidator(10000)],
     )

--- a/templates/core/partials/comment_form.html
+++ b/templates/core/partials/comment_form.html
@@ -35,7 +35,7 @@
                 hx-swap="innerHTML">Preview</button>
       </div>
       {% include "core/partials/editor_toolbar.html" %} {# formatting toolbar #}
-      {{ form.body }}
+      <textarea name="{{ form.body.name }}" id="{{ form.body.id_for_label }}" rows="3" cols="40" data-editor="1" maxlength="10000" required>{{ form.body.value|default_if_none:'' }}</textarea>
       <div class="char-count"></div>
       <div id="{{ preview_id }}" class="preview" style="display:none"></div>
     </div>

--- a/templates/core/submit.html
+++ b/templates/core/submit.html
@@ -19,6 +19,7 @@
     </div>
     <div class="form-row">
       {{ form.title.label_tag }} {{ form.title }}
+      <div class="char-count"></div>
       {{ form.title.errors }}
     </div>
     <div class="form-row">
@@ -34,6 +35,7 @@
       <div class="editor-container prose">
         {% include "core/partials/editor_toolbar.html" %}
         {{ form.body }}
+        <div class="char-count"></div>
       </div>
       {{ form.body.errors }}
     </div>

--- a/templates/registration/signup.html
+++ b/templates/registration/signup.html
@@ -5,7 +5,7 @@
 <form method="post" hx-boost="false" hx-swap="none">
   {% csrf_token %}
   {{ form.username.errors }}
-  <p>{{ form.username.label_tag }} {{ form.username }}</p>
+  <p>{{ form.username.label_tag }} {{ form.username }}<span class="char-count"></span></p>
   {{ form.password.errors }}
   <p>{{ form.password.label_tag }} {{ form.password }}</p>
   {% if captcha_question %}


### PR DESCRIPTION
## Summary
- Add maxlength to post body field and surface char counters in submit form
- Ensure comment form textarea uses explicit maxlength and retains char counter
- Include username char counter on signup page

## Testing
- `pytest core/tests/test_comment_edit.py::CommentEditTests::test_author_can_edit_within_window -q`
- `pytest core/tests/test_length_errors.py::LengthErrorHandlingTests::test_post_submit_data_error -q`
- `pytest tests/test_smoke_v2.py::test_signup_submit_sort_and_commands -q`
- `pytest` *(fails: 13 failed, 155 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68be61d28284832c9990bd964df7a0d0