### PR TITLE
feat: add data-max attributes for editors

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -45,7 +45,9 @@ class PostForm(forms.Form):
         max_length=140, validators=[MaxLengthValidator(140)]
     )
     body = forms.CharField(
-        widget=forms.Textarea(attrs={"data-editor": "1", "maxlength": 10000}),
+        widget=forms.Textarea(
+            attrs={"data-editor": "1", "maxlength": 10000, "data-max": 10000}
+        ),
         required=False,
         validators=[MaxLengthValidator(10000)],
     )
@@ -120,7 +122,7 @@ class PostForm(forms.Form):
 class CommentForm(forms.ModelForm):
     body = forms.CharField(
         widget=forms.Textarea(
-            attrs={"rows": 3, "data-editor": "1", "maxlength": 10000}
+            attrs={"rows": 3, "data-editor": "1", "maxlength": 10000, "data-max": 10000}
         ),
         validators=[MaxLengthValidator(10000)],
     )

--- a/templates/core/partials/comment_form.html
+++ b/templates/core/partials/comment_form.html
@@ -35,7 +35,7 @@
                 hx-swap="innerHTML">Preview</button>
       </div>
       {% include "core/partials/editor_toolbar.html" %} {# formatting toolbar #}
-      <textarea name="{{ form.body.name }}" id="{{ form.body.id_for_label }}" rows="3" cols="40" data-editor="1" maxlength="10000" required>{{ form.body.value|default_if_none:'' }}</textarea>
+      <textarea name="{{ form.body.name }}" id="{{ form.body.id_for_label }}" rows="3" cols="40" data-editor="1" maxlength="10000" data-max="10000" required>{{ form.body.value|default_if_none:'' }}</textarea>
       <div class="char-count"></div>
       <div id="{{ preview_id }}" class="preview" style="display:none"></div>
     </div>

--- a/templates/core/partials/reply_form.html
+++ b/templates/core/partials/reply_form.html
@@ -4,7 +4,7 @@
       hx-swap="beforeend"
       method="post">
   {% csrf_token %}
-  <textarea name="body" rows="3" required></textarea>
+  <textarea name="body" rows="3" maxlength="10000" data-max="10000" required></textarea>
   <input type="hidden" name="parent_id" value="{{ parent_id }}">
   <div class="form-actions">
     <button type="reset">Cancel</button>

--- a/templates/core/post_detail.html
+++ b/templates/core/post_detail.html
@@ -76,7 +76,7 @@
             hx-swap="beforeend"
             method="post">
         {% csrf_token %}
-        <textarea name="body" rows="4" required></textarea>
+        <textarea name="body" rows="4" maxlength="10000" data-max="10000" required></textarea>
         <div class="form-actions">
           <button type="reset">Cancel</button>
           <button type="submit">Comment</button>


### PR DESCRIPTION
## Summary
- ensure post and comment forms expose `data-max` for the character counter
- add matching attributes on standalone comment textareas

## Testing
- `pytest` *(fails: CommunitiesIndexTests::test_header_sort_highlight, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68be63d678d8832c848eda14e5c351c6