### PR TITLE
Refactor post URL routing into app module

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -1,28 +1,9 @@
 # core/urls.py
 from django.urls import path
-from core.views import posts as post_views
 from core.views import users as user_views
-from core.views import moderation as mod_views
 from core.views import reports as report_views
 
 urlpatterns = [
-    # Home / front page
-    path("", post_views.home, name="home"),
-    path("p/<int:pk>", post_views.post_detail_id, name="post_detail_id"),
-    path("feed", post_views.feed_list, name="feed_list"),
-    path("mission", post_views.mission, name="mission"),
-    path("anti-astroturf", post_views.anti_astroturf, name="anti_astroturf"),
-    path("mod/astro", mod_views.mod_astro, name="mod_astro"),
-    path("methods", mod_views.transparency_methods, name="transparency_methods"),
-    path("posts", mod_views.transparency_posts, name="transparency_posts"),
-    # Markdown preview endpoint
-    path("preview", post_views.preview_markdown, name="preview_markdown"),
-    path("markdown/preview/", post_views.markdown_preview, name="markdown_preview"),
-    path("submit", post_views.post_submit, name="post_submit"),
-
-    # Post signals
-    path("posts/<int:pk>/signals.json", post_views.post_signals_json, name="post_signals_json"),
-
     # Recovery codes
     path("accounts/recovery-codes/", user_views.recovery_codes, name="recovery_codes"),
     path(
@@ -36,31 +17,7 @@ urlpatterns = [
         name="recovery_codes_regenerate",
     ),
 
-    # Post detail (nested under community, with id + slug)
-    path(
-        "r/<slug:community>/comments/<int:pk>/<slug:slug>",
-        post_views.post_detail,
-        name="post_detail",
-    ),
-
-    # Comments & voting
-    # Post moderation
-    path("post/<int:pk>/edit/", post_views.post_edit, name="post_edit"),
-    path(
-        "post/<int:pk>/delete-owner/",
-        post_views.post_delete_owner,
-        name="post_delete_owner",
-    ),
-    # Hard delete (admin-only; not linked from templates)
-    path("post/<int:pk>/delete/", mod_views.post_delete, name="post_delete"),
-    path("post/<int:pk>/remove/", mod_views.post_remove, name="post_remove"),
-    path("post/<int:pk>/lock/", mod_views.post_lock, name="post_lock"),
-    path("post/<int:pk>/slowmode/", mod_views.post_slowmode, name="post_slowmode"),
-    path(
-        "post/<int:pk>/domain-throttle/",
-        mod_views.post_domain_throttle,
-        name="post_domain_throttle",
-    ),
+    # Reports
     path("report/", report_views.report, name="report"),
     path("reports/", report_views.report_list, name="report_list"),
 

--- a/posts/urls.py
+++ b/posts/urls.py
@@ -1,3 +1,34 @@
 from django.urls import path
+from core.views import posts as post_views
+from core.views import moderation as mod_views
 
-urlpatterns: list = []
+urlpatterns = [
+    path("", post_views.home, name="home"),
+    path("p/<int:pk>", post_views.post_detail_id, name="post_detail_id"),
+    path("feed", post_views.feed_list, name="feed_list"),
+    path("mission", post_views.mission, name="mission"),
+    path("anti-astroturf", post_views.anti_astroturf, name="anti_astroturf"),
+    path("mod/astro", mod_views.mod_astro, name="mod_astro"),
+    path("methods", mod_views.transparency_methods, name="transparency_methods"),
+    path("posts", mod_views.transparency_posts, name="transparency_posts"),
+    path("preview", post_views.preview_markdown, name="preview_markdown"),
+    path("markdown/preview/", post_views.markdown_preview, name="markdown_preview"),
+    path("submit", post_views.post_submit, name="post_submit"),
+    path("posts/<int:pk>/signals.json", post_views.post_signals_json, name="post_signals_json"),
+    path(
+        "r/<slug:community>/comments/<int:pk>/<slug:slug>",
+        post_views.post_detail,
+        name="post_detail",
+    ),
+    path("post/<int:pk>/edit/", post_views.post_edit, name="post_edit"),
+    path("post/<int:pk>/delete-owner/", post_views.post_delete_owner, name="post_delete_owner"),
+    path("post/<int:pk>/delete/", mod_views.post_delete, name="post_delete"),
+    path("post/<int:pk>/remove/", mod_views.post_remove, name="post_remove"),
+    path("post/<int:pk>/lock/", mod_views.post_lock, name="post_lock"),
+    path("post/<int:pk>/slowmode/", mod_views.post_slowmode, name="post_slowmode"),
+    path(
+        "post/<int:pk>/domain-throttle/",
+        mod_views.post_domain_throttle,
+        name="post_domain_throttle",
+    ),
+]

--- a/tests/test_url_names.py
+++ b/tests/test_url_names.py
@@ -1,0 +1,55 @@
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+
+from communities.models import Community
+from core.models import Post
+from comments.models import Comment
+
+
+class URLNameTests(TestCase):
+    def setUp(self):
+        user_model = get_user_model()
+        self.user = user_model.objects.create_user("tester", password="pwd")
+        self.community = Community.objects.create(
+            slug="test", name="Test", title="Test", created_by=self.user
+        )
+        self.post = Post.objects.create(
+            community=self.community,
+            author=self.user,
+            post_type="text",
+            title="Hello",
+        )
+        self.comment = Comment.objects.create(
+            post=self.post, author=self.user, body="Hi", path="0001"
+        )
+
+    def test_reverse_names(self):
+        self.assertEqual(reverse("feed_list"), "/feed")
+        self.assertEqual(reverse("post_submit"), "/submit")
+        self.assertEqual(
+            reverse("post_detail_id", args=[self.post.pk]),
+            f"/p/{self.post.pk}",
+        )
+        self.assertEqual(
+            reverse(
+                "post_detail",
+                args=[self.community.slug, self.post.pk, self.post.slug],
+            ),
+            f"/r/{self.community.slug}/comments/{self.post.pk}/{self.post.slug}",
+        )
+        self.assertEqual(reverse("comment_create"), "/comments/create")
+        self.assertEqual(
+            reverse("vote_post", args=[self.post.pk]),
+            f"/posts/vote/{self.post.pk}/",
+        )
+        self.assertEqual(
+            reverse("vote_comment", args=[self.comment.pk]),
+            f"/comments/vote/{self.comment.pk}/",
+        )
+        self.assertEqual(
+            reverse("community", args=[self.community.slug]),
+            f"/r/{self.community.slug}/",
+        )
+        self.assertEqual(reverse("healthz"), "/healthz")
+


### PR DESCRIPTION
## Summary
- Move post-related routes from `core/urls.py` into `posts/urls.py`
- Keep `core/urls.py` focused on user and report endpoints
- Add regression test to ensure common URL names still reverse correctly

## Testing
- `pytest tests/test_url_names.py -q`
- `pytest -q` *(fails: 13 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68bfa5240254832c9d775f1ccfc5f947