### PR TITLE
Add image field validation for image posts

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -2,8 +2,13 @@ from django import forms
 from django.core.validators import MaxLengthValidator, URLValidator
 from django.utils.text import slugify
 
+import os
+from urllib.parse import urlparse
+
 import bleach
 import mistune
+import requests
+from PIL import Image
 
 from .models import Comment, Community
 from .utils.link_safety import check_url_safety
@@ -52,6 +57,8 @@ class PostForm(forms.Form):
         validators=[MaxLengthValidator(2048), URLValidator()],
         required=False,
     )
+    image = forms.ImageField(required=False)
+
     def clean_body(self):
         body = (self.cleaned_data.get("body") or "").strip()
         if not body:
@@ -65,12 +72,14 @@ class PostForm(forms.Form):
         content_url = (cleaned.get("content_url") or "").strip()
         post_type = cleaned.get("post_type")
         body = cleaned.get("body") or ""
+        image = cleaned.get("image")
 
         cleaned.update(
             {
                 "title": title,
                 "content_url": content_url,
                 "body": body,
+                "image": image,
             }
         )
 
@@ -85,7 +94,61 @@ class PostForm(forms.Form):
                 self.add_error("content_url", "Link is required for link posts.")
             elif not check_url_safety(content_url):
                 self.add_error("content_url", "URL flagged as unsafe.")
-        elif post_type != "image":
+        elif post_type == "image":
+            has_image = bool(image)
+            has_url = bool(content_url)
+            if has_image and has_url:
+                msg = "Choose either an image file or a content URL, not both."
+                self.add_error("image", msg)
+                self.add_error("content_url", msg)
+            elif not has_image and not has_url:
+                msg = "Provide a JPEG/PNG file or a valid image URL."
+                self.add_error("image", msg)
+                self.add_error("content_url", msg)
+            elif has_image:
+                if image.size > 5 * 1024 * 1024:
+                    self.add_error(
+                        "image", "Provide a JPEG/PNG file or a valid image URL."
+                    )
+                else:
+                    ext = os.path.splitext(image.name)[1].lower()
+                    if ext not in [".jpg", ".jpeg", ".png"]:
+                        self.add_error("image", "Only JPEG/PNG are supported.")
+                    else:
+                        try:
+                            image.file.seek(0)
+                            img = Image.open(image)
+                            if img.format not in ["JPEG", "PNG"]:
+                                self.add_error(
+                                    "image", "Only JPEG/PNG are supported."
+                                )
+                        except Exception:
+                            self.add_error(
+                                "image", "Only JPEG/PNG are supported."
+                            )
+            else:  # has_url
+                ext = os.path.splitext(urlparse(content_url).path)[1].lower()
+                if ext not in [".jpg", ".jpeg", ".png"]:
+                    self.add_error("content_url", "Only JPEG/PNG are supported.")
+                else:
+                    try:
+                        resp = requests.head(content_url, allow_redirects=True, timeout=5)
+                        content_type = resp.headers.get("Content-Type", "")
+                        content_length = int(resp.headers.get("Content-Length") or 0)
+                        if content_type not in ["image/jpeg", "image/png"]:
+                            self.add_error(
+                                "content_url", "Only JPEG/PNG are supported."
+                            )
+                        elif content_length > 5 * 1024 * 1024:
+                            self.add_error(
+                                "content_url",
+                                "Provide a JPEG/PNG file or a valid image URL.",
+                            )
+                    except Exception:
+                        self.add_error(
+                            "content_url", "Provide a JPEG/PNG file or a valid image URL."
+                        )
+        else:
             self.add_error("post_type", "Invalid post type.")
 
         return cleaned

--- a/core/tests/test_post_form_validation.py
+++ b/core/tests/test_post_form_validation.py
@@ -1,5 +1,10 @@
+from io import BytesIO
+from unittest.mock import Mock, patch
+
 from django.contrib.auth import get_user_model
+from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase
+from PIL import Image
 
 from core.forms import PostForm
 from core.models import Community
@@ -10,6 +15,15 @@ class PostFormValidationTests(TestCase):
         user = get_user_model().objects.create_user("alice", password="pwd")
         self.community = Community.objects.create(
             slug="t", name="Test", title="Test", created_by=user
+        )
+
+    def _image_file(self, fmt="JPEG", name="test.jpg"):
+        buffer = BytesIO()
+        Image.new("RGB", (1, 1)).save(buffer, format=fmt)
+        return SimpleUploadedFile(
+            name,
+            buffer.getvalue(),
+            content_type=f"image/{fmt.lower()}",
         )
 
     def test_title_only_rejected(self):
@@ -39,3 +53,93 @@ class PostFormValidationTests(TestCase):
             }
         )
         self.assertTrue(form.is_valid())
+
+    def test_image_post_requires_single_source(self):
+        img = self._image_file()
+        form = PostForm(
+            data={
+                "community": self.community.id,
+                "title": "T",
+                "post_type": "image",
+                "content_url": "http://example.com/x.jpg",
+            },
+            files={"image": img},
+        )
+        self.assertFalse(form.is_valid())
+        self.assertIn(
+            "Choose either an image file or a content URL, not both.",
+            form.errors["image"],
+        )
+
+        form = PostForm(
+            data={"community": self.community.id, "title": "T", "post_type": "image"}
+        )
+        self.assertFalse(form.is_valid())
+        self.assertIn(
+            "Provide a JPEG/PNG file or a valid image URL.",
+            form.errors["image"],
+        )
+
+    def test_image_post_valid_file(self):
+        img = self._image_file()
+        form = PostForm(
+            data={"community": self.community.id, "title": "T", "post_type": "image"},
+            files={"image": img},
+        )
+        self.assertTrue(form.is_valid())
+
+    def test_image_post_invalid_type(self):
+        gif = self._image_file(fmt="GIF", name="t.gif")
+        form = PostForm(
+            data={"community": self.community.id, "title": "T", "post_type": "image"},
+            files={"image": gif},
+        )
+        self.assertFalse(form.is_valid())
+        self.assertIn("Only JPEG/PNG are supported.", form.errors["image"])
+
+    def test_image_post_too_large(self):
+        buffer = BytesIO()
+        Image.new("RGB", (1, 1)).save(buffer, format="JPEG")
+        big_bytes = buffer.getvalue() + b"0" * (5 * 1024 * 1024)
+        big = SimpleUploadedFile("big.jpg", big_bytes, content_type="image/jpeg")
+        form = PostForm(
+            data={"community": self.community.id, "title": "T", "post_type": "image"},
+            files={"image": big},
+        )
+        self.assertFalse(form.is_valid())
+        self.assertIn(
+            "Provide a JPEG/PNG file or a valid image URL.",
+            form.errors["image"],
+        )
+
+    @patch("core.forms.requests.head")
+    def test_image_post_valid_content_url(self, mock_head):
+        mock_head.return_value = Mock(
+            headers={"Content-Type": "image/png", "Content-Length": "100"}
+        )
+        form = PostForm(
+            data={
+                "community": self.community.id,
+                "title": "T",
+                "post_type": "image",
+                "content_url": "http://example.com/x.png",
+            }
+        )
+        self.assertTrue(form.is_valid())
+        mock_head.assert_called_once()
+
+    @patch("core.forms.requests.head")
+    def test_image_post_invalid_content_url_type(self, mock_head):
+        mock_head.return_value = Mock(
+            headers={"Content-Type": "text/html", "Content-Length": "100"}
+        )
+        form = PostForm(
+            data={
+                "community": self.community.id,
+                "title": "T",
+                "post_type": "image",
+                "content_url": "http://example.com/x.png",
+            }
+        )
+        self.assertFalse(form.is_valid())
+        self.assertIn("Only JPEG/PNG are supported.", form.errors["content_url"])


### PR DESCRIPTION
## Summary
- allow optional image uploads on posts
- validate that image posts use either an upload or URL
- test new image validation rules

## Testing
- `python manage.py test core.tests.test_post_form_validation -v 2`
- `python manage.py test core.tests.test_astro -v 2` (fails: ModuleNotFoundError: No module named 'freezegun')
- `python manage.py test core.tests.test_comment_reply.CommentReplyTests.test_rate_limit -v 2` (fails: Missing staticfiles manifest entry for 'css/app.css')

------
https://chatgpt.com/codex/tasks/task_e_68beb1f244cc832c9cbb9e7f5129dc0c