### PR TITLE
Add environment and migration validation commands

### DIFF
--- a/core/management/commands/check_env.py
+++ b/core/management/commands/check_env.py
@@ -1,0 +1,36 @@
+"""Validate required runtime environment variables."""
+
+import os
+from urllib.parse import urlparse
+
+from django.core.management.base import BaseCommand
+
+
+class Command(BaseCommand):
+    """Check critical environment variables for CI."""
+
+    def handle(self, *args, **options):
+        issues = []
+
+        if not os.environ.get("DJANGO_SECRET_KEY"):
+            issues.append("missing DJANGO_SECRET_KEY")
+        if not os.environ.get("DATABASE_URL"):
+            issues.append("missing DATABASE_URL")
+
+        media_url = os.environ.get("MEDIA_URL")
+        if not media_url:
+            issues.append("missing MEDIA_URL")
+        else:
+            parsed = urlparse(media_url)
+            if parsed.scheme != "https":
+                issues.append("MEDIA_URL not https")
+            if not media_url.endswith("/"):
+                issues.append("MEDIA_URL must end with /")
+
+        if issues:
+            for issue in issues:
+                self.stdout.write(f"✗ {issue}")
+            raise SystemExit(1)
+
+        self.stdout.write("env PASS")
+        raise SystemExit(0)

--- a/core/management/commands/check_schema.py
+++ b/core/management/commands/check_schema.py
@@ -1,0 +1,47 @@
+"""Validate database schema state using migrations."""
+
+from django.core.management.base import BaseCommand
+from django.db import DEFAULT_DB_ALIAS, connections
+from django.db.migrations.loader import MigrationLoader
+from django.db.migrations.recorder import MigrationRecorder
+
+
+class Command(BaseCommand):
+    """Report unapplied, ghost, or divergent migrations."""
+
+    def handle(self, *args, **options):
+        connection = connections[DEFAULT_DB_ALIAS]
+        loader = MigrationLoader(connection, ignore_no_migrations=True)
+        recorder = MigrationRecorder(connection)
+
+        graph_nodes = set(loader.graph.nodes.keys())
+        applied = set(recorder.applied_migrations())
+
+        unapplied = sorted(graph_nodes - applied)
+        ghost = sorted(applied - graph_nodes)
+        conflicts = loader.detect_conflicts()
+
+        problems = False
+
+        if unapplied:
+            names = ", ".join(f"{app}.{name}" for app, name in unapplied)
+            self.stdout.write(f"✗ unapplied migrations: {names}")
+            problems = True
+
+        if ghost:
+            names = ", ".join(f"{app}.{name}" for app, name in ghost)
+            self.stdout.write(f"✗ ghost migrations: {names}")
+            problems = True
+
+        if conflicts:
+            conflict_str = ", ".join(
+                f"{app}: {', '.join(names)}" for app, names in conflicts.items()
+            )
+            self.stdout.write(f"✗ divergent migrations: {conflict_str}")
+            problems = True
+
+        if problems:
+            raise SystemExit(1)
+
+        self.stdout.write("schema PASS")
+        raise SystemExit(0)


### PR DESCRIPTION
## Summary
- add `check_env` management command to validate critical environment variables
- add `check_schema` management command to report unapplied, ghost, or divergent migrations

## Testing
- `python manage.py check_env`
- `python manage.py migrate --noinput`
- `python manage.py check_schema`
- `pytest` *(fails: CommunitiesIndexTests.test_header_sort_highlight, CommunitiesIndexTests.test_lists_communities, FeedRangeFilterHTMXTests.test_24h_filter, FeedRangeFilterHTMXTests.test_7d_filter, FeedRangeFilterHomeTests.test_24h_filter, FeedRangeFilterHomeTests.test_7d_filter, FeedRangeFilterHomeTests.test_all_filter, LengthErrorHandlingTests.test_post_submit_data_error, PostDeleteOwnerTests.test_requires_login, test_secret_key_fallback, test_env_allowed_hosts_override, test_env_csrf_trusted_override, AstroEnvVarToggleTests.test_astroturf_watch_env_var_controls_flag)*

------
https://chatgpt.com/codex/tasks/task_e_68bf9ff8e93c832c95a3a702298966ea