### PR TITLE
docs: add SureJan v3.1 persistent docs set

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ python manage.py runserver
 
 Production secrets are set via `fly secrets` and should never be committed to the repo.
 
+## Docs
+
+- [Architecture](docs/architecture.md)
+- [Smoke Tests](docs/runbooks/smoke.md)
+
 ## License
 
 This project is licensed under the [MIT License](LICENSE).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,26 @@
+# SureJan v3.1 — System Overview
+
+**Goal:** Local-first community forum with anti-astroturf scoring.
+
+```mermaid
+flowchart LR
+  A[Client] --> B[Cloudflare (surejan.app)]
+  B --> C[Django app (Fly.io)]
+  C <--> D[(Postgres)]
+  C <--> E[(Tigris S3 - MEDIA)]
+  C --> F[Static via Whitenoise]
+  C --> G[/healthz]
+```
+
+
+Components
+
+Edge: Cloudflare proxy; only surejan.app served.
+
+App: Django (core now; target split posts/comments/votes/communities).
+
+DB: Fly Postgres. Media: Tigris via MEDIA_URL. Static: Whitenoise.
+
+Obs: Fly logs + /healthz; HTML error templates.
+
+

--- a/docs/contracts/routes.md
+++ b/docs/contracts/routes.md
@@ -1,0 +1,14 @@
+# Route Contracts (stable external behavior)
+
+| Path | Method | View (module.fn) | Template | Auth | Notes |
+|------|--------|------------------|----------|------|-------|
+| `/` | GET | posts.views.feed | posts/feed.html | Opt | Hot/New/Top |
+| `/c/<slug>/` | GET | communities.views.detail | communities/detail.html | Opt | Community feed |
+| `/c/<slug>/submit` | GET | posts.views.submit_get | posts/submit.html | Req | Show form |
+| `/c/<slug>/submit` | POST | posts.views.submit_post | (302 redirect) | Req | Create Post |
+| `/p/<id-or-slug>/` | GET | posts.views.detail | posts/detail.html | Opt | Astro-chip renders |
+| `/p/<id-or-slug>/comment` | POST | comments.views.create | (fragment/redirect) | Req | HTMX/standard |
+| `/vote/post/<id>` | POST | votes.views.vote_post | (JSON/fragment/204) | Req | value ∈ {+1,-1,0} |
+| `/healthz` | GET | health.views.ok | (plain 200) | No | Used by Fly |
+| errors 400/403/404/413/429/500 | ANY | config.urls.handlers | templates/errors/*.html | — | Must exist |
+

--- a/docs/data/erd.md
+++ b/docs/data/erd.md
@@ -1,0 +1,24 @@
+# Data Model (ERD - simplified)
+
+```mermaid
+erDiagram
+  COMMUNITY ||--o{ POST : has
+  POST ||--o{ COMMENT : has
+  USER ||--o{ POST : author
+  USER ||--o{ COMMENT : author
+  USER ||--o{ VOTE : casts
+  POST ||--o{ VOTE : receives
+  COMMENT ||--o{ VOTE : receives
+```
+
+
+Key fields:
+
+Community(slug unique)
+
+Post(community_id, author_id, slug unique within community)
+
+Comment(post_id, author_id, parent_id nullable)
+
+Vote(user_id, target_type, target_id, value ∈ {-1,0,1}), unique (user,target)
+

--- a/docs/data/invariants.md
+++ b/docs/data/invariants.md
@@ -1,0 +1,8 @@
+# Data Invariants
+
+- Post slugs unique per community.
+- One active vote per (user,target).
+- Image uploads: JPEG/PNG only; size ≤ N MB; under `MEDIA_URL`.
+- AstroShield score ∈ [1,100]; bands: 0–39 Normal, 40–69 Watch, 70–84 High, 85+ Severe.
+- Astro chips color palette is fixed (not affected by global theme changes).
+

--- a/docs/flows/comments.md
+++ b/docs/flows/comments.md
@@ -1,0 +1,6 @@
+# Flow — Create Comment
+
+- Entry: `POST /p/<id>/comment` (Auth required)
+- Validate → INSERT `core_comment` → 302 to post (or HTMX 200 fragment)
+- Invariants: comments belong to a post; soft-delete hides content.
+

--- a/docs/flows/posts.md
+++ b/docs/flows/posts.md
@@ -1,0 +1,22 @@
+# Flow — Create Post
+
+```mermaid
+sequenceDiagram
+  participant U as User
+  participant W as Cloudflare
+  participant A as Django
+  participant DB as Postgres
+  participant S as Tigris
+
+  U->>W: POST /c/<slug>/submit
+  W->>A: Forward (TLS)
+  A->>A: validate form, (optional) upload image
+  A->>S: PUT media (if image)
+  A->>DB: INSERT core_post
+  A-->>U: 302 /p/<id-or-slug>
+```
+
+
+Side effects: media stored under MEDIA_URL; AstroShield score updated lazily/on render.
+Failures: invalid input → form errors; media failure → reject, no DB write.
+

--- a/docs/flows/votes.md
+++ b/docs/flows/votes.md
@@ -1,0 +1,6 @@
+# Flow — Vote on Post/Comment
+
+- Entry: `POST /vote/post/<id>` (or comment variant), Auth required.
+- Service: `cast_vote(user, target, value)` upserts unique (user,target).
+- Net score = sum(value); repeat same vote → idempotent (no change).
+

--- a/docs/migrations/LEDGER.md
+++ b/docs/migrations/LEDGER.md
@@ -1,0 +1,11 @@
+# Migrations Ledger (authoritative history)
+
+| App  | Number | Summary                               | Risk | Prod Applied? | Notes |
+|------|--------|---------------------------------------|------|---------------|-------|
+| core | 0031b  | Add slug field                        | High | ?             | Must precede data backfill |
+| core | 0031a  | Populate slugs                        | Med  | ?             | Runs after 0031b |
+| core | 0032   | Drop legacy image fields (if present) | High | ?             | Template reliance risk |
+| ...  | ...    | ...                                   | ...  | ...           | ...   |
+
+> Update on every migration PR. Never delete a migration without noting the replacement/alias plan here.
+

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -1,0 +1,18 @@
+# Module Boundaries (current → target)
+
+**Current:** `core/` holds models, views, forms, services, templates.
+
+**Target (code-first split; models remain in core until stable):**
+- `posts/` — views/forms/services/templates for posts.
+- `comments/` — comment CRUD & moderation helpers.
+- `votes/` — vote endpoints + idempotent service.
+- `communities/` — community listing/admin UI.
+
+**Public APIs**
+- posts.services: `create_post`, `get_post`, `list_feed`
+- comments.services: `add_comment`, `list_comments`
+- votes.services: `cast_vote(user, target, value)` (value ∈ {+1, -1, 0})
+- communities.services: `get_by_slug`, `list_communities`
+
+Rule: views ↔ services ↔ models. Templates read context only.
+

--- a/docs/ops/errors.md
+++ b/docs/ops/errors.md
@@ -1,0 +1,6 @@
+# Error Handling & Health
+
+- Error templates: `templates/errors/{400,403,404,413,429,500}.html`
+- Handlers wired in `config/urls.py` (keep them).
+- Health endpoint `/healthz` → 200 when app + DB reachable.
+

--- a/docs/ops/logs.md
+++ b/docs/ops/logs.md
@@ -1,0 +1,15 @@
+# Reading Logs (Fly)
+
+Search for:
+- `DisallowedHost` → host/Cloudflare mismatch
+- `TemplateDoesNotExist: errors/500.html` → missing error template
+- `django.db.utils` at startup → migration loop/schema drift
+- `ImportError` in core/posts/comments → refactor path issues
+
+Commands:
+
+```
+fly logs -a surejan --recent 200
+fly status
+```
+

--- a/docs/ops/settings.md
+++ b/docs/ops/settings.md
@@ -1,0 +1,13 @@
+# Settings & Secrets
+
+| ENV var              | Required | Used by | Example |
+|----------------------|----------|--------|---------|
+| DJANGO_SECRET_KEY    | Yes      | Django | random |
+| DATABASE_URL         | Yes      | DB     | postgres://... |
+| MEDIA_URL            | Yes      | Media  | https://surejan-media.fly.storage.tigris.dev/ |
+| ALLOWED_HOSTS        | Yes      | Sec    | surejan.app,www.surejan.app,127.0.0.1 |
+| CSRF_TRUSTED_ORIGINS | Yes      | Sec    | https://surejan.app,https://www.surejan.app |
+| SUREJAN_READONLY     | No       | Views  | 1/0 |
+
+Policy: block `.fly.dev` in both ALLOWED_HOSTS and CSRF; only serve `surejan.app`.
+

--- a/docs/runbooks/boot.md
+++ b/docs/runbooks/boot.md
@@ -1,0 +1,8 @@
+# Runbook — Boot (no schema changes)
+
+1) Ensure secrets: `DJANGO_SECRET_KEY`, `DATABASE_URL`, `MEDIA_URL`.
+2) `ALLOWED_HOSTS` / `CSRF_TRUSTED_ORIGINS` only `surejan.app`.
+3) `python manage.py collectstatic --noinput`
+4) `python manage.py check && python manage.py runserver`
+5) Verify `/healthz` → 200; `/` renders; error pages load.
+

--- a/docs/runbooks/smoke.md
+++ b/docs/runbooks/smoke.md
@@ -1,0 +1,9 @@
+# Runbook — Smoke Tests
+
+- `/healthz` → 200
+- `/` → 200 (Hot/New visible)
+- `/c/brisbane/` → 200
+- `/p/<known-id>/` → 200; astro-chip visible
+- Comment POST → 302/200
+- Vote POST (+1 then 0) → counts correct and idempotent
+


### PR DESCRIPTION
## Summary
- document system architecture, modules, route contracts, data model & invariants
- add ops settings/errors/logs guidance and migrations ledger
- include boot and smoke test runbooks and link docs from README

## Testing
- `python manage.py test` *(fails: Missing staticfiles manifest, astro env var toggle, etc.)*
- `git ls-files docs | wc -l`


------
https://chatgpt.com/codex/tasks/task_e_68bf9ac61820832ca4f4fb1b66cf8f16