### PR TITLE
Use shared post thumbnail partial in post_row template

### DIFF
--- a/templates/posts/partials/post_row.html
+++ b/templates/posts/partials/post_row.html
@@ -12,17 +12,7 @@
       <p class="post-excerpt">{{ post.excerpt }}</p>
     </div>
     {% endif %}
-    {% if post.post_type == "link" %}
     {% include "partials/post_thumbnail.html" with post=post %}
-    {% elif post.image_thumb or post.image %}
-    <a href="{{ detail_url }}" class="thumb">
-      {% if post.image_thumb %}
-        <img src="{{ post.image_thumb.url }}" alt="{{ post.title }}" width="320" height="180" loading="lazy" decoding="async">
-      {% elif post.image %}
-        <img src="{{ post.image.url }}" alt="{{ post.title }}" width="320" height="180" loading="lazy" decoding="async">
-      {% endif %}
-    </a>
-    {% endif %}
     <div class="post-actions">
       {% if show_vote_widget is not False %}
         {% include "votes/partials/vote_widget.html" with post=post user=user request=request only %}


### PR DESCRIPTION
## Summary
- simplify post row template to rely on `post_thumbnail` partial for image rendering

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'config'; django.core.exceptions.ImproperlyConfigured)*

------
https://chatgpt.com/codex/tasks/task_e_68bff0e70c5c832c87ad4b2e4c116514