### PR TITLE
fix slug migration dependencies

### DIFF
--- a/core/migrations/0031a_populate_slugs.py
+++ b/core/migrations/0031a_populate_slugs.py
@@ -32,7 +32,7 @@ class Migration(migrations.Migration):
 
     dependencies = [
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
-        ("core", "0030_remove_post_thumbnail_alt_remove_post_thumbnail_url"),
+        ("core", "0031b_schema_updates"),
     ]
 
     operations = [

--- a/core/migrations/0031b_schema_updates.py
+++ b/core/migrations/0031b_schema_updates.py
@@ -7,7 +7,7 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ("core", "0031a_populate_slugs"),
+        ("core", "0030_remove_post_thumbnail_alt_remove_post_thumbnail_url"),
     ]
 
     operations = [

--- a/core/migrations/0032_alignment.py
+++ b/core/migrations/0032_alignment.py
@@ -19,7 +19,7 @@ def backfill_slugs(apps, schema_editor):
 class Migration(migrations.Migration):
 
     dependencies = [
-        ("core", "0031b_schema_updates"),
+        ("core", "0031a_populate_slugs"),
     ]
 
     operations = [


### PR DESCRIPTION
## Summary
- order slug migrations so schema changes run before data migration
- update alignment migration to follow populate slugs

## Testing
- `python manage.py makemigrations`
- `python manage.py migrate` *(fails: near "EXISTS": syntax error)*
- `pytest` *(fail: near "EXISTS": syntax error)*

------
https://chatgpt.com/codex/tasks/task_e_68be9ab0f534832caffa6d6c5da692ab