### PR TITLE
Add allowed host handling and integration tests

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -54,6 +54,13 @@ if _env_hosts:
 else:
     ALLOWED_HOSTS = DEFAULT_HOSTS
 
+ALLOWED_HOSTS = list(
+    sorted(
+        set(ALLOWED_HOSTS)
+        | {"surejan.app", "www.surejan.app", ".fly.dev", "127.0.0.1"}
+    )
+)
+
 CSRF_TRUSTED_ORIGINS = [
     "https://surejan.onrender.com",
     "https://surejan.fly.dev",

--- a/config/urls.py
+++ b/config/urls.py
@@ -37,3 +37,6 @@ if settings.DEBUG:
     urlpatterns += serve_static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
     urlpatterns += serve_static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
 
+
+handler400 = "core.views.disallowed_host"
+

--- a/core/views.py
+++ b/core/views.py
@@ -61,6 +61,11 @@ from .http import login_required_htmx
 logger = logging.getLogger(__name__)
 
 
+def disallowed_host(request, exception=None):
+    """Render a friendly message for disallowed host errors."""
+    return HttpResponseBadRequest("Unknown host—check the URL")
+
+
 def _is_banned(user):
     return getattr(getattr(user, "profile", None), "is_banned", False)
 

--- a/tests/test_allowed_hosts.py
+++ b/tests/test_allowed_hosts.py
@@ -1,0 +1,14 @@
+import pytest
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("host", [
+    "surejan.app",
+    "www.surejan.app",
+    "foo.fly.dev",
+    "127.0.0.1",
+])
+def test_allowed_hosts_no_disallowed_error(client, settings, host):
+    settings.DEBUG = False
+    resp = client.get("/", HTTP_HOST=host)
+    assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- extend ALLOWED_HOSTS with production domains
- serve friendly message for disallowed hosts
- test known hosts to prevent DisallowedHost errors

## Testing
- `pytest` *(fails: CommunitiesIndexTests::test_header_sort_highlight, ...)*
- `pytest tests/test_allowed_hosts.py`


------
https://chatgpt.com/codex/tasks/task_e_68be6f7e9e94832ca4312bb26e3777c2