### PR TITLE
chore: configure production env for Fly

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -10,6 +10,11 @@ primary_region = "syd"
   FLY_APP_NAME = "surejan"
   AWS_S3_ENDPOINT_URL = "https://fly.storage.tigris.dev"
   AWS_S3_REGION_NAME = "auto"
+  DJANGO_SETTINGS_MODULE = "config.settings.prod"
+  DJANGO_DEBUG = "0"
+  DJANGO_ALLOWED_HOSTS = "surejan.app,www.surejan.app,localhost"
+  DJANGO_SECRET_KEY = "use-a-strong-secret"
+  DATABASE_URL = "postgres://<user>:<pass>@surejan-db-green.internal:5432/surejan"
 
 [deploy]
   release_command = "python manage.py migrate --noinput"


### PR DESCRIPTION
## Summary
- add Django production variables to Fly config

## Testing
- `python manage.py check`
- `python manage.py test --failfast` *(fails: ModuleNotFoundError: No module named 'freezegun')*
- `flyctl deploy -a surejan --remote-only` *(fails: command not found)*
- `flyctl logs -a surejan` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf9084b8e8832c9d32cc589cd1ca5a