### PR TITLE
Lock project to Django’s built-in user

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -158,11 +158,10 @@ INSTALLED_APPS = [
     "django_htmx",
     "csp",   # django-csp
     "storages",
-    "accounts",
     "core",
 ]
-
-AUTH_USER_MODEL = "accounts.User"
+# explicitly lock the project to Django's built-in user
+AUTH_USER_MODEL = "auth.User"
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",

--- a/docs/ops/runbooks/migrations.md
+++ b/docs/ops/runbooks/migrations.md
@@ -4,14 +4,14 @@ This runbook covers backing up the database and applying migrations for the `acc
 
 ## Confirm User Model
 
-Ensure Django is configured to use the custom user model:
+Ensure Django is configured to use Django's built-in user model:
 
 ```bash
 rg AUTH_USER_MODEL config/settings.py
 ```
 Expected output:
 ```
-AUTH_USER_MODEL = "accounts.User"
+AUTH_USER_MODEL = "auth.User"
 ```
 
 ## Back up Database


### PR DESCRIPTION
## Summary
- Lock project to Django’s built-in auth.User model and drop the unused accounts app
- Document the new AUTH_USER_MODEL in the migration runbook

## Testing
- `python manage.py test --settings=config.test_settings` *(fails: failures=9, errors=4, skipped=2)*

------
https://chatgpt.com/codex/tasks/task_e_68be7f6347e0832cac71094b54475d7d