### PR TITLE
Include CSRF token in HTMX requests and handle 403 errors

### DIFF
--- a/static/js/htmx-errors.js
+++ b/static/js/htmx-errors.js
@@ -1,0 +1,8 @@
+// Displays a message when HTMX requests fail with a 403 status
+(function () {
+  document.body.addEventListener('htmx:responseError', function (evt) {
+    if (evt.detail.xhr.status === 403) {
+      alert('Session expired—please refresh.');
+    }
+  });
+})();

--- a/templates/core/base.html
+++ b/templates/core/base.html
@@ -10,7 +10,8 @@
   <link rel="icon" type="image/x-icon" href="{% static 'img/favicon.ico' %}">
   {% block head %}{% endblock %}
 </head>
-<body class="layout-root">
+<body class="layout-root" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'>
+  <div hidden>{% csrf_token %}</div>
   {% include "core/partials/header.html" %}
   <main id="app-main" class="layout-main" role="main">
     <div class="page">
@@ -34,7 +35,7 @@
   <!-- HTMX (local) -->
   <script src="{% static 'js/htmx.min.js' %}" defer></script>
   <script src="{% static 'js/htmx-guard.js' %}" defer></script>
-  <script src="{% static 'js/htmx-csrf.js' %}" defer></script>
+  <script src="{% static 'js/htmx-errors.js' %}" defer></script>
   {% block scripts %}{% endblock %}
 </body>
 </html>


### PR DESCRIPTION
## Summary
- attach CSRF token to all HTMX requests via `hx-headers`
- notify users when an HTMX request returns 403

## Testing
- `pytest` *(fails: CommunitiesIndexTests, CommunityCreateTests, FeedRangeFilterTests, PostFormValidationTests, PostSubmitTests)*
- `curl -I -X POST http://127.0.0.1:8000/accounts/login/`
- `playwright install chromium` *(fails: Download failed: Domain forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68be67e5f0d0832c8bb7ad5c87831e7f