### PR TITLE
refactor: centralize common view helpers

### DIFF
--- a/comments/views.py
+++ b/comments/views.py
@@ -16,7 +16,12 @@ from django.template.loader import render_to_string
 from django.utils import timezone
 from django.db import DataError, IntegrityError
 
-from core.views import _is_banned, is_new_user, limit_or_429, _find_offending_field
+from core.utils.view_helpers import (
+    _find_offending_field,
+    _is_banned,
+    is_new_user,
+    limit_or_429,
+)
 from core.pagination import PAGE_SIZE
 from core.models import Post
 from core.http import login_required_htmx

--- a/communities/views.py
+++ b/communities/views.py
@@ -9,7 +9,7 @@ from .forms import CommunityCreateForm
 from .models import Community
 from core.pagination import PAGE_SIZE
 from core.services.feed import TAB_ORDER, feed_queryset
-from core.views import SORT_TABS, _is_banned
+from core.utils.view_helpers import SORT_TABS, _is_banned
 
 
 @require_GET
@@ -90,7 +90,7 @@ def community(request, slug):
         sort_query += f"&t={t}"
 
     if request.headers.get("HX-Request") == "true":
-        from core.views import _render_posts
+        from core.utils.view_helpers import _render_posts
 
         return _render_posts(request, posts, next_page, sort_query=sort_query)
 

--- a/core/tests/test_history_community.py
+++ b/core/tests/test_history_community.py
@@ -3,7 +3,7 @@ from django.test import TestCase
 from django.urls import reverse
 
 from communities.models import Community
-from core.views import SORT_TABS
+from core.utils.view_helpers import SORT_TABS
 
 
 class HistoryCommunityRoutingTests(TestCase):

--- a/core/utils/view_helpers.py
+++ b/core/utils/view_helpers.py
@@ -1,0 +1,86 @@
+"""Shared helper functions for views."""
+
+from datetime import timedelta
+
+from django.core.validators import MaxLengthValidator
+from django.http import HttpResponse
+from django.template.loader import render_to_string
+from django.utils import timezone
+from django_ratelimit.core import is_ratelimited
+
+
+def _is_banned(user):
+    """Return True if the user is banned."""
+    return getattr(getattr(user, "profile", None), "is_banned", False)
+
+
+def is_new_user(u):
+    """Determine whether a user account is less than 24 hours old."""
+    if not u.is_authenticated:
+        return True
+    return (timezone.now() - u.date_joined) < timedelta(hours=24)
+
+
+def limit_or_429(request, group, rate):
+    """Return whether a request should be rate limited."""
+    return is_ratelimited(
+        request,
+        group=group,
+        key="user",
+        rate=rate,
+        method=["POST"],
+        increment=True,
+    )
+
+
+def _find_offending_field(form):
+    """Identify the field that exceeds the allowed length in a form."""
+    for name, field in form.fields.items():
+        value = form.data.get(name)
+        if value is None:
+            continue
+        try:
+            length = len(value)
+        except TypeError:
+            continue
+        maxlen = getattr(field, "max_length", None)
+        if maxlen and length > maxlen:
+            return name, length
+        for validator in field.validators:
+            if isinstance(validator, MaxLengthValidator) and length > validator.limit_value:
+                return name, length
+    return "unknown", 0
+
+
+SORT_TABS = [
+    ("hot", "HOT"),
+    ("new", "NEW"),
+    ("top", "TOP"),
+    ("wiki", "WIKI"),
+]
+
+
+def _render_posts(request, posts, next_page, show_community=False, sort_query=""):
+    """Render a list of posts and optional pagination link."""
+    html = render_to_string(
+        "core/partials/post_list.html",
+        {
+            "posts": posts,
+            "show_community": show_community,
+            "next_page": next_page,
+            "sort_query": sort_query,
+        },
+        request=request,
+    )
+    return HttpResponse(html)
+
+
+__all__ = [
+    "_is_banned",
+    "is_new_user",
+    "limit_or_429",
+    "_find_offending_field",
+    "SORT_TABS",
+    "_render_posts",
+]
+

--- a/core/views.py
+++ b/core/views.py
@@ -41,7 +41,6 @@ from django.core.cache import cache
 from django.utils.cache import patch_cache_control
 
 from django.contrib.contenttypes.models import ContentType
-from django_ratelimit.core import is_ratelimited
 from django.urls import reverse
 from .forms import PostForm
 from .models import Post, RecoveryCode, Report
@@ -51,6 +50,14 @@ from .services.astro import compute_post_signals, compute_user_post_summary
 from .services.feed import TAB_ORDER, RANGE_MAP, feed_queryset
 from . import mod
 from .http import login_required_htmx
+from .utils.view_helpers import (
+    _is_banned,
+    _find_offending_field,
+    _render_posts,
+    is_new_user,
+    limit_or_429,
+    SORT_TABS,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -98,43 +105,6 @@ def request_too_big(request, exception: RequestDataTooBig | None = None):
     return render(request, _error_template(request, 413), status=413)
 
 
-def _is_banned(user):
-    return getattr(getattr(user, "profile", None), "is_banned", False)
-
-
-def is_new_user(u):
-    if not u.is_authenticated:
-        return True
-    return (timezone.now() - u.date_joined) < timedelta(hours=24)
-
-
-def limit_or_429(request, group, rate):
-    return is_ratelimited(
-        request,
-        group=group,
-        key="user",
-        rate=rate,
-        method=["POST"],
-        increment=True,
-    )
-
-
-def _find_offending_field(form):
-    for name, field in form.fields.items():
-        value = form.data.get(name)
-        if value is None:
-            continue
-        try:
-            length = len(value)
-        except TypeError:
-            continue
-        maxlen = getattr(field, "max_length", None)
-        if maxlen and length > maxlen:
-            return name, length
-        for validator in field.validators:
-            if isinstance(validator, MaxLengthValidator) and length > validator.limit_value:
-                return name, length
-    return "unknown", 0
 
 
 markdown_renderer = mistune.create_markdown()
@@ -462,30 +432,6 @@ def regenerate_recovery_codes(request):
     _store_codes(request.user, codes)
     request.session["new_recovery_codes"] = codes
     return redirect("recovery_codes")
-
-
-SORT_TABS = [
-    ("hot", "HOT"),
-    ("new", "NEW"),
-    ("top", "TOP"),
-    ("wiki", "WIKI"),
-]
-
-
-def _render_posts(request, posts, next_page, show_community=False, sort_query=""):
-    """Render a list of posts and optional pagination link."""
-
-    html = render_to_string(
-        "core/partials/post_list.html",
-        {
-            "posts": posts,
-            "show_community": show_community,
-            "next_page": next_page,
-            "sort_query": sort_query,
-        },
-        request=request,
-    )
-    return HttpResponse(html)
 
 
 @require_GET


### PR DESCRIPTION
## Summary
- add shared `core.utils.view_helpers` module for view utilities
- refactor view modules and tests to import helpers from the new module

## Testing
- `python manage.py test core.tests.test_history_community -v 2` *(fails: Missing staticfiles manifest entry for 'css/app.css')*


------
https://chatgpt.com/codex/tasks/task_e_68bf952ab878832c97a3ad206e577289