### PR TITLE
Handle conditional image uploads in post forms

### DIFF
--- a/templates/core/post_form.html
+++ b/templates/core/post_form.html
@@ -3,7 +3,7 @@
 
 {% block content %}
 <h1>Create Post</h1>
-<form method="post" action="{% url 'post_submit' %}" class="post-form">
+<form method="post" action="{% url 'post_submit' %}" class="post-form" enctype="multipart/form-data">
   {% csrf_token %}
   <div class="draft-pill" hidden></div>
   {{ form.non_field_errors }}
@@ -16,15 +16,14 @@
   {% endif %}
 
   <div class="form-row">
-    {{ form.title.label_tag }}
-    {{ form.title }}
-    {{ form.title.errors }}
+    {{ form.post_type.label_tag }} {{ form.post_type }}
+    {{ form.post_type.errors }}
   </div>
 
   <div class="form-row">
-    {{ form.heading.label_tag }}
-    {{ form.heading }}
-    {{ form.heading.errors }}
+    {{ form.title.label_tag }}
+    {{ form.title }}
+    {{ form.title.errors }}
   </div>
 
   <div class="form-row">
@@ -51,6 +50,14 @@
     {{ form.content_url }}
     {{ form.content_url.errors }}
   </div>
+
+  {% if form.post_type.value == "image" %}
+  <div class="form-row">
+    {{ form.image.label_tag }}
+    <input type="file" name="image" id="id_image">
+    {{ form.image.errors }}
+  </div>
+  {% endif %}
 
   <div class="form-actions">
     <button class="button" type="submit">Submit<span class="spinner" hidden aria-hidden="true"></span></button>

--- a/templates/core/submit.html
+++ b/templates/core/submit.html
@@ -26,10 +26,13 @@
       {{ form.content_url.label_tag }} {{ form.content_url }}
       {{ form.content_url.errors }}
     </div>
+    {% if form.post_type.value == "image" %}
     <div class="form-row">
-      {{ form.image.label_tag }} {{ form.image }}
+      {{ form.image.label_tag }}
+      <input type="file" name="image" id="id_image">
       {{ form.image.errors }}
     </div>
+    {% endif %}
     <div class="form-row">
       {{ form.body.label_tag }}
       <div class="editor-container prose">


### PR DESCRIPTION
## Summary
- show image upload input only when creating/editing image posts
- allow post edit form to send file data

## Testing
- `python manage.py test` *(fails: failures=6, errors=50, missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68beb631e180832cba8a6a10f7216f92