### PR TITLE
Add smoke tests for root and health routes

### DIFF
--- a/posts/tests/test_routes_smoke.py
+++ b/posts/tests/test_routes_smoke.py
@@ -1,0 +1,19 @@
+from django.test import TestCase
+from django.urls import reverse
+
+
+class RouteSmokeTests(TestCase):
+    def test_home_route_has_nav_tabs(self):
+        url = reverse("home")
+        resp = self.client.get(url)
+        self.assertEqual(resp.status_code, 200)
+        # Check navbar tabs are present
+        self.assertContains(resp, 'id="sort-tabs"')
+        for tab in ("Hot", "New", "Top"):
+            self.assertContains(resp, tab)
+
+    def test_healthz_route(self):
+        url = reverse("healthz")
+        resp = self.client.get(url)
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.content, b"ok")

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,3 +4,4 @@ testpaths =
     tests
     core/tests
     votes/tests
+    posts/tests


### PR DESCRIPTION
## Summary
- add smoke tests for home and healthz endpoints
- include posts tests path in pytest config

## Testing
- `pytest posts/tests/test_routes_smoke.py votes/tests/test_vote_model.py votes/tests/test_vote_service.py votes/tests/test_vote_engagement.py core/tests/test_comment_delete.py`

------
https://chatgpt.com/codex/tasks/task_e_68bfa862b4f8832cae68273f87397277