### PR TITLE
Add generic error handlers with HTMX support

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -38,5 +38,10 @@ if settings.DEBUG:
     urlpatterns += serve_static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
 
 
-handler400 = "core.views.disallowed_host"
+handler400 = "core.views.handler400"
+handler403 = "core.views.handler403"
+handler404 = "core.views.handler404"
+handler500 = "core.views.handler500"
+handler429 = "core.views.handler429"
+request_too_big = "core.views.request_too_big"
 

--- a/core/tests/test_error_handlers.py
+++ b/core/tests/test_error_handlers.py
@@ -1,0 +1,43 @@
+from django.test import SimpleTestCase, override_settings
+from django.urls import path
+
+from core import views as core_views
+from config.urls import urlpatterns as base_urlpatterns
+
+urlpatterns = base_urlpatterns + [
+    path("400/", core_views.handler400),
+    path("403/", core_views.handler403),
+    path("404/", core_views.handler404),
+    path("500/", core_views.handler500),
+    path("429/", core_views.handler429),
+    path("413/", core_views.request_too_big),
+]
+
+
+@override_settings(ROOT_URLCONF=__name__)
+class ErrorHandlerTests(SimpleTestCase):
+    def _check(self, url, code):
+        resp = self.client.get(url)
+        self.assertEqual(resp.status_code, code)
+        self.assertTemplateUsed(resp, f"errors/{code}.html")
+        resp = self.client.get(url, HTTP_HX_REQUEST="true")
+        self.assertEqual(resp.status_code, code)
+        self.assertTemplateUsed(resp, f"errors/partials/{code}.html")
+
+    def test_400(self):
+        self._check("/400/", 400)
+
+    def test_403(self):
+        self._check("/403/", 403)
+
+    def test_404(self):
+        self._check("/404/", 404)
+
+    def test_500(self):
+        self._check("/500/", 500)
+
+    def test_429(self):
+        self._check("/429/", 429)
+
+    def test_413(self):
+        self._check("/413/", 413)

--- a/core/views.py
+++ b/core/views.py
@@ -34,7 +34,7 @@ from django.utils import timezone
 from django.db import DataError, IntegrityError
 from django.db.models import F
 from django import forms
-from django.core.exceptions import ValidationError
+from django.core.exceptions import ValidationError, RequestDataTooBig
 from django.core.paginator import EmptyPage, Paginator
 from django.core.validators import MaxLengthValidator
 
@@ -64,6 +64,43 @@ logger = logging.getLogger(__name__)
 def disallowed_host(request, exception=None):
     """Render a friendly message for disallowed host errors."""
     return HttpResponseBadRequest("Unknown host—check the URL")
+
+
+def _error_template(request, code):
+    """Return full or HTMX partial error template path."""
+    if request.headers.get("HX-Request") == "true":
+        return f"errors/partials/{code}.html"
+    return f"errors/{code}.html"
+
+
+def handler400(request, exception=None):
+    """Render 400 Bad Request page."""
+    return render(request, _error_template(request, 400), status=400)
+
+
+def handler403(request, exception=None):
+    """Render 403 Forbidden page."""
+    return render(request, _error_template(request, 403), status=403)
+
+
+def handler404(request, exception=None):
+    """Render 404 Not Found page."""
+    return render(request, _error_template(request, 404), status=404)
+
+
+def handler500(request):
+    """Render 500 Server Error page."""
+    return render(request, _error_template(request, 500), status=500)
+
+
+def handler429(request, exception=None):
+    """Render 429 Too Many Requests page."""
+    return render(request, _error_template(request, 429), status=429)
+
+
+def request_too_big(request, exception: RequestDataTooBig | None = None):
+    """Render 413 Request Entity Too Large page."""
+    return render(request, _error_template(request, 413), status=413)
 
 
 def _is_banned(user):

--- a/templates/errors/400.html
+++ b/templates/errors/400.html
@@ -1,0 +1,5 @@
+{% extends "core/base.html" %}
+{% block content %}
+<h1>Bad request</h1>
+<p>The request could not be understood.</p>
+{% endblock %}

--- a/templates/errors/403.html
+++ b/templates/errors/403.html
@@ -1,0 +1,5 @@
+{% extends "core/base.html" %}
+{% block content %}
+<h1>Permission denied</h1>
+<p>You do not have access to this resource.</p>
+{% endblock %}

--- a/templates/errors/404.html
+++ b/templates/errors/404.html
@@ -1,0 +1,5 @@
+{% extends "core/base.html" %}
+{% block content %}
+<h1>Page not found</h1>
+<p>The page you requested could not be found.</p>
+{% endblock %}

--- a/templates/errors/413.html
+++ b/templates/errors/413.html
@@ -1,0 +1,5 @@
+{% extends "core/base.html" %}
+{% block content %}
+<h1>Request too large</h1>
+<p>The data submitted exceeds the allowed size.</p>
+{% endblock %}

--- a/templates/errors/429.html
+++ b/templates/errors/429.html
@@ -1,0 +1,5 @@
+{% extends "core/base.html" %}
+{% block content %}
+<h1>Too many requests</h1>
+<p>Please slow down and try again later.</p>
+{% endblock %}

--- a/templates/errors/500.html
+++ b/templates/errors/500.html
@@ -1,0 +1,5 @@
+{% extends "core/base.html" %}
+{% block content %}
+<h1>Server error</h1>
+<p>Something went wrong. Please try again later.</p>
+{% endblock %}

--- a/templates/errors/partials/400.html
+++ b/templates/errors/partials/400.html
@@ -1,0 +1,4 @@
+<div class="error">
+  <h1>Bad request</h1>
+  <p>The request could not be understood.</p>
+</div>

--- a/templates/errors/partials/403.html
+++ b/templates/errors/partials/403.html
@@ -1,0 +1,4 @@
+<div class="error">
+  <h1>Permission denied</h1>
+  <p>You do not have access to this resource.</p>
+</div>

--- a/templates/errors/partials/404.html
+++ b/templates/errors/partials/404.html
@@ -1,0 +1,4 @@
+<div class="error">
+  <h1>Page not found</h1>
+  <p>The page you requested could not be found.</p>
+</div>

--- a/templates/errors/partials/413.html
+++ b/templates/errors/partials/413.html
@@ -1,0 +1,4 @@
+<div class="error">
+  <h1>Request too large</h1>
+  <p>The data submitted exceeds the allowed size.</p>
+</div>

--- a/templates/errors/partials/429.html
+++ b/templates/errors/partials/429.html
@@ -1,0 +1,4 @@
+<div class="error">
+  <h1>Too many requests</h1>
+  <p>Please slow down and try again later.</p>
+</div>

--- a/templates/errors/partials/500.html
+++ b/templates/errors/partials/500.html
@@ -1,0 +1,4 @@
+<div class="error">
+  <h1>Server error</h1>
+  <p>Something went wrong. Please try again later.</p>
+</div>


### PR DESCRIPTION
## Summary
- add HTML and HTMX-aware handlers for HTTP 400, 403, 404, 500, 429, and 413
- wire the new handlers into the root URLconf
- cover handlers with tests and provide templates under `templates/errors/`

## Testing
- `DJANGO_SETTINGS_MODULE=config.test_settings python manage.py test core.tests.test_error_handlers`
- `DJANGO_SETTINGS_MODULE=config.test_settings python manage.py test` *(fails: ModuleNotFoundError: No module named 'freezegun')*


------
https://chatgpt.com/codex/tasks/task_e_68be72ae1218832c89ed93a3e6f3b42e