### PR TITLE
Handle out-of-range pagination

### DIFF
--- a/core/tests/test_pagination.py
+++ b/core/tests/test_pagination.py
@@ -11,7 +11,7 @@ class PaginationTests(TestCase):
         user_model = get_user_model()
         self.user = user_model.objects.create_user("alice", password="pwd")
         self.community = Community.objects.create(
-            slug="t", name="Test", title="Test", created_by=self.user
+            slug="news", name="News", title="News", created_by=self.user
         )
         for i in range(40):
             Post.objects.create(
@@ -41,4 +41,12 @@ class PaginationTests(TestCase):
 
     def test_last_page_no_next(self):
         resp = self.client.get(reverse("feed_list") + "?page=3", HTTP_HX_REQUEST="true")
+        self.assertIsNone(resp.context.get("next_page"))
+
+    def test_out_of_range_page_clamped(self):
+        url = reverse("community", kwargs={"slug": self.community.slug}) + "?page=9999"
+        resp = self.client.get(url)
+        self.assertEqual(resp.status_code, 200)
+        # 40 posts with PAGE_SIZE 15 -> last page has 10 posts
+        self.assertEqual(len(resp.context["posts"]), 40 - 2 * PAGE_SIZE)
         self.assertIsNone(resp.context.get("next_page"))

--- a/core/views.py
+++ b/core/views.py
@@ -35,7 +35,7 @@ from django.db import DataError, IntegrityError
 from django.db.models import F
 from django import forms
 from django.core.exceptions import ValidationError
-from django.core.paginator import Paginator
+from django.core.paginator import EmptyPage, Paginator
 from django.core.validators import MaxLengthValidator
 
 from django.core.cache import cache
@@ -217,8 +217,20 @@ def transparency_posts(request):
     rows.sort(key=lambda x: x.get(key, 0), reverse=reverse)
 
     paginator = Paginator(rows, 20)
-    page_number = request.GET.get("page")
-    page_obj = paginator.get_page(page_number)
+    page_param = request.GET.get("page", "1")
+    try:
+        requested = int(page_param)
+    except (TypeError, ValueError):
+        messages.error(request, "Invalid page number.")
+        return redirect(request.path)
+    if requested < 1:
+        messages.error(request, "Invalid page number.")
+        return redirect(request.path)
+    page = max(1, min(requested, paginator.num_pages))
+    try:
+        page_obj = paginator.page(page)
+    except EmptyPage:
+        page_obj = paginator.page(paginator.num_pages)
 
     ctx = {"page_obj": page_obj, "sort": sort}
     return render(request, "core/transparency_posts.html", ctx)
@@ -459,12 +471,24 @@ def feed_list(request):
         t = "all"
 
     if request.headers.get("HX-Request") == "true":
-        page = int(request.GET.get("page", "1") or 1)
+        page_param = request.GET.get("page", "1")
+        try:
+            requested = int(page_param)
+        except (TypeError, ValueError):
+            messages.error(request, "Invalid page number.")
+            return redirect(request.path)
+        if requested < 1:
+            messages.error(request, "Invalid page number.")
+            return redirect(request.path)
         size = int(request.GET.get("size", PAGE_SIZE) or PAGE_SIZE)
         base_qs = Post.objects.filter(is_deleted=False).select_related("community", "author")
         qs = feed_queryset(tab, t, base_qs=base_qs)
         paginator = Paginator(qs, size)
-        page_obj = paginator.get_page(page)
+        page = max(1, min(requested, paginator.num_pages))
+        try:
+            page_obj = paginator.page(page)
+        except EmptyPage:
+            page_obj = paginator.page(paginator.num_pages)
         posts = list(page_obj.object_list)
         ctx = {
             "posts": posts,
@@ -641,15 +665,27 @@ def community(request, slug):
     if sort == "top" and t is None:
         t = "all"
 
-    page = int(request.GET.get("page", "1") or 1)
+    page_param = request.GET.get("page", "1")
+    try:
+        requested = int(page_param)
+    except (TypeError, ValueError):
+        messages.error(request, "Invalid page number.")
+        return redirect(request.path)
+    if requested < 1:
+        messages.error(request, "Invalid page number.")
+        return redirect(request.path)
 
     base_qs = community.posts.filter(is_deleted=False).select_related("author")
     qs = feed_queryset(sort, t, base_qs=base_qs)
 
-    offset = (page - 1) * PAGE_SIZE
-    posts = list(qs[offset : offset + PAGE_SIZE + 1])
-    next_page = page + 1 if len(posts) > PAGE_SIZE else None
-    posts = posts[:PAGE_SIZE]
+    paginator = Paginator(qs, PAGE_SIZE)
+    page = max(1, min(requested, paginator.num_pages))
+    try:
+        page_obj = paginator.page(page)
+    except EmptyPage:
+        page_obj = paginator.page(paginator.num_pages)
+    posts = list(page_obj.object_list)
+    next_page = page_obj.next_page_number() if page_obj.has_next() else None
 
     sort_query = ""
     if sort and sort != "hot":


### PR DESCRIPTION
## Summary
- sanitize `page` query parameter and clamp to last page in transparency, feed, and community views
- add test ensuring `/r/news?page=9999` returns a valid page

## Testing
- `pytest core/tests/test_pagination.py::PaginationTests::test_out_of_range_page_clamped -q`
- `pytest` *(fails: CommunitiesIndexTests::test_header_sort_highlight, CommunitiesIndexTests::test_lists_communities, CommunityCreateTests::test_a_staff_can_view_and_create, CommunityCreateTests::test_b_non_staff_forbidden, CommunityCreateTests::test_c_duplicate_rejected, CommunityCreateTests::test_d_rate_limit, FeedRangeFilterHTMXTests::test_24h_filter, FeedRangeFilterHTMXTests::test_7d_filter, FeedRangeFilterHomeTests::test_24h_filter, FeedRangeFilterHomeTests::test_7d_filter, FeedRangeFilterHomeTests::test_all_filter, PostFormValidationTests::test_image_with_caption_allowed, PostSubmitTests::test_large_upload_rejected, test_env_allowed_hosts_override)*

------
https://chatgpt.com/codex/tasks/task_e_68be70f9f7d4832ca717da8a178e069b